### PR TITLE
feat: promote the fuzz oracle bridge to WasmTarget.Bridge

### DIFF
--- a/src/WasmTarget.jl
+++ b/src/WasmTarget.jl
@@ -43,6 +43,7 @@ include("codegen/wasm_constructors.jl")
 include("runtime/intrinsics.jl")
 include("runtime/stringops.jl")
 include("runtime/arrayops.jl")
+include("bridge.jl")
 
 
 # Main API

--- a/src/bridge.jl
+++ b/src/bridge.jl
@@ -1,0 +1,425 @@
+# ============================================================================
+# WasmTarget.Bridge — type-directed, BIT-EXACT value transport across the
+# JS↔wasm boundary
+# ============================================================================
+#
+# Promoted from the differential fuzzer's oracle bridge (test/fuzz/bridge.jl +
+# bridge_args.jl), where it transports every supported Julia value into and
+# out of compiled modules without ever becoming decimal text. Downstream
+# consumers (PlutoIslands.jl islands, the fuzz oracle) share this one
+# implementation.
+#
+# READ side (return values / post-call re-reads):
+#   `descriptor(T)` → (desc, accessors): a JSON-able tree describing how to
+#   take `T` apart + the minimal ACCESSOR CLOSURE — tiny getter functions
+#   (`getfield` wrappers, vector len/get, float→bits reinterprets, string
+#   codeunits) compiled INTO the module alongside the target via
+#   `compile_multi((fn, args, name))`. The generic JS walker (`WALK_JS`)
+#   drives those exports and returns a tagged tree whose every leaf is an
+#   EXACT integer (stringified BigInt). `tree_matches(desc, native, tree)`
+#   compares against the native value; all numeric policy (NaN classes equal,
+#   ULP tolerance) lives in `_float_match`.
+#
+# ARG side (values INTO wasm):
+#   `arg_descriptor(T)` → (desc, accessors): constructor exports (positional
+#   ctors for structs/tuples/namedtuples, new/set! pairs for vectors, Char
+#   from codepoint, String from a byte vector). Julia encodes native values
+#   as the same tagged exact-integer trees (`value_to_tree`); the generic JS
+#   builder (`BUILD_JS`) reconstructs them inside wasm. Float leaves cross as
+#   raw f64 bits via DataView — never decimal text.
+#
+# Universe (both directions): Int8–64, UInt8–64, Bool, Float32/64, Char,
+# String, Tuple, NamedTuple, plain/nested/parametric/mutable structs,
+# Vector{T} (recursively). `descriptor`/`arg_descriptor` return `nothing`
+# outside the universe — callers fall back / skip.
+#
+# The accessor closures are themselves WasmTarget output: a codegen bug there
+# surfaces as a systematic, classified failure — not a hidden dependency.
+
+module Bridge
+
+export descriptor, arg_descriptor, bridge_supported, args_supported,
+    value_to_tree, tree_matches, tree_decode, ismutable_shape,
+    WALK_JS, BUILD_JS
+
+# ── Export-name mangling ─────────────────────────────────────────────────────
+_mangle(T::Type) = replace(string(T), r"[^A-Za-z0-9]" => "_")
+
+const _INTS = Dict{Type,Tuple{Int,Bool}}(   # T => (bitwidth, signed)
+    Int8 => (8, true),  Int16 => (16, true),  Int32 => (32, true),  Int64 => (64, true),
+    UInt8 => (8, false), UInt16 => (16, false), UInt32 => (32, false), UInt64 => (64, false),
+    Bool => (1, false),
+)
+
+# An accessor entry is `(fn, argtypes::Tuple, export_name::String)` — the
+# 3-tuple form `compile_multi` accepts. The same concrete type always maps to
+# the same export names, so entries dedupe across nesting via `names`.
+function _acc!(accs, names, name::String, fn, argtypes::Tuple)
+    if !(name in names)
+        push!(names, name)
+        push!(accs, (fn, argtypes, name))
+    end
+    return name
+end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# READ side
+# ═════════════════════════════════════════════════════════════════════════════
+
+const _DESC_CACHE = Dict{Type,Union{Nothing,Tuple{Any,Vector{Any}}}}()
+
+"""
+    descriptor(T) -> Union{Nothing, (desc, accessors)}
+
+Read-side descriptor for `T` plus the accessor closure to compile alongside
+the target. `nothing` when `T` is outside the bridge universe.
+"""
+function descriptor(T::Type)
+    get!(_DESC_CACHE, T) do
+        accs = Any[]
+        names = Set{String}()
+        d = _build!(accs, names, T)
+        d === nothing ? nothing : (d, accs)
+    end
+end
+
+bridge_supported(T::Type) = descriptor(T) !== nothing
+
+function _build!(accs, names, T::Type)
+    if haskey(_INTS, T)
+        w, s = _INTS[T]
+        return Dict("k" => "int", "w" => w, "s" => s)
+    elseif T === Float64
+        b = _acc!(accs, names, "_bits_f64", _bits_f64, (Float64,))
+        return Dict("k" => "bits", "b" => b, "w" => 64)
+    elseif T === Float32
+        # reinterpret(Int32, ::Float32) miscompiles today (ledgered), so
+        # transport the EXACTLY-widened Float64 bits — lossless.
+        b = _acc!(accs, names, "_bits_f32w", _bits_f32w, (Float32,))
+        return Dict("k" => "bits", "b" => b, "w" => 32)
+    elseif T === Char
+        b = _acc!(accs, names, "_bits_char", _bits_char, (Char,))
+        return Dict("k" => "char", "b" => b)
+    elseif T === String
+        l = _acc!(accs, names, "_str_len", _str_len, (String,))
+        c = _acc!(accs, names, "_str_cu", _str_cu, (String, Int64))
+        return Dict("k" => "str", "len" => l, "cu" => c)
+    elseif T <: Vector && isconcretetype(T)
+        E = eltype(T)
+        m = _mangle(T)
+        el = _build!(accs, names, E)
+        el === nothing && return nothing
+        lf = _make_vlen(T);  l = _acc!(accs, names, "_vlen_$m", lf, (T,))
+        gf = _make_vget(T);  g = _acc!(accs, names, "_vget_$m", gf, (T, Int64))
+        return Dict("k" => "vec", "len" => l, "get" => g, "el" => el)
+    elseif T isa Union
+        # all-int unions transport as the widest member — codegen widens the
+        # wasm return to the largest int; String(v) handles number and BigInt.
+        ms = Base.uniontypes(T)
+        if all(m -> haskey(_INTS, m) && m !== Bool, ms)
+            ws = [_INTS[m] for m in ms]
+            if all(t -> t[2], ws) || all(t -> !t[2], ws)   # uniform signedness
+                return Dict("k" => "int", "w" => maximum(first.(ws)), "s" => ws[1][2])
+            end
+        end
+        return nothing
+    elseif (isstructtype(T) || T <: Tuple) && isconcretetype(T)
+        # Tuples, NamedTuples, and (im)mutable structs all decompose by field.
+        n = fieldcount(T)
+        m = _mangle(T)
+        fs = Any[]
+        for i in 1:n
+            FT = fieldtype(T, i)
+            fd = _build!(accs, names, FT)
+            fd === nothing && return nothing
+            ff = _make_fget(T, i)
+            a = _acc!(accs, names, "_fget_$(m)_$i", ff, (T,))
+            push!(fs, Dict("a" => a, "d" => fd))
+        end
+        return Dict("k" => "fields", "fs" => fs, "names" => _field_names(T))
+    end
+    return nothing   # outside the universe (Dict/Set/ranges/abstract…)
+end
+
+# field names for name-keyed sources (e.g. msgpack objects); tuples have none
+_field_names(T::Type) = T <: Tuple && !(T <: NamedTuple) ? nothing :
+    [string(n) for n in fieldnames(T)]
+
+# ── Leaf accessors (shared) ──────────────────────────────────────────────────
+_bits_f64(x::Float64)::Int64 = reinterpret(Int64, x)
+_bits_f32w(x::Float32)::Int64 = reinterpret(Int64, Float64(x))
+# reinterpret(UInt32, ::Char) miscompiles today (ledgered); codepoint() is
+# exact for valid Chars.
+_bits_char(c::Char)::Int64 = Int64(codepoint(c))
+_str_len(s::String)::Int64 = Int64(ncodeunits(s))
+_str_cu(s::String, i::Int64)::Int32 = Int32(codeunit(s, Int(i)))
+
+# ── Per-type accessor factories (memoized via @eval; named fns compile best) ──
+const _FN_CACHE = Dict{Any,Function}()
+
+function _make_vlen(::Type{T}) where {T<:Vector}
+    get!(_FN_CACHE, (:vlen, T)) do
+        f = Symbol("_vlenfn_", _mangle(T))
+        @eval (function $f(v::$T)::Int64; Int64(length(v)); end)
+    end
+end
+
+function _make_vget(::Type{T}) where {T<:Vector}
+    get!(_FN_CACHE, (:vget, T)) do
+        f = Symbol("_vgetfn_", _mangle(T))
+        E = eltype(T)
+        @eval (function $f(v::$T, i::Int64)::$E; v[Int(i)]; end)
+    end
+end
+
+function _make_fget(::Type{T}, i::Int) where {T}
+    get!(_FN_CACHE, (:fget, T, i)) do
+        f = Symbol("_fgetfn_", _mangle(T), "_", i)
+        FT = fieldtype(T, i)
+        # Integer-index getfield traps when the receiver ref crossed the JS
+        # boundary (ledgered); symbol/getindex forms are solid.
+        if T <: Tuple
+            @eval (function $f(x::$T)::$FT; x[$i]; end)
+        else
+            fname = fieldname(T, i)
+            @eval (function $f(x::$T)::$FT; x.$fname; end)
+        end
+    end
+end
+
+# ── The generic JS walker ────────────────────────────────────────────────────
+# Every numeric leaf leaves the module as an exact integer string. `ex` is the
+# instance's exports; `v` may be a JS Number, BigInt, or an opaque wasm-GC ref.
+const WALK_JS = """
+const walk = (d, v) => {
+  switch (d.k) {
+    case 'int':  return { x: String(v) };
+    case 'bits': return { x: String(ex[d.b](v)) };
+    case 'char': return { x: String(ex[d.b](v)) };
+    case 'str': {
+      const n = Number(ex[d.len](v)); const a = [];
+      for (let i = 1; i <= n; i++) a.push(Number(ex[d.cu](v, BigInt(i))));
+      return { s: a };
+    }
+    case 'fields': return { f: d.fs.map(fd => walk(fd.d, ex[fd.a](v))) };
+    case 'vec': {
+      const n = Number(ex[d.len](v)); const a = [];
+      for (let i = 1; i <= n; i++) a.push(walk(d.el, ex[d.get](v, BigInt(i))));
+      return { a: a };
+    }
+    default: return { err: 'bad-desc-kind ' + d.k };
+  }
+};
+"""
+
+# ═════════════════════════════════════════════════════════════════════════════
+# ARG side
+# ═════════════════════════════════════════════════════════════════════════════
+
+const _ARG_CACHE = Dict{Type,Union{Nothing,Tuple{Any,Vector{Any}}}}()
+
+"""
+    arg_descriptor(T) -> Union{Nothing, (desc, accessors)}
+
+Argument-side descriptor for `T` plus the constructor closure (ctor exports,
+vector new/set! pairs) to compile alongside the target. `nothing` when `T`
+is outside the universe.
+"""
+function arg_descriptor(T::Type)
+    get!(_ARG_CACHE, T) do
+        accs = Any[]
+        names = Set{String}()
+        d = _build_arg!(accs, names, T)
+        d === nothing ? nothing : (d, accs)
+    end
+end
+
+args_supported(T::Type) = arg_descriptor(T) !== nothing
+
+function _build_arg!(accs, names, T::Type)
+    if haskey(_INTS, T)
+        w, s = _INTS[T]
+        return Dict("k" => "int", "w" => w, "s" => s)
+    elseif T === Float64
+        return Dict("k" => "bits", "w" => 64)          # JS DataView decodes bits → f64 param
+    elseif T === Float32
+        return Dict("k" => "bits", "w" => 32)          # bits of the exact f64 widening
+    elseif T === Char
+        mk = _acc!(accs, names, "_mk_char", _mk_char, (Int64,))
+        return Dict("k" => "char", "mk" => mk)
+    elseif T === String
+        nf = _acc!(accs, names, "_mkv_new_u8", _make_vnew(Vector{UInt8}), (Int64,))
+        sf = _acc!(accs, names, "_mkv_set_u8", _make_vset(Vector{UInt8}), (Vector{UInt8}, Int64, UInt8))
+        mk = _acc!(accs, names, "_mk_str", _mk_str, (Vector{UInt8},))
+        return Dict("k" => "str", "mk" => mk, "new" => nf, "set" => sf)
+    elseif T <: Vector && isconcretetype(T)
+        E = eltype(T)
+        el = _build_arg!(accs, names, E)
+        el === nothing && return nothing
+        m = _mangle(T)
+        nf = _acc!(accs, names, "_mkv_new_$m", _make_vnew(T), (Int64,))
+        sf = _acc!(accs, names, "_mkv_set_$m", _make_vset(T), (T, Int64, E))
+        return Dict("k" => "vec", "new" => nf, "set" => sf, "el" => el)
+    elseif (isstructtype(T) || T <: Tuple) && isconcretetype(T)
+        n = fieldcount(T)
+        fs = Any[]
+        for i in 1:n
+            fd = _build_arg!(accs, names, fieldtype(T, i))
+            fd === nothing && return nothing
+            push!(fs, Dict("d" => fd))
+        end
+        mk = _acc!(accs, names, "_mk_$(_mangle(T))", _make_ctor(T), Tuple(fieldtype(T, i) for i in 1:n))
+        return Dict("k" => "fields", "mk" => mk, "fs" => fs, "names" => _field_names(T))
+    end
+    return nothing
+end
+
+# ── Constructor leaf/factory functions ───────────────────────────────────────
+_mk_char(x::Int64)::Char = Char(x)
+_mk_str(b::Vector{UInt8})::String = String(copy(b))
+
+function _make_vnew(::Type{T}) where {T<:Vector}
+    get!(_FN_CACHE, (:vnew, T)) do
+        f = Symbol("_vnewfn_", _mangle(T))
+        @eval (function $f(n::Int64)::$T; $T(undef, Int(n)); end)
+    end
+end
+
+function _make_vset(::Type{T}) where {T<:Vector}
+    get!(_FN_CACHE, (:vset, T)) do
+        f = Symbol("_vsetfn_", _mangle(T))
+        E = eltype(T)
+        @eval (function $f(v::$T, i::Int64, x::$E)::Int64; v[Int(i)] = x; Int64(0); end)
+    end
+end
+
+function _make_ctor(::Type{T}) where {T}
+    get!(_FN_CACHE, (:ctor, T)) do
+        f = Symbol("_ctorfn_", _mangle(T))
+        n = fieldcount(T)
+        params = [Symbol("a", i) for i in 1:n]
+        sig = [:( $(params[i])::$(fieldtype(T, i)) ) for i in 1:n]
+        body = if T <: NamedTuple
+            :( NamedTuple{$(fieldnames(T))}(tuple($(params...))) )
+        elseif T <: Tuple
+            :( tuple($(params...)) )
+        else
+            :( $T($(params...)) )
+        end
+        @eval (function $f($(sig...))::$T; $body; end)
+    end
+end
+
+# ── Julia-side encoder: native value → tagged exact tree ─────────────────────
+function value_to_tree(d, v)
+    k = d["k"]
+    if k == "int"
+        # Signed stay negative; unsigned stay in [0, 2^w). JS wraps modulo 2^w.
+        return Dict("x" => v isa Bool ? (v ? "1" : "0") : string(v))
+    elseif k == "bits"
+        b = d["w"] == 64 ? reinterpret(Int64, v::Float64) : reinterpret(Int64, Float64(v::Float32))
+        return Dict("x" => string(b))
+    elseif k == "char"
+        return Dict("x" => string(Int64(codepoint(v::Char))))
+    elseif k == "str"
+        return Dict("s" => Int.(codeunits(v::String)))
+    elseif k == "fields"
+        return Dict("f" => Any[value_to_tree(d["fs"][i]["d"], getfield(v, i)) for i in eachindex(d["fs"])])
+    elseif k == "vec"
+        return Dict("a" => Any[value_to_tree(d["el"], x) for x in v])
+    end
+    error("value_to_tree: bad kind $k")
+end
+
+# ── JS builder (inverse walker) ──────────────────────────────────────────────
+const BUILD_JS = """
+const _dv = new DataView(new ArrayBuffer(8));
+const f64bits = s => { _dv.setBigUint64(0, BigInt.asUintN(64, BigInt(s))); return _dv.getFloat64(0); };
+const build = (d, t) => {
+  switch (d.k) {
+    case 'int':  return d.w === 64 ? BigInt(t.x) : Number(t.x);
+    case 'bits': return f64bits(t.x);                       // f32 params fround on pass — exact
+    case 'char': return ex[d.mk](BigInt(t.x));
+    case 'str': {
+      const b = ex[d.new](BigInt(t.s.length));
+      for (let i = 0; i < t.s.length; i++) ex[d.set](b, BigInt(i + 1), t.s[i]);
+      return ex[d.mk](b);
+    }
+    case 'fields': return ex[d.mk](...d.fs.map((fd, i) => build(fd.d, t.f[i])));
+    case 'vec': {
+      const v = ex[d.new](BigInt(t.a.length));
+      for (let i = 0; i < t.a.length; i++) ex[d.set](v, BigInt(i + 1), build(d.el, t.a[i]));
+      return v;
+    }
+    default: throw new Error('bad-arg-desc-kind ' + d.k);
+  }
+};
+"""
+
+# ── Mutability: which arg types need post-call re-reads ──────────────────────
+ismutable_shape(T::Type) = T <: Vector || (isstructtype(T) && ismutabletype(T))
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Decode + compare (Julia side)
+# ═════════════════════════════════════════════════════════════════════════════
+
+function _float_match(a::AbstractFloat, b::AbstractFloat)
+    (isnan(a) && isnan(b)) && return true            # NaN payloads may differ
+    a === b && return true                           # bit-identical (covers ±0.0)
+    (isinf(a) || isinf(b)) && return a == b
+    # wasm libm ≠ openlibm for transcendentals: tolerate tiny ULP drift.
+    return isapprox(Float64(a), Float64(b); rtol = 1e-9, atol = 1e-12)
+end
+
+_dec_bits(::Val{64}, s::AbstractString) = reinterpret(Float64, parse(Int64, s))
+_dec_bits(::Val{32}, s::AbstractString) = Float32(reinterpret(Float64, parse(Int64, s)))
+
+function _dec_int(w::Int, signed::Bool, s::AbstractString)
+    v = parse(Int128, s)
+    w == 1 && return v != 0                              # Bool
+    ST = w == 8 ? Int8 : w == 16 ? Int16 : w == 32 ? Int32 : Int64
+    sv = ST(mod(v, Int128(2)^w) - (mod(v, Int128(2)^w) >= Int128(2)^(w - 1) ? Int128(2)^w : 0))
+    return signed ? sv : reinterpret(unsigned(ST), sv)
+end
+
+"Compare a walked wasm tree against the native value (policy lives here)."
+function tree_matches(d, native, tree)::Bool
+    tree isa AbstractDict || return false
+    haskey(tree, "err") && return false
+    k = d["k"]
+    if k == "int"
+        return native == _dec_int(d["w"], d["s"], tree["x"])
+    elseif k == "bits"
+        return _float_match(native, _dec_bits(Val(d["w"]), tree["x"]))
+    elseif k == "char"
+        return codepoint(native::Char) == UInt32(parse(Int64, tree["x"]))
+    elseif k == "str"
+        return codeunits(native::String) == UInt8.(tree["s"])
+    elseif k == "fields"
+        fs = d["fs"]
+        tf = tree["f"]
+        length(tf) == length(fs) || return false
+        return all(tree_matches(fs[i]["d"], getfield(native, i), tf[i]) for i in eachindex(fs))
+    elseif k == "vec"
+        ta = tree["a"]
+        length(native) == length(ta) || return false
+        return all(tree_matches(d["el"], native[i], ta[i]) for i in eachindex(ta))
+    end
+    return false
+end
+
+"Best-effort tree → displayable Julia value (diagnostics only)."
+function tree_decode(d, tree)
+    tree isa AbstractDict || return tree
+    haskey(tree, "err") && return Symbol(tree["err"])
+    k = d["k"]
+    k == "int" && return _dec_int(d["w"], d["s"], tree["x"])
+    k == "bits" && return _dec_bits(Val(d["w"]), tree["x"])
+    k == "char" && return Char(parse(Int64, tree["x"]))
+    k == "str" && return String(UInt8.(tree["s"]))
+    k == "fields" && return Tuple(tree_decode(d["fs"][i]["d"], tree["f"][i]) for i in eachindex(d["fs"]))
+    k == "vec" && return Any[tree_decode(d["el"], t) for t in tree["a"]]
+    return tree
+end
+
+end # module Bridge

