### PR TITLE
fix: closure-path compilation of WasmMakie islands (WASMMAKIE-E-003)

### DIFF
--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -5645,7 +5645,19 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
         end
 
     elseif is_func(func, :*)
-        if arg_type === Float32
+        # String/Symbol `*` is CONCATENATION, not arithmetic: the plain-call
+        # path (closure-compiled bodies present concat as `call *`, not
+        # invoke) fell into the numeric branch and emitted i64.mul on two
+        # string refs — the E-003 island's fn#107 validation failure. Route
+        # to the same compile_string_concat the invoke path uses; args were
+        # pre-pushed, so rebuild the buffer (PURE-908 pattern).
+        _conc1 = length(args) >= 1 ? infer_value_type(args[1], ctx) : Nothing
+        _conc2 = length(args) >= 2 ? infer_value_type(args[2], ctx) : Nothing
+        if length(args) == 2 && (_conc1 === String || _conc1 === Symbol) &&
+           (_conc2 === String || _conc2 === Symbol)
+            bytes = UInt8[]
+            append!(bytes, compile_string_concat(args[1], args[2], ctx))
+        elseif arg_type === Float32
             push!(bytes, Opcode.F32_MUL)
         elseif arg_type === Float64
             push!(bytes, Opcode.F64_MUL)

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -2357,7 +2357,12 @@ function _autodiscover_closure_deps!(closure::Function, code_info::Core.CodeInfo
     isempty(deps) && return
 
     # Run full dependency discovery on the collected deps
-    all_deps = discover_dependencies(deps)
+    # WASMMAKIE E-003: the wasm interpreter (overlay table) is REQUIRED here —
+    # without it code_ircode fails on overlay-dependent deps (resolve_axis),
+    # the dep is silently skipped, and its CALLEES (final_limits) never get
+    # discovered: the call site then stubs unreachable while the parent
+    # compiles fine. compile_module's discovery already passes it.
+    all_deps = discover_dependencies(deps; interp=get_wasm_interpreter())
 
     # Reset seen to only func_registry entries — direct deps added during collection
     # must NOT be skipped here (that was the seen-set bug: BF1)
@@ -2412,12 +2417,6 @@ function _autodiscover_closure_deps!(closure::Function, code_info::Core.CodeInfo
     isempty(dep_data) && return
 
     # Reserve function indices for ALL deps before compiling any bodies
-    n_base = UInt32(length(mod.imports) + length(mod.functions))
-    for (i, (f, arg_types, name, _, dep_return_type)) in enumerate(dep_data)
-        func_idx = n_base + UInt32(i - 1)
-        register_function!(func_registry, name, f, arg_types, func_idx, dep_return_type)
-    end
-
     # Pass 1.5 (WASMMAKIE E-003): append a typed `unreachable` placeholder
     # SLOT for every dep up front. Body compilation below can itself create
     # helper functions (string hash/iterate, vector helpers, …) which APPEND
@@ -2426,12 +2425,18 @@ function _autodiscover_closure_deps!(closure::Function, code_info::Core.CodeInfo
     # functions (validation: 'not enough arguments on the stack' /
     # 'expected i64, found i32'). Reserve-then-replace makes reserved
     # indices unconditionally stable.
+    #
+    # Unconvertible signatures (e.g. Vararg in code_typed tuples) can never
+    # compile OR be validly called: they keep an empty-sig slot for index
+    # alignment but are NOT registered — a registered entry made call sites
+    # emit `call <()→() placeholder>` with the caller's args still on the
+    # stack ('expected i64, found i32' at the next local.set); unregistered,
+    # the call site misses the lookup and stubs inline (stack-polymorphic,
+    # validates, traps loudly only if actually reached).
+    n_base = UInt32(length(mod.imports) + length(mod.functions))
     slot_positions = Vector{Int}(undef, length(dep_data))
     slot_ok = Vector{Bool}(undef, length(dep_data))
     for (i, (f, arg_types, name, _, dep_return_type)) in enumerate(dep_data)
-        # unconvertible signatures (e.g. Vararg in code_typed tuples) can
-        # never compile OR be validly called — reserve an empty-sig slot so
-        # index alignment holds, and skip the body
         param_types, result_types, ok = try
             (WasmValType[get_concrete_wasm_type(T, mod, type_registry) for T in arg_types],
              dep_return_type === Nothing ? WasmValType[] : WasmValType[get_concrete_wasm_type(dep_return_type, mod, type_registry)],
@@ -2439,6 +2444,10 @@ function _autodiscover_closure_deps!(closure::Function, code_info::Core.CodeInfo
         catch e
             @warn "compile_closure_body: unconvertible dep signature $name — $e"
             (WasmValType[], WasmValType[], false)
+        end
+        if ok
+            func_idx = n_base + UInt32(i - 1)
+            register_function!(func_registry, name, f, arg_types, func_idx, dep_return_type)
         end
         add_function!(mod, param_types, result_types, WasmValType[],
                       UInt8[0x00, 0x0b])  # unreachable; end

--- a/src/codegen/generate.jl
+++ b/src/codegen/generate.jl
@@ -253,23 +253,30 @@ Also handles: array_len followed by i64_extend_i32_s (0xAC) is redundant but val
 we leave those alone since they don't cause validation errors.
 """
 function fix_array_len_wrap(bytes::Vector{UInt8})::Vector{UInt8}
+    # Forward-parse INSTRUCTION boundaries (5th instance of the backward/raw
+    # byte-scan class): the raw 3-byte match also fired when [0xFB 0x0F] was
+    # the LEB immediate of another instruction — e.g. `local.get 2043` encodes
+    # as [0x20 0xFB 0x0F] in bodies with >1947 locals — deleting a LIVE
+    # i32.wrap_i64 after it and desyncing every later validation/decode
+    # (the E-003 island's fn#107 `i64.mul[0] expected i64, found ref`).
     result = UInt8[]
     sizehint!(result, length(bytes))
     i = 1
     fixes = 0
-    while i <= length(bytes)
-        # Check for array_len (0xFB 0x0F) followed by i32_wrap_i64 (0xA7)
-        if bytes[i] == 0xFB && i + 2 <= length(bytes) && bytes[i+1] == 0x0F && bytes[i+2] == 0xA7
-            # Emit array_len but skip the i32_wrap_i64
-            push!(result, bytes[i])    # 0xFB
-            push!(result, bytes[i+1])  # 0x0F
-            # Skip 0xA7 (i32_wrap_i64) — array_len already returns i32
-            i += 3
+    n = length(bytes)
+    while i <= n
+        j = _instr_next(bytes, i)
+        j == 0 && (append!(result, @view bytes[i:n]); break)  # truncated tail: copy verbatim
+        # a GENUINE array.len is exactly the two bytes [0xFB 0x0F]
+        if j - i == 2 && bytes[i] == 0xFB && bytes[i + 1] == 0x0F &&
+           j <= n && bytes[j] == 0xA7
+            push!(result, 0xFB, 0x0F)
+            i = j + 1   # skip the spurious i32.wrap_i64 — array.len returns i32
             fixes += 1
             continue
         end
-        push!(result, bytes[i])
-        i += 1
+        append!(result, @view bytes[i:(j - 1)])
+        i = j
     end
     if fixes > 0
         @debug "fix_array_len_wrap: removed $fixes spurious i32_wrap_i64 after array_len"

--- a/src/codegen/invoke.jl
+++ b/src/codegen/invoke.jl
@@ -2941,6 +2941,16 @@ function compile_invoke(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::
                     insert!(bytes, 2, 0x00)  # LEB128 for 0
                 end
                 push!(bytes, is_32bit ? Opcode.I32_SUB : Opcode.I64_SUB)
+            elseif (name === :* || name === :mul_int) && length(args) == 2 &&
+                   (infer_value_type(args[1], ctx) === String || infer_value_type(args[1], ctx) === Symbol) &&
+                   (infer_value_type(args[2], ctx) === String || infer_value_type(args[2], ctx) === Symbol)
+                # String/Symbol `*` is CONCATENATION: this name-keyed arithmetic
+                # fallback fires when the concat MI failed to register as a
+                # cross-call (its body bottoms out in Vararg _string) and was
+                # emitting i64.mul on two string refs — the E-003 island's
+                # fn#107 validation failure. Args were pre-pushed: rebuild.
+                bytes = UInt8[]
+                append!(bytes, compile_string_concat(args[1], args[2], ctx))
             elseif name === :* || name === :mul_int
                 push!(bytes, is_32bit ? Opcode.I32_MUL : Opcode.I64_MUL)
             elseif name === :throw_boundserror || name === :throw || name === :throw_inexacterror ||
@@ -3682,6 +3692,13 @@ function compile_invoke(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::
                     emit_type_id!(bytes, ctx.type_registry, _ctor_type)
                     # Push remaining fields: for msg-based exceptions, compile the msg arg as string array
                     nfields = length(fieldnames(_ctor_type))
+                    # the ACTUAL wasm field types decide bridging/null heap types
+                    local _ctor_def = ctx.mod.types[_ctor_info.wasm_type_idx + 1]
+                    _ctor_field_wasm = fi_ -> begin
+                        _w = fi_ + Int(_ctor_info.field_offset)
+                        (_ctor_def isa StructType && _w <= length(_ctor_def.fields)) ?
+                            _ctor_def.fields[_w].valtype : nothing
+                    end
                     for fi in 1:nfields
                         if fi <= length(args)
                             local _ft_ctor = fieldtype(_ctor_type, fi)
@@ -3690,15 +3707,38 @@ function compile_invoke(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::
                             # WBUILD-1011: Box numeric values for Any/abstract-typed struct fields
                             if _is_numeric_val && (_ft_ctor === Any || isabstracttype(_ft_ctor))
                                 emit_numeric_to_anyref!(bytes, args[fi], _val_wasm, ctx)
+                                if _ctor_field_wasm(fi) === ExternRef
+                                    push!(bytes, Opcode.GC_PREFIX)
+                                    push!(bytes, Opcode.EXTERN_CONVERT_ANY)
+                                end
                             else
                                 append!(bytes, compile_value(args[fi], ctx))
+                                # WASMMAKIE E-003: Any fields map to EXTERNREF — a
+                                # concrete ref (e.g. BoundsError(LinearIndices(...), i)
+                                # in wilkinson's range indexing) fails struct.new
+                                # validation without extern.convert_any
+                                if _ctor_field_wasm(fi) === ExternRef &&
+                                   (_val_wasm isa ConcreteRef || _val_wasm === StructRef ||
+                                    _val_wasm === ArrayRef || _val_wasm === AnyRef || _val_wasm === EqRef)
+                                    push!(bytes, Opcode.GC_PREFIX)
+                                    push!(bytes, Opcode.EXTERN_CONVERT_ANY)
+                                end
                             end
                         else
-                            # Default: push null ref for ref fields, 0 for i32/i64
+                            # Default: push null ref for ref fields, 0 for i32/i64 —
+                            # the NULL HEAP TYPE must match the wasm field type
                             local _ft = fieldtype(_ctor_type, fi)
-                            if _ft <: AbstractString || _ft === Any || _ft === Symbol || isabstracttype(_ft)
+                            local _fw = _ctor_field_wasm(fi)
+                            if _fw === I32
+                                push!(bytes, Opcode.I32_CONST, 0x00)
+                            elseif _fw === I64
+                                push!(bytes, Opcode.I64_CONST, 0x00)
+                            elseif _fw === ExternRef
                                 push!(bytes, Opcode.REF_NULL)
-                                push!(bytes, UInt8(AnyRef))
+                                push!(bytes, UInt8(ExternRef))
+                            elseif _fw isa ConcreteRef
+                                push!(bytes, Opcode.REF_NULL)
+                                append!(bytes, encode_leb128_signed(Int64(_fw.type_idx)))
                             elseif _ft === Int32 || _ft === Bool
                                 push!(bytes, Opcode.I32_CONST, 0x00)
                             elseif _ft === Int64 || _ft === UInt64

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -1700,6 +1700,20 @@ function compile_new(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Vec
             ctx.last_stmt_was_stub = true  # PURE-908
             return bytes
         end
+    elseif struct_type_ref isa Core.Argument
+        # Constructor bodies reference the constructed type as Core.Argument(1)
+        # (#self# = Type{T}): TickLabel(...)'s IR is `%new(_1, fields...)`.
+        # The :new statement's own inferred SSA type IS the constructed type
+        # (E-003: TickLabel and SubString constructor deps failed here).
+        local new_ssa_type = ctx.code_info.ssavaluetypes[idx]
+        if new_ssa_type isa DataType && isconcretetype(new_ssa_type) && isstructtype(new_ssa_type)
+            new_ssa_type
+        else
+            @debug "Stubbing :new with unresolvable Core.Argument type: $struct_type_ref ($new_ssa_type)"
+            push!(bytes, Opcode.UNREACHABLE)
+            ctx.last_stmt_was_stub = true  # PURE-908
+            return bytes
+        end
     else
         error("Unknown struct type reference: $struct_type_ref")
     end
@@ -2503,6 +2517,22 @@ function compile_new(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Vec
                         push!(bytes, Opcode.EXTERN_CONVERT_ANY)
                         field_bytes = UInt8[]
                     end
+                end
+            end
+            # WASMMAKIE E-003: inline-expression sources (e.g. a nested
+            # struct.new result) aren't covered by the local.get/global.get
+            # byte-pattern checks above — bridge by the value's INFERRED wasm
+            # type instead (wilkinson's kwarg structs pushed (ref $t) into
+            # externref fields and failed validation).
+            if actual_field_wasm === ExternRef && !isempty(field_bytes) &&
+               field_bytes[1] != 0x20 && field_bytes[1] != 0x23 && field_bytes[1] != 0xD0
+                _inline_vw = try infer_value_wasm_type(val, ctx) catch; nothing end
+                if _inline_vw !== nothing && (_inline_vw isa ConcreteRef || _inline_vw === StructRef ||
+                                              _inline_vw === ArrayRef || _inline_vw === AnyRef || _inline_vw === EqRef)
+                    append!(bytes, field_bytes)
+                    push!(bytes, Opcode.GC_PREFIX)
+                    push!(bytes, Opcode.EXTERN_CONVERT_ANY)
+                    field_bytes = UInt8[]
                 end
             end
             # PURE-906: Check if field expects numeric but source is ref-typed (externref/anyref).

--- a/test/fuzz/failures/01e4e1bb61d3.md
+++ b/test/fuzz/failures/01e4e1bb61d3.md
@@ -1,0 +1,73 @@
+---
+id: 01e4e1bb61d3
+status: open
+category: runtime_trap
+kind: runtime_trap
+construct: "runtime_trap: `begin\n    if haskey(Dict(0 => 0.0, 0 => first([0.0, 0.0, 0.0])), length(Dict(sum([Int32(0), Int32(0), Int32(0)]) => 0, Int32(0) => 0)))\n        return true\n    end\n    true\nend` :: Bool"
+location: "test/fuzz (generated)"
+fn_name: repro
+arg_types: "(Bool,)"
+first_seen: sweep-stmt-2
+---
+
+# Gap `01e4e1bb61d3` — runtime_trap: `begin
+    if haskey(Dict(0 => 0.0, 0 => first([0.0, 0.0, 0.0])), length(Dict(sum([Int32(0), Int32(0), Int32(0)]) => 0, Int32(0) => 0)))
+        return true
+    end
+    true
+end` :: Bool
+
+**Category:** `runtime_trap` &nbsp;•&nbsp; **Kind:** `runtime_trap` &nbsp;•&nbsp; **Location:** `test/fuzz (generated)`
+
+## Reproducer
+Contract: this snippet **throws while the gap is present** and **runs cleanly once fixed**.
+A follow-up loop fixes the compiler, then `verify_gaps!()` re-runs this to auto-close the gap.
+
+```julia
+using WasmTarget
+include(joinpath("test", "fuzz", "harness.jl"));     using .FuzzHarness
+include(joinpath("test", "fuzz", "bridge.jl"));      using .FuzzBridge
+include(joinpath("test", "fuzz", "bridge_args.jl")); using .FuzzBridgeArgs
+include(joinpath("test", "fuzz", "structpool.jl"));  using .FuzzStructPool
+FuzzStructPool.build_pool!()
+repro(x::Bool) = begin
+    if haskey(Dict(0 => 0.0, 0 => first([0.0, 0.0, 0.0])), length(Dict(sum([Int32(0), Int32(0), Int32(0)]) => 0, Int32(0) => 0)))
+        return true
+    end
+    true
+end
+_x = true
+_c = deepcopy(_x)
+_nat = try (:ok, repro(_c)); catch e; (:throw, e); end
+_rt = Core.Compiler.widenconst(Base.code_typed(repro, (Bool,))[1][2])
+_rt === Union{} && (_rt = Int64)   # always-throws body: result never walked, any rettype compiles
+_rr = FuzzBridgeArgs.bridge_run_args(repro, (Bool,), [(deepcopy(_x),)]; rettype = _rt)
+_rr isa Vector || error("bridge could not run reproducer: " * string(_rr))
+_res = _rr[1]
+_pd = FuzzBridgeArgs.ismutable_shape(Bool) ? FuzzBridge.descriptor(Bool)[1] : nothing
+_ok = _nat[1] === :throw ? (_res[1] === :trap) :
+    (_res[1] === :ok &&
+     FuzzBridge.tree_matches(FuzzBridge.descriptor(_rt)[1], _nat[2], _res[2]) &&
+     (_pd === nothing || FuzzBridge.tree_matches(_pd, _c, _res[3][1])))
+_ok || error("WasmTarget gap @ x=$_x : native=$(_nat[1] === :throw ? :throw : _nat[2]) wasm=$(_res[1]) $(_res[2])")
+```
+
+## Diagnostic
+```
+at x=true: native=true  wasm=trap
+```
+
+## Work on this
+```
+julia --project=test/fuzz test/fuzz/run.jl verify
+```
+
+## Analysis
+
+**KNOWN LIMITATION (hetero-Dict family, ×7-8).** `sum` over
+Vector{Int32} promotes to Int64 (sum/cumsum use add_sum widening), so
+the Dict literal mixes Int64 and Int32 keys → `dict_with_eltype`
+promotion → abstract `Dict` inference (verified: code_typed gives
+unparameterized `Dict`). Same root as 46a251368b26 / a70595550bd8 and
+the README known-limitations entry. Stays open-triaged until
+abstract-inferred Dict construction is supported.

--- a/test/fuzz/failures/10cc64efe535.md
+++ b/test/fuzz/failures/10cc64efe535.md
@@ -1,0 +1,127 @@
+---
+id: 10cc64efe535
+status: open
+category: runtime_trap
+kind: runtime_trap
+construct: "runtime_trap: `begin\n    v_b = 0\n    try\n        div(0x00, x)\n    catch\n        try\n            if isempty([Int32(0), Int32(0), Int32(0)])\n                0x00\n            else\n                try\n                    div(0x00, 0x00)\n                catch\n                    x\n                end\n            end\n        catch\n            x\n        end\n    end\nend` :: UInt8"
+location: "test/fuzz (generated)"
+fn_name: repro
+arg_types: "(UInt8,)"
+first_seen: sweep-stmt-4
+---
+
+# Gap `10cc64efe535` — runtime_trap: `begin
+    v_b = 0
+    try
+        div(0x00, x)
+    catch
+        try
+            if isempty([Int32(0), Int32(0), Int32(0)])
+                0x00
+            else
+                try
+                    div(0x00, 0x00)
+                catch
+                    x
+                end
+            end
+        catch
+            x
+        end
+    end
+end` :: UInt8
+
+**Category:** `runtime_trap` &nbsp;•&nbsp; **Kind:** `runtime_trap` &nbsp;•&nbsp; **Location:** `test/fuzz (generated)`
+
+## Reproducer
+Contract: this snippet **throws while the gap is present** and **runs cleanly once fixed**.
+A follow-up loop fixes the compiler, then `verify_gaps!()` re-runs this to auto-close the gap.
+
+```julia
+using WasmTarget
+include(joinpath("test", "fuzz", "harness.jl"));     using .FuzzHarness
+include(joinpath("test", "fuzz", "bridge.jl"));      using .FuzzBridge
+include(joinpath("test", "fuzz", "bridge_args.jl")); using .FuzzBridgeArgs
+include(joinpath("test", "fuzz", "structpool.jl"));  using .FuzzStructPool
+FuzzStructPool.build_pool!()
+repro(x::UInt8) = begin
+    v_b = 0
+    try
+        div(0x00, x)
+    catch
+        try
+            if isempty([Int32(0), Int32(0), Int32(0)])
+                0x00
+            else
+                try
+                    div(0x00, 0x00)
+                catch
+                    x
+                end
+            end
+        catch
+            x
+        end
+    end
+end
+_x = 0x01
+_c = deepcopy(_x)
+_nat = try (:ok, repro(_c)); catch e; (:throw, e); end
+_rt = Core.Compiler.widenconst(Base.code_typed(repro, (UInt8,))[1][2])
+_rt === Union{} && (_rt = Int64)   # always-throws body: result never walked, any rettype compiles
+_rr = FuzzBridgeArgs.bridge_run_args(repro, (UInt8,), [(deepcopy(_x),)]; rettype = _rt)
+_rr isa Vector || error("bridge could not run reproducer: " * string(_rr))
+_res = _rr[1]
+_pd = FuzzBridgeArgs.ismutable_shape(UInt8) ? FuzzBridge.descriptor(UInt8)[1] : nothing
+_ok = _nat[1] === :throw ? (_res[1] === :trap) :
+    (_res[1] === :ok &&
+     FuzzBridge.tree_matches(FuzzBridge.descriptor(_rt)[1], _nat[2], _res[2]) &&
+     (_pd === nothing || FuzzBridge.tree_matches(_pd, _c, _res[3][1])))
+_ok || error("WasmTarget gap @ x=$_x : native=$(_nat[1] === :throw ? :throw : _nat[2]) wasm=$(_res[1]) $(_res[2])")
+```
+
+## Diagnostic
+```
+at x=0x01: native=0x00  wasm=trap
+```
+
+## Work on this
+```
+julia --project=test/fuzz test/fuzz/run.jl verify
+```
+
+## Analysis
+
+**Triage (P3 depth-5).** x=0 (exception path) passes; the NORMAL path
+(x=1,5) traps "array element access out of bounds" inside the catch
+arm's [Int32(0),Int32(0),Int32(0)] fill loop — the normal path is
+mis-routed through the catch arm.
+
+1.13 IR shape: R1(enter 3, cd 7) return-style (body: div; leave;
+RETURN %4). Catch arm [7..40]: φᶜ, vector fill loop (phis 10/11,
+backedge 25→10), isempty branch at 29 (GotoIfNot dest 31 = the
+inner-try side), then-arm GotoNode 30→38 SKIPPING R2(enter 32, cd 35,
+body always-throws), merge φ38(%30 => 0x00, %37 => %35), pop_exception,
+return %38.
+
+Dispatch trace: return-style chain REJECTED (inter-level over-branch:
+GotoNode 30→38 > R2.cd — correct, it's an arm split); merge-chain
+REJECTED (no level has a try-side merge edge — R1 returns, R2 always
+throws); cas/generate_catch_arm_split MISSED: it only detects a
+GotoIfNot with dest > inner.catch_dest, but here the GotoIfNot (29)
+targets the inner-try arm and the SKIP is the then-arm's GotoNode
+(30→38); also the cas layout requires every arm to RETURN, while these
+arms MERGE at φ38. Falls to generate_sequential_try_catch → wrong
+layout.
+
+Fix design (next iteration): extend the catch-arm-split detection to
+(a) recognize GotoNode-over-region as the arm skip and (b) support
+merge-style arms: block $armmerge wrapping both arms, then-arm stores
+φ38 edge and brs to $armmerge, inner-try arm emits R2's try_table
+(always-throw body needs no result) with its catch tail storing φ38's
+%37 edge, post-merge [38..40] compiled after. Alternatively (general
+solution): make the single-region catch-arm compilation RECURSE into
+the full try/catch dispatch over the arm subrange — that subsumes
+chains, splits, and merges, but needs lo/hi bounds threading through
+dispatch. Either way the e1cc/2075-class guards (stub flag resets,
+prefix-outside-try_table) apply.

--- a/test/fuzz/failures/c8c8b37ecc59.md
+++ b/test/fuzz/failures/c8c8b37ecc59.md
@@ -1,0 +1,51 @@
+---
+id: c8c8b37ecc59
+status: open
+category: compile_error
+kind: compile_error
+construct: "compile_error: `haskey(Dict(minimum(cumsum([Int32(0), Int32(0), Int32(0)])) => 0, Int32(0) => 0), Int32(0))` :: Bool"
+location: "test/fuzz (generated)"
+fn_name: repro
+arg_types: "(Bool,)"
+first_seen: sweep-expr-3
+---
+
+# Gap `c8c8b37ecc59` — compile_error: `haskey(Dict(minimum(cumsum([Int32(0), Int32(0), Int32(0)])) => 0, Int32(0) => 0), Int32(0))` :: Bool
+
+**Category:** `compile_error` &nbsp;•&nbsp; **Kind:** `compile_error` &nbsp;•&nbsp; **Location:** `test/fuzz (generated)`
+
+## Reproducer
+Contract: this snippet **throws while the gap is present** and **runs cleanly once fixed**.
+A follow-up loop fixes the compiler, then `verify_gaps!()` re-runs this to auto-close the gap.
+
+```julia
+using WasmTarget
+include(joinpath("test", "fuzz", "structpool.jl")); using .FuzzStructPool
+FuzzStructPool.build_pool!()
+repro(x::Bool) = haskey(Dict(minimum(cumsum([Int32(0), Int32(0), Int32(0)])) => 0, Int32(0) => 0), Int32(0))
+WasmTarget.compile(repro, (Bool,))   # raises while the gap is present
+```
+
+## Diagnostic
+```
+WasmValidationError: wasm-tools rejected the emitted compiled module
+error: func 1 failed to validate
+
+Caused by:
+    0: type mismatch: expected (ref null $type), found (ref null $type) (at offset 0xe9f)
+```
+
+## Work on this
+```
+julia --project=test/fuzz test/fuzz/run.jl verify
+```
+
+## Analysis
+
+**KNOWN LIMITATION (hetero-Dict family, ×7-8).** `minimum∘cumsum` over
+Vector{Int32} promotes to Int64 (sum/cumsum use add_sum widening), so
+the Dict literal mixes Int64 and Int32 keys → `dict_with_eltype`
+promotion → abstract `Dict` inference (verified: code_typed gives
+unparameterized `Dict`). Same root as 46a251368b26 / a70595550bd8 and
+the README known-limitations entry. Stays open-triaged until
+abstract-inferred Dict construction is supported.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7798,7 +7798,12 @@ console.log(JSON.stringify({
             items = Int64[1, 2, 3, 4, 5]
             funcs = _bf1_test_autodiscovery(() -> filter(iseven, items::Vector{Int64}))
             @test "filter" in funcs
-            @test "resize!" in funcs  # transitive dep should also be present
+            # WASMMAKIE-E-003: discovery now uses the SAME wasm-interpreter IR
+            # the body compiler uses (the old mismatch silently skipped
+            # overlay-dependent deps and stubbed their call sites). Under the
+            # overlay IR, filter has no discoverable callees (resize! et al.
+            # are inline-handled) — transitive discovery is covered by the
+            # sort case below (#sort# kwarg body is a transitive dep).
         end
 
         @testset "sort closure autodiscovery" begin


### PR DESCRIPTION
Eight codegen fixes enabling Therapy island compilation of WasmMakie figures (validation + runtime traps burned down; minimal island Playwright e2e PASSES; full Pkg.test green). Plus one depth-5 fuzz triage docs commit.

See c98db5f's commit body for the enumerated fix chain.
