### PR TITLE
Dates stdlib integration: value layer + rendering overlays (stdlib #2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,11 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [weakdeps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [extensions]
+WasmTargetDatesExt = "Dates"
 WasmTargetStatisticsExt = "Statistics"
 
 [compat]

--- a/ext/WasmTargetDatesExt.jl
+++ b/ext/WasmTargetDatesExt.jl
@@ -1,0 +1,53 @@
+# WasmTargetDatesExt — Dates stdlib integration.
+#
+# The VALUE layer (Date/DateTime construction, period arithmetic, accessors,
+# date subtraction, parsing with a DateFormat, period conversions,
+# daysinmonth/isleapyear) compiles from the real Dates implementations with
+# no stdlib-specific code. This extension carries only the rendering
+# overlays: native string(::Date) goes through IOBuffer growth internals
+# (ensureroom machinery) that WasmGC does not support yet, so render via the
+# compileable string(::Int64) + concatenation machinery instead —
+# semantically identical output.
+#
+# now()/today() are NOT overlaid here: they need a host-time import wired by
+# the embedding pipeline (compile_multi's import_stubs, e.g. "Date"/"now" →
+# JS Date.now), and wall-clock reads are host-dependent by nature.
+module WasmTargetDatesExt
+
+using WasmTarget
+using Dates
+using Base.Experimental: @overlay
+
+function _wt_zpad(n::Int64, w::Int64)
+    s = string(n)
+    while sizeof(s) < w   # ASCII digits: byte length == digit count
+        s = "0" * s
+    end
+    return s
+end
+
+@overlay WasmTarget.WASM_METHOD_TABLE function Base.string(d::Dates.Date)
+    y = Int64(Dates.year(d))
+    m = Int64(Dates.month(d))
+    dd = Int64(Dates.day(d))
+    sign = y < 0 ? "-" : ""
+    ya = y < 0 ? -y : y
+    return sign * _wt_zpad(ya, 4) * "-" * _wt_zpad(m, 2) * "-" * _wt_zpad(dd, 2)
+end
+
+@overlay WasmTarget.WASM_METHOD_TABLE function Base.string(dt::Dates.DateTime)
+    y = Int64(Dates.year(dt))
+    m = Int64(Dates.month(dt))
+    dd = Int64(Dates.day(dt))
+    h = Int64(Dates.hour(dt))
+    mi = Int64(Dates.minute(dt))
+    se = Int64(Dates.second(dt))
+    ms = Int64(Dates.millisecond(dt))
+    sign = y < 0 ? "-" : ""
+    ya = y < 0 ? -y : y
+    base = sign * _wt_zpad(ya, 4) * "-" * _wt_zpad(m, 2) * "-" * _wt_zpad(dd, 2) *
+           "T" * _wt_zpad(h, 2) * ":" * _wt_zpad(mi, 2) * ":" * _wt_zpad(se, 2)
+    return ms == 0 ? base : base * "." * _wt_zpad(ms, 3)
+end
+
+end # module

--- a/test/fuzz/Project.toml
+++ b/test/fuzz/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Supposition = "5a0628fe-1738-4658-9b6d-0b7605a9755b"

--- a/test/fuzz/catalogue.jl
+++ b/test/fuzz/catalogue.jl
@@ -117,6 +117,11 @@ function _build()
     # NOTE: round(Int64, x) needs a TYPE-literal first slot the generator can't
     # type-direct (an Int64-typed EXPR is not the type Int64) — covered by the
     # Int64(::Float64) ctor entry above instead.
+    # ── P4-stdlib: Dates scalar predicates (the Date-typed surface needs
+    # value generators — deferred; these compose freely with Int64 exprs).
+    add(:isleapyear, (Int64,), Bool; mod = :dates)
+    add(:daysinmonth, (Int64, Int64), Int64; mod = :dates, throws = true)  # month ∉ 1:12 throws
+
     # Bool logic
     add(:&, (Bool, Bool), Bool; mod = :bool); add(:|, (Bool, Bool), Bool; mod = :bool)
     add(:!, (Bool,), Bool; mod = :bool); add(:xor, (Bool, Bool), Bool; mod = :bool)

--- a/test/fuzz/run.jl
+++ b/test/fuzz/run.jl
@@ -18,6 +18,7 @@
 
 using Supposition, Random
 using Statistics   # P4-stdlib: catalogue :stats entries resolve in Main
+using Dates: isleapyear, daysinmonth   # P4-stdlib: :dates entries
 using Supposition: Data
 
 const FUZZ_DIR = @__DIR__

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,8 @@ using WasmTarget: add_array_type!, add_export!, add_function!, add_import!, add_
                   Opcode, to_bytes, WasmModule
 using Test
 import Statistics
+import Dates
+using Dates: Dates, @dateformat_str
 
 # Package-level QA runs first so structural failures surface
 # before the ~hour-long codegen suite spins up. (Shard 0 only — it's process-wide.)
@@ -10407,6 +10409,53 @@ console.log(JSON.stringify({
         @test compare_julia_wasm_vec(_stats_median, Float64[9.0, -2.0, 7.5, 0.0, 1.0, 3.25, -8.0]).pass
         @test compare_julia_wasm_vec(_stats_quantile, Float64[1.0, 2.0, 3.0, 4.0]).pass
         @test compare_julia_wasm_vec(_stats_middle, Float64[1.0, 9.0, 2.0]).pass
+    end
+
+    # ── P4-stdlib: Dates (stdlib #2) ───────────────────────────────────────
+    # Value layer compiles from the real Dates implementations; rendering
+    # (string(::Date)/(::DateTime)) via WasmTargetDatesExt overlays (the
+    # native path needs IOBuffer growth machinery). now()/today() need a
+    # host-time import wired by the embedding pipeline — not covered here.
+    _dates_year(x::Int64)::Int64 = Dates.year(Dates.Date(2020, 1, 1) + Dates.Day(x))
+    _dates_dow(x::Int64)::Int64 = Dates.dayofweek(Dates.Date(2024, 1, 1) + Dates.Day(x))
+    _dates_diff(x::Int64)::Int64 = Dates.value(Dates.Date(2024, 3, 1) - Dates.Date(2024, 2, x % 28 + 1))
+    _dates_dim(x::Int64)::Int64 = Dates.daysinmonth(Dates.Date(2024, x % 12 + 1, 1))
+    _dates_leap(x::Int64)::Bool = Dates.isleapyear(2000 + x)
+    _dates_conv(x::Int64)::Int64 = Dates.value(convert(Dates.Millisecond, Dates.Second(x)))
+    _dates_parse(x::Int64)::Int64 = Dates.day(Dates.Date("2024-03-15", dateformat"yyyy-mm-dd")) + x
+    # Rendering checks return an in-wasm content checksum (the scalar JS
+    # harness can't marshal String returns; the polynomial hash makes the
+    # comparison content-exact anyway — bridge probes verified the actual
+    # strings bit-exact during integration).
+    function _dates_strsum(x::Int64)::Int64
+        s = string(Dates.Date(2024, 1, 1) + Dates.Day(x))
+        h = Int64(0)
+        for b in codeunits(s)
+            h = h * 31 + Int64(b)
+        end
+        return h
+    end
+    function _dates_strdtsum(x::Int64)::Int64
+        s = string(Dates.DateTime(2023, 6, 15, 12, 0, 0) + Dates.Millisecond(x))
+        h = Int64(0)
+        for b in codeunits(s)
+            h = h * 31 + Int64(b)
+        end
+        return h
+    end
+
+    @pphase "Dates stdlib" begin
+        @test compare_julia_wasm(_dates_year, 5).pass
+        @test compare_julia_wasm(_dates_dow, 5).pass
+        @test compare_julia_wasm(_dates_diff, 5).pass
+        @test compare_julia_wasm(_dates_dim, 5).pass
+        @test compare_julia_wasm(_dates_leap, 5).pass
+        @test compare_julia_wasm(_dates_leap, 0).pass
+        @test compare_julia_wasm(_dates_conv, 5).pass
+        @test compare_julia_wasm(_dates_parse, 5).pass
+        @test compare_julia_wasm(_dates_strsum, 5).pass
+        @test compare_julia_wasm(_dates_strdtsum, 123).pass
+        @test compare_julia_wasm(_dates_strdtsum, 0).pass
     end
 
 end  # end of phase-registration block


### PR DESCRIPTION
## Summary

Second stdlib integration, riding the Statistics playbook and infrastructure:

- **Value layer — zero stdlib-specific code**: Date/DateTime construction, period arithmetic, accessors, date subtraction, `daysinmonth`/`isleapyear`, period conversions, and **Date parsing with a DateFormat** all compile from the real Dates implementations, bit-exact on Julia 1.12 + 1.13.
- **`ext/WasmTargetDatesExt.jl`**: overlays `string(::Date)`/`string(::DateTime)` through the proven string/concat machinery (native rendering needs IOBuffer `ensureroom` growth machinery — documented as a future campaign; same blocker applies to `Dates.format`).
- **Deferred by design**: `now()`/`today()` need a host-time import (embedding pipeline's `import_stubs`, e.g. `Date`/`now` → JS `Date.now`) and are nondeterministic — not fuzzer material.
- New "Dates stdlib" test phase (11 checks) + fuzzer catalogue `:dates` slice.

## Test plan
- Bridge probes: 9/9 value-layer + 6/6 rendering (incl. millisecond edge cases) bit-exact on both versions
- Full Pkg.test suites green on 1.12 + 1.13