--- a/test/fuzz/bridge.jl
+++ b/test/fuzz/bridge.jl
@@ -1,287 +1,36 @@
 # ============================================================================
-# FuzzBridge — type-directed, BIT-EXACT value transport for the oracle
+# FuzzBridge — fuzz-harness runner over WasmTarget.Bridge
 # ============================================================================
 #
-# Why this exists: the old path round-trips results through JSON decimal text,
-# which inherits the serializer's numeric semantics (gap fa64c0d70add: JSON 0.21
-# silently wrapped >typemax(Int64) literals — a fake divergence). Here a value
-# never becomes decimal text:
-#
-#   1. From the STATIC return type `T`, `descriptor(T)` builds a JSON-able tree
-#      describing how to take `T` apart, plus the minimal ACCESSOR CLOSURE —
-#      tiny getter functions (`getfield` wrappers, vector len/get, float→bits
-#      reinterprets, string codeunits) that are compiled INTO the module
-#      alongside the target via `compile_multi((fn, args, name))`.
-#   2. One generic JS walker (`_WALK_JS`) drives those exports and returns a
-#      tagged tree whose every leaf is an EXACT integer (stringified BigInt).
-#   3. `tree_matches(desc, native, tree)` walks the same descriptor against the
-#      native value. All comparison POLICY (NaN classes equal, ULP tolerance
-#      for libm divergence) lives in `_float_match` — decoupled from transport.
-#
-# The accessor closure is itself WasmTarget output: a codegen bug there surfaces
-# as a systematic, classified failure (it's part of the compiler under test, not
-# a hidden oracle dependency).
-#
-# v1 universe (M1, return values): Int8–128? no — Int8/16/32/64, UInt8–64, Bool,
-# Float32/64, Char, String, Tuple, NamedTuple, plain/nested/parametric/mutable
-# structs, Vector{T} (recursively, incl. vectors of structs/vectors).
-# `descriptor` returns `nothing` for anything outside the universe — callers
-# fall back / skip, and the round-trip test records the boundary.
+# The type-directed, bit-exact transport core (descriptors, accessor/ctor
+# closures, JS walker, comparators) was PROMOTED into the package as
+# `WasmTarget.Bridge` so downstream consumers (PlutoIslands.jl) share the one
+# implementation. This module keeps the fuzz-specific part: `bridge_run`,
+# which executes a compiled target + accessor closure over the harness's
+# persistent Node runner pool.
 
 module FuzzBridge
 
 export bridge_run, descriptor, tree_matches, tree_decode, bridge_supported
 
 using WasmTarget
