### PR TITLE
ci: add CompatHelper workflow

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,36 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add the General registry via Git
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: Install CompatHelper
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Daily CompatHelper scan (midnight UTC) + manual dispatch
- Opens PRs bumping `[compat]` entries in `Project.toml` when deps release newer versions that satisfy semver bumps
- Uses default `GITHUB_TOKEN` (no DOCUMENTER_KEY/COMPATHELPER_PRIV); compat PRs won't retrigger CI on themselves — standard tradeoff

## Conventional commit note
CompatHelper emits its PR titles as \`CompatHelper: bump compat for Foo to X, ...\` — **not** conventional-commits-formatted. That means release-please won't count them as \`fix:\`/\`feat:\`, so they don't trigger releases on their own. If you want them released, you'd squash-merge with a conventional title like \`chore(deps): bump compat\` (or \`fix(deps): …\` if you want a patch release), which is the usual flow.

## Test plan
- [ ] Merge
- [ ] Trigger manually: \`gh workflow run CompatHelper.yml\` — confirm it runs clean
- [ ] Wait for first daily run (or check if a PR is opened if any dep needs bumping)