+using WasmTarget.Bridge
+using WasmTarget.Bridge: WALK_JS, _mangle, _acc!, _FN_CACHE, _INTS, _build!
 using JSON
-# FuzzHarness (included by the entrypoint before this file) owns Node detection,
-# the scalar-arg encoder, and the persistent WasmRunner pool.
 using ..FuzzHarness: NODE_OK, DEFAULT_TIMEOUT, _js_inputs, run_driver_batch
 
-# ── Export-name mangling ─────────────────────────────────────────────────────
-_mangle(T::Type) = replace(string(T), r"[^A-Za-z0-9]" => "_")
-
-# ── Descriptor + accessor-closure construction (memoized per root type) ──────
-# An accessor entry is `(fn, argtypes::Tuple, export_name::String)` — the
-# 3-tuple form `compile_multi` accepts. The same concrete type always maps to
-# the same export names, so entries dedupe across nesting via `names`.
-const _DESC_CACHE = Dict{Type,Union{Nothing,Tuple{Any,Vector{Any}}}}()
-
-const _INTS = Dict{Type,Tuple{Int,Bool}}(   # T => (bitwidth, signed)
-    Int8 => (8, true),  Int16 => (16, true),  Int32 => (32, true),  Int64 => (64, true),
-    UInt8 => (8, false), UInt16 => (16, false), UInt32 => (32, false), UInt64 => (64, false),
-    Bool => (1, false),
-)
-
-function descriptor(T::Type)
-    get!(_DESC_CACHE, T) do
-        accs = Any[]
-        names = Set{String}()
-        d = _build!(accs, names, T)
-        d === nothing ? nothing : (d, accs)
-    end
-end
-
-bridge_supported(T::Type) = descriptor(T) !== nothing
-
-function _acc!(accs, names, name::String, fn, argtypes::Tuple)
-    if !(name in names)
-        push!(names, name)
-        push!(accs, (fn, argtypes, name))
-    end
-    return name
-end
-
-function _build!(accs, names, T::Type)
-    if haskey(_INTS, T)
-        w, s = _INTS[T]
-        return Dict("k" => "int", "w" => w, "s" => s)
-    elseif T === Float64
-        b = _acc!(accs, names, "_bits_f64", _bits_f64, (Float64,))
-        return Dict("k" => "bits", "b" => b, "w" => 64)
-    elseif T === Float32
-        # reinterpret(Int32, ::Float32) miscompiles today (invalid wasm — ledgered),
-        # so transport the EXACTLY-widened Float64 bits instead; Float32↔Float64
-        # widening/narrowing of a widened value is lossless.
-        b = _acc!(accs, names, "_bits_f32w", _bits_f32w, (Float32,))
-        return Dict("k" => "bits", "b" => b, "w" => 32)
-    elseif T === Char
-        b = _acc!(accs, names, "_bits_char", _bits_char, (Char,))
-        return Dict("k" => "char", "b" => b)
-    elseif T === String
-        l = _acc!(accs, names, "_str_len", _str_len, (String,))
-        c = _acc!(accs, names, "_str_cu", _str_cu, (String, Int64))
-        return Dict("k" => "str", "len" => l, "cu" => c)
-    elseif T <: Vector && isconcretetype(T)
-        E = eltype(T)
-        m = _mangle(T)
-        el = _build!(accs, names, E)
-        el === nothing && return nothing
-        lf = _make_vlen(T);  l = _acc!(accs, names, "_vlen_$m", lf, (T,))
-        gf = _make_vget(T);  g = _acc!(accs, names, "_vget_$m", gf, (T, Int64))
-        return Dict("k" => "vec", "len" => l, "get" => g, "el" => el)
-    elseif T isa Union
-        # P2-batch18: all-int unions (e.g. Union{Int32,Int64} from
-        # `try div(0,x)::Int64 catch x::Int32 end`) transport as the widest
-        # member — codegen widens the wasm return to the largest int, and the
-        # JS walker's String(v) handles number and BigInt alike. tree_matches
-        # compares with ==, which is value-based across Int widths.
-        ms = Base.uniontypes(T)
-        if all(m -> haskey(_INTS, m) && m !== Bool, ms)
-            ws = [_INTS[m] for m in ms]
-            if all(t -> t[2], ws) || all(t -> !t[2], ws)   # uniform signedness
-                return Dict("k" => "int", "w" => maximum(first.(ws)), "s" => ws[1][2])
-            end
-        end
-        return nothing
-    elseif (isstructtype(T) || T <: Tuple) && isconcretetype(T)
-        # Tuples, NamedTuples, and (im)mutable structs all decompose by field.
-        n = fieldcount(T)
-        m = _mangle(T)
-        fs = Any[]
-        for i in 1:n
-            FT = fieldtype(T, i)
-            fd = _build!(accs, names, FT)
-            fd === nothing && return nothing
-            ff = _make_fget(T, i)
-            a = _acc!(accs, names, "_fget_$(m)_$i", ff, (T,))
-            push!(fs, Dict("a" => a, "d" => fd))
-        end
-        return Dict("k" => "fields", "fs" => fs)
-    end
-    return nothing   # outside the v1 universe (Dict/Set/ranges/Union/abstract…)
-end
-
-# ── Leaf accessors (shared) ──────────────────────────────────────────────────
-_bits_f64(x::Float64)::Int64 = reinterpret(Int64, x)
-_bits_f32w(x::Float32)::Int64 = reinterpret(Int64, Float64(x))
-# reinterpret(UInt32, ::Char) miscompiles today (ledgered with the f32 case);
-# codepoint() compiles fine and is exact for the valid Chars the generator emits.
-_bits_char(c::Char)::Int64 = Int64(codepoint(c))
-_str_len(s::String)::Int64 = Int64(ncodeunits(s))
-_str_cu(s::String, i::Int64)::Int32 = Int32(codeunit(s, Int(i)))
-
-# ── Per-type accessor factories (memoized via @eval; named fns compile best) ──
-const _FN_CACHE = Dict{Any,Function}()
-
-function _make_vlen(::Type{T}) where {T<:Vector}
-    get!(_FN_CACHE, (:vlen, T)) do
-        f = Symbol("_vlenfn_", _mangle(T))
-        @eval (function $f(v::$T)::Int64; Int64(length(v)); end)
-    end
-end
-
-function _make_vget(::Type{T}) where {T<:Vector}
-    get!(_FN_CACHE, (:vget, T)) do
-        f = Symbol("_vgetfn_", _mangle(T))
-        E = eltype(T)
-        @eval (function $f(v::$T, i::Int64)::$E; v[Int(i)]; end)
-    end
-end
-
-function _make_fget(::Type{T}, i::Int) where {T}
-    get!(_FN_CACHE, (:fget, T, i)) do
-        f = Symbol("_fgetfn_", _mangle(T), "_", i)
-        FT = fieldtype(T, i)
-        # Integer-index getfield traps when the receiver ref crossed the JS
-        # boundary (works in-module — a WasmTarget quirk, ledgered); the
-        # symbol/getindex forms are solid. Tuples have no field names.
-        if T <: Tuple
-            @eval (function $f(x::$T)::$FT; x[$i]; end)
-        else
-            fname = fieldname(T, i)
-            @eval (function $f(x::$T)::$FT; x.$fname; end)
-        end
-    end
-end
-
-# ── The generic JS walker ────────────────────────────────────────────────────
-# Every numeric leaf leaves the module as an exact integer string. `ex` is the
-# instance's exports; `v` may be a JS Number, BigInt, or an opaque wasm-GC ref.
-const _WALK_JS = """
-const walk = (d, v) => {
-  switch (d.k) {
-    case 'int':  return { x: String(v) };
-    case 'bits': return { x: String(ex[d.b](v)) };
-    case 'char': return { x: String(ex[d.b](v)) };
-    case 'str': {
-      const n = Number(ex[d.len](v)); const a = [];
-      for (let i = 1; i <= n; i++) a.push(Number(ex[d.cu](v, BigInt(i))));
-      return { s: a };
-    }
-    case 'fields': return { f: d.fs.map(fd => walk(fd.d, ex[fd.a](v))) };
-    case 'vec': {
-      const n = Number(ex[d.len](v)); const a = [];
-      for (let i = 1; i <= n; i++) a.push(walk(d.el, ex[d.get](v, BigInt(i))));
-      return { a: a };
-    }
-    default: return { err: 'bad-desc-kind ' + d.k };
-  }
-};
-"""
-
-# ── Decode + compare (Julia side) ────────────────────────────────────────────
-# Walks the descriptor against the NATIVE value and the wasm tree TOGETHER —
-# no reconstruction. Numeric policy is centralized here.
-function _float_match(a::AbstractFloat, b::AbstractFloat)
-    (isnan(a) && isnan(b)) && return true            # NaN payloads may differ (JS canonicalization)
-    a === b && return true                           # bit-identical (covers ±0.0 distinction)
-    (isinf(a) || isinf(b)) && return a == b
-    # wasm libm ≠ openlibm for transcendentals: tolerate tiny ULP drift, same as vals_match.
-    return isapprox(Float64(a), Float64(b); rtol = 1e-9, atol = 1e-12)
-end
-
-_dec_bits(::Val{64}, s::AbstractString) = reinterpret(Float64, parse(Int64, s))
-# Float32 travels as its exactly-widened Float64 bits (see _bits_f32w).
-_dec_bits(::Val{32}, s::AbstractString) = Float32(reinterpret(Float64, parse(Int64, s)))
-
-# Exact integer decode: the wire value is the (possibly sign-mangled) machine
-# integer; normalize through the same-width signed type then reinterpret.
-function _dec_int(w::Int, signed::Bool, s::AbstractString)
-    v = parse(Int128, s)
-    w == 1 && return v != 0                              # Bool
-    ST = w == 8 ? Int8 : w == 16 ? Int16 : w == 32 ? Int32 : Int64
-    sv = ST(mod(v, Int128(2)^w) - (mod(v, Int128(2)^w) >= Int128(2)^(w - 1) ? Int128(2)^w : 0))
-    return signed ? sv : reinterpret(unsigned(ST), sv)
-end
-
-function tree_matches(d, native, tree)::Bool
-    tree isa AbstractDict || return false
-    haskey(tree, "err") && return false
-    k = d["k"]
-    if k == "int"
-        w = d["w"]; s = d["s"]
-        dec = _dec_int(w, s, tree["x"])
-        return w == 1 ? (native == dec) : (native == dec)
-    elseif k == "bits"
-        dec = _dec_bits(Val(d["w"]), tree["x"])
-        return _float_match(native, dec)
-    elseif k == "char"
-        return codepoint(native::Char) == UInt32(parse(Int64, tree["x"]))
-    elseif k == "str"
-        bytes = tree["s"]
-        return codeunits(native::String) == UInt8.(bytes)
-    elseif k == "fields"
-        fs = d["fs"]
-        tf = tree["f"]
-        length(tf) == length(fs) || return false
-        return all(tree_matches(fs[i]["d"], getfield(native, i), tf[i]) for i in eachindex(fs))
-    elseif k == "vec"
-        ta = tree["a"]
-        length(native) == length(ta) || return false
-        return all(tree_matches(d["el"], native[i], ta[i]) for i in eachindex(ta))
-    end
-    return false
-end
-
-# Best-effort reconstruction of a walked tree into a displayable Julia value —
-# for ledger DIAGNOSTICS only (composites decode to tuples/vectors; comparison
-# never goes through this, it uses tree_matches).
-function tree_decode(d, tree)
-    tree isa AbstractDict || return tree
-    haskey(tree, "err") && return Symbol(tree["err"])
-    k = d["k"]
-    k == "int" && return _dec_int(d["w"], d["s"], tree["x"])
-    k == "bits" && return _dec_bits(Val(d["w"]), tree["x"])
-    k == "char" && return Char(parse(Int64, tree["x"]))
-    k == "str" && return String(UInt8.(tree["s"]))
-    k == "fields" && return Tuple(tree_decode(d["fs"][i]["d"], tree["f"][i]) for i in eachindex(d["fs"]))
-    k == "vec" && return Any[tree_decode(d["el"], t) for t in tree["a"]]
-    return tree
-end
+# back-compat alias for fuzz files that referenced the old internal name
+const _WALK_JS = WALK_JS
 
 # ── Execution: compile target + accessor closure, run, return walked trees ───
 """
     bridge_run(fn, argtypes, inputs; rettype, strict=true, timeout, opt=false)
 
 Compile `fn` together with the accessor closure for `rettype` and evaluate it
-over every arg-tuple in `inputs` (scalar args, as in `compile_and_run`) in one
-Node round-trip. Returns a vector of `(:ok, tree)` / `(:trap, msg)` per input,
-`:unsupported` if `rettype` is outside the bridge universe, or
-`(:compile_error => e)` / `:no_node` for whole-batch failures.
-
-Compare each `(:ok, tree)` against the native value via
-`tree_matches(descriptor(rettype)[1], native, tree)`.
+over every arg-tuple in `inputs` (scalar args) in one Node round-trip.
+Returns a vector of `(:ok, tree)` / `(:trap, msg)` per input, `:unsupported`
+if `rettype` is outside the bridge universe, or `(:compile_error => e)` /
+`:no_node` for whole-batch failures.
 """
 function bridge_run(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
                     strict::Bool = true, timeout::Real = DEFAULT_TIMEOUT, opt = false)
@@ -304,7 +53,7 @@ function bridge_run(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
     const ex = instance.exports;
     const f = ex['$fname'];
     const desc = $(JSON.json(desc));
-    $_WALK_JS
+    $WALK_JS
     return inputs.map(args => {
         try { return { ok: walk(desc, f(...args)) }; }
         catch (e) { return { trap: String(e && e.message || e) }; }

--- a/test/fuzz/bridge_args.jl
+++ b/test/fuzz/bridge_args.jl
@@ -1,175 +1,25 @@
 # ============================================================================
-# FuzzBridgeArgs — argument-side of the bit-exact bridge (M2)
+# FuzzBridgeArgs — argument-side fuzz runner over WasmTarget.Bridge
 # ============================================================================
 #
-# Inverse of the read-side walker: Julia encodes each native argument as the
-# same tagged exact-integer tree (`value_to_tree`); a generic JS `build`
-# reconstructs the value INSIDE wasm via a compiled constructor closure
-# (positional ctors for structs/tuples, new/set! pairs for vectors, Char from
-# codepoint, String from a byte vector; float leaves cross as raw f64 bits via
-# DataView — never decimal text).
-#
-# Mutation parity: arguments whose type is mutable (Vector, mutable struct) are
-# RE-READ through the read-side walker after the call; the property layer
-# compares them against native's post-call arguments. This is what makes
-# `push!`/`sort!`-style ops honestly testable.
-#
-# `bridge_run_args` is the full-generality runner: arbitrary supported arg
-# types AND return type. It supersedes both the scalar `_js_inputs` path and
-# the hand-rolled `_bv_*` vector bridge.
+# The constructor-closure marshalling core lives in `WasmTarget.Bridge`
+# (promoted from here). This module keeps `bridge_run_args`, the
+# full-generality fuzz runner: arbitrary supported arg types AND return type,
+# with post-call re-reads of mutable args (mutation parity).
 
 module FuzzBridgeArgs
 
 export bridge_run_args, arg_descriptor, value_to_tree, args_supported, ismutable_shape
 
 using WasmTarget
+using WasmTarget.Bridge
+using WasmTarget.Bridge: WALK_JS, BUILD_JS, _acc!
 using JSON
 using ..FuzzHarness: NODE_OK, DEFAULT_TIMEOUT, run_driver_batch
 using ..FuzzBridge
-using ..FuzzBridge: _mangle, _acc!, _FN_CACHE, _INTS, _build!
 
-# ── Argument descriptor: read-descriptor keys + constructor exports ──────────
-# Cached per type. `accs` accumulates BOTH read-side accessors (for post-call
-# re-reads) and constructor exports.
-const _ARG_CACHE = Dict{Type,Union{Nothing,Tuple{Any,Vector{Any}}}}()
-
-function arg_descriptor(T::Type)
-    get!(_ARG_CACHE, T) do
-        accs = Any[]
-        names = Set{String}()
-        d = _build_arg!(accs, names, T)
-        d === nothing ? nothing : (d, accs)
-    end
-end
-
-args_supported(T::Type) = arg_descriptor(T) !== nothing
-
-function _build_arg!(accs, names, T::Type)
-    if haskey(_INTS, T)
-        w, s = _INTS[T]
-        return Dict("k" => "int", "w" => w, "s" => s)
-    elseif T === Float64
-        return Dict("k" => "bits", "w" => 64)          # JS DataView decodes bits → f64 param
-    elseif T === Float32
-        return Dict("k" => "bits", "w" => 32)          # bits of the exact f64 widening; fround on pass
-    elseif T === Char
-        mk = _acc!(accs, names, "_mk_char", _mk_char, (Int64,))
-        return Dict("k" => "char", "mk" => mk)
-    elseif T === String
-        m = "_mk_str"
-        nf = _acc!(accs, names, "_mkv_new_u8", _make_vnew(Vector{UInt8}), (Int64,))
-        sf = _acc!(accs, names, "_mkv_set_u8", _make_vset(Vector{UInt8}), (Vector{UInt8}, Int64, UInt8))
-        mk = _acc!(accs, names, m, _mk_str, (Vector{UInt8},))
-        return Dict("k" => "str", "mk" => mk, "new" => nf, "set" => sf)
-    elseif T <: Vector && isconcretetype(T)
-        E = eltype(T)
-        el = _build_arg!(accs, names, E)
-        el === nothing && return nothing
-        m = _mangle(T)
-        nf = _acc!(accs, names, "_mkv_new_$m", _make_vnew(T), (Int64,))
-        sf = _acc!(accs, names, "_mkv_set_$m", _make_vset(T), (T, Int64, E))
-        return Dict("k" => "vec", "new" => nf, "set" => sf, "el" => el)
-    elseif (isstructtype(T) || T <: Tuple) && isconcretetype(T)
-        n = fieldcount(T)
-        fs = Any[]
-        for i in 1:n
-            fd = _build_arg!(accs, names, fieldtype(T, i))
-            fd === nothing && return nothing
-            push!(fs, Dict("d" => fd))
-        end
-        mk = _acc!(accs, names, "_mk_$(_mangle(T))", _make_ctor(T), Tuple(fieldtype(T, i) for i in 1:n))
-        return Dict("k" => "fields", "mk" => mk, "fs" => fs)
-    end
-    return nothing
-end
-
-# ── Constructor leaf/factory functions ───────────────────────────────────────
-_mk_char(x::Int64)::Char = Char(x)
-_mk_str(b::Vector{UInt8})::String = String(copy(b))
-
-function _make_vnew(::Type{T}) where {T<:Vector}
-    get!(_FN_CACHE, (:vnew, T)) do
-        f = Symbol("_vnewfn_", _mangle(T))
-        @eval (function $f(n::Int64)::$T; $T(undef, Int(n)); end)
-    end
-end
-
-function _make_vset(::Type{T}) where {T<:Vector}
-    get!(_FN_CACHE, (:vset, T)) do
-        f = Symbol("_vsetfn_", _mangle(T))
-        E = eltype(T)
-        @eval (function $f(v::$T, i::Int64, x::$E)::Int64; v[Int(i)] = x; Int64(0); end)
-    end
-end
-
-function _make_ctor(::Type{T}) where {T}
-    get!(_FN_CACHE, (:ctor, T)) do
-        f = Symbol("_ctorfn_", _mangle(T))
-        n = fieldcount(T)
-        params = [Symbol("a", i) for i in 1:n]
-        sig = [:( $(params[i])::$(fieldtype(T, i)) ) for i in 1:n]
-        body = if T <: Tuple
-            :( tuple($(params...)) )
-        elseif T <: NamedTuple
-            :( NamedTuple{$(fieldnames(T))}(tuple($(params...))) )
-        else
-            :( $T($(params...)) )
-        end
-        @eval (function $f($(sig...))::$T; $body; end)
-    end
-end
-
-# ── Julia-side encoder: native value → tagged exact tree ─────────────────────
-function value_to_tree(d, v)
-    k = d["k"]
-    if k == "int"
-        # Natural decimal of the value: signed stay negative; unsigned stay in
-        # [0, 2^w) (wasm params ZERO-extend unsigned — sign-extending UInt8(255)
-        # to -1 produced 0xFFFFFFFF on the other side). JS ToInt32/i64-BigInt
-        # wrap modulo 2^w, so UInt32/UInt64 top-bit values pass exactly.
-        return Dict("x" => v isa Bool ? (v ? "1" : "0") : string(v))
-    elseif k == "bits"
-        b = d["w"] == 64 ? reinterpret(Int64, v::Float64) : reinterpret(Int64, Float64(v::Float32))
-        return Dict("x" => string(b))
-    elseif k == "char"
-        return Dict("x" => string(Int64(codepoint(v::Char))))
-    elseif k == "str"
-        return Dict("s" => Int.(codeunits(v::String)))
-    elseif k == "fields"
-        return Dict("f" => Any[value_to_tree(d["fs"][i]["d"], getfield(v, i)) for i in eachindex(d["fs"])])
-    elseif k == "vec"
-        return Dict("a" => Any[value_to_tree(d["el"], x) for x in v])
-    end
-    error("value_to_tree: bad kind $k")
-end
-
-# ── JS builder (inverse walker) ──────────────────────────────────────────────
-const _BUILD_JS = """
-const _dv = new DataView(new ArrayBuffer(8));
-const f64bits = s => { _dv.setBigUint64(0, BigInt.asUintN(64, BigInt(s))); return _dv.getFloat64(0); };
-const build = (d, t) => {
-  switch (d.k) {
-    case 'int':  return d.w === 64 ? BigInt(t.x) : Number(t.x);
-    case 'bits': return f64bits(t.x);                       // f32 params fround on pass — exact
-    case 'char': return ex[d.mk](BigInt(t.x));
-    case 'str': {
-      const b = ex[d.new](BigInt(t.s.length));
-      for (let i = 0; i < t.s.length; i++) ex[d.set](b, BigInt(i + 1), t.s[i]);
-      return ex[d.mk](b);
-    }
-    case 'fields': return ex[d.mk](...d.fs.map((fd, i) => build(fd.d, t.f[i])));
-    case 'vec': {
-      const v = ex[d.new](BigInt(t.a.length));
-      for (let i = 0; i < t.a.length; i++) ex[d.set](v, BigInt(i + 1), build(d.el, t.a[i]));
-      return v;
-    }
-    default: throw new Error('bad-arg-desc-kind ' + d.k);
-  }
-};
-"""
-
-# ── Mutability: which arg types need post-call re-reads ──────────────────────
-ismutable_shape(T::Type) = T <: Vector || (isstructtype(T) && ismutabletype(T))
+# back-compat alias
+const _BUILD_JS = BUILD_JS
 
 """
     bridge_run_args(fn, argtypes, inputs; rettype, strict, timeout, opt)
@@ -182,7 +32,7 @@ immutable args) — or `:unsupported` / `(:compile_error => e)` / `:no_node`.
 function bridge_run_args(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
                          strict::Bool = true, timeout::Real = DEFAULT_TIMEOUT, opt = false)
     NODE_OK || return :no_node
-    rp = FuzzBridge.descriptor(rettype)
+    rp = Bridge.descriptor(rettype)
     rp === nothing && return :unsupported
     rdesc, raccs = rp
     adescs = Any[]
@@ -201,11 +51,11 @@ function bridge_run_args(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
             _acc!(accs, names, nm_, fn_, at_)
         end
         push!(adescs, ad)
-        mut = T <: Vector || (isstructtype(T) && ismutabletype(T))
+        mut = ismutable_shape(T)
         push!(mutable_flags, mut)
         if mut
             # post-call re-read uses the READ-side descriptor (+ its accessors)
-            rp2 = FuzzBridge.descriptor(T)
+            rp2 = Bridge.descriptor(T)
             rp2 === nothing && return :unsupported
             pd, paccs = rp2
             for (fn_, at_, nm_) in paccs
@@ -234,8 +84,8 @@ function bridge_run_args(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
     const rdesc = $(JSON.json(rdesc));
     const pdescs = $(JSON.json(postdescs));
     const inputs = $(JSON.json(enc_inputs));
-    $(FuzzBridge._WALK_JS)
-    $_BUILD_JS
+    $WALK_JS
+    $BUILD_JS
     return inputs.map(trees => {
         try {
             const args = trees.map((t, j) => build(adescs[j], t));


### PR DESCRIPTION
Promotes the differential fuzzer's bit-exact value-transport core (test/fuzz/bridge.jl + bridge_args.jl) into the package as `WasmTarget.Bridge`, so PlutoIslands.jl can marshal String/NamedTuple/Vector/struct bond values across the JS↔wasm boundary with the same fuzzer-proven machinery.

- `src/bridge.jl`: descriptors (read + arg side), accessor/constructor factories, `WALK_JS`/`BUILD_JS`, `value_to_tree`/`tree_matches`/`tree_decode` — dependency-free core.
- `test/fuzz/bridge{,_args}.jl`: now thin wrappers keeping only the FuzzHarness-bound runners (`bridge_run`, `bridge_run_args`); back-compat aliases preserved.
- New: `fields` descriptors carry `names` for name-keyed sources (msgpack objects → ctor args).
- Verified: fuzz round-trip suites pass through the promoted core (26/26 read, 15/15 args).
