### PR TITLE
Random stdlib integration: seeded Xoshiro bit-exact on 1.12 + deep pointer-model fixes (stdlib #3)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,9 +39,10 @@ julia = "~1.12, ~1.13"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Supposition = "5a0628fe-1738-4658-9b6d-0b7605a9755b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Dates", "Random", "Statistics", "Supposition", "Test"]
+test = ["Aqua", "Dates", "Random", "SHA", "Statistics", "Supposition", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,10 +9,13 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [weakdeps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [extensions]
 WasmTargetDatesExt = "Dates"
+WasmTargetRandomExt = ["Random", "SHA"]
 WasmTargetStatisticsExt = "Statistics"
 
 [compat]
@@ -26,6 +29,7 @@ Dates = "1"
 JSON = "1"
 PrecompileTools = "1"
 Random = "1"
+SHA = "0.7, 1"
 Statistics = "1"
 Supposition = "0.3"
 Test = "1"

--- a/ext/WasmTargetRandomExt.jl
+++ b/ext/WasmTargetRandomExt.jl
@@ -33,9 +33,39 @@ using Base.Experimental: @overlay
         push!(bytes, (word >> 24) % UInt8)
         iszero(seed) && break
     end
-    neg && push!(bytes, 0x01)
+    if neg
+        push!(bytes, 0x01)
+    end
     SHA.update!(ctx, bytes)
     return SHA.digest!(ctx)
+end
+
+
+# Julia 1.13 changed the API: hash_seed(seed, ctx::SHA_CTX) streams into a
+# caller-provided context. Same type-stable byte-vector reroute; the native
+# tail returns `nothing`.
+@static if VERSION >= v"1.13-"
+    @overlay WasmTarget.WASM_METHOD_TABLE function Random.hash_seed(seed::Integer, ctx::SHA.SHA_CTX)
+        neg = signbit(seed)
+        if neg
+            seed = ~seed
+        end
+        bytes = UInt8[]
+        while true
+            word = (seed % UInt32) & 0xffffffff
+            seed >>>= 32
+            push!(bytes, word % UInt8)
+            push!(bytes, (word >> 8) % UInt8)
+            push!(bytes, (word >> 16) % UInt8)
+            push!(bytes, (word >> 24) % UInt8)
+            iszero(seed) && break
+        end
+        if neg
+            push!(bytes, 0x01)
+        end
+        SHA.update!(ctx, bytes)
+        return nothing
+    end
 end
 
 end # module

--- a/ext/WasmTargetRandomExt.jl
+++ b/ext/WasmTargetRandomExt.jl
@@ -1,0 +1,41 @@
+# WasmTargetRandomExt — Random stdlib integration.
+#
+# Seeded Xoshiro streams compile from the real implementations; the one
+# overlay below reroutes Random.hash_seed(::Integer) through SHA's
+# TYPE-STABLE Vector{UInt8} update path. The native implementation feeds the
+# hash 4-byte NTuple chunks through `Base.write`'s reflection machinery
+# (Any-typed foldl/==/type-intersection guards — runtime dispatch WasmGC
+# does not support). SHA-256 is streaming, so hashing one concatenated byte
+# vector is bit-identical to hashing the chunks: same digest, same seed
+# expansion, same stream as native (verified across positive/negative/wide
+# seeds). now()-style OS entropy (seed-less RNGs, TaskLocalRNG) defers to
+# embedding-side imports, like Dates.now().
+module WasmTargetRandomExt
+
+using WasmTarget
+using Random
+import SHA
+using Base.Experimental: @overlay
+
+@overlay WasmTarget.WASM_METHOD_TABLE function Random.hash_seed(seed::Integer)
+    ctx = SHA.SHA2_256_CTX()
+    neg = signbit(seed)
+    if neg
+        seed = ~seed
+    end
+    bytes = UInt8[]
+    while true
+        word = (seed % UInt32) & 0xffffffff
+        seed >>>= 32
+        push!(bytes, word % UInt8)
+        push!(bytes, (word >> 8) % UInt8)
+        push!(bytes, (word >> 16) % UInt8)
+        push!(bytes, (word >> 24) % UInt8)
+        iszero(seed) && break
+    end
+    neg && push!(bytes, 0x01)
+    SHA.update!(ctx, bytes)
+    return SHA.digest!(ctx)
+end
+
+end # module

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -4247,18 +4247,68 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
         local _pr_vec = ptr_arg !== nothing ? _trace_memmove_ptr(ptr_arg, ctx) : nothing
         if _pr_vec !== nothing
             local _pr_arr_t = get_array_type!(ctx.mod, ctx.type_registry, UInt8)
-            append!(bytes, compile_value(_pr_vec, ctx))
-            local _pr_vinfo = ctx.type_registry.structs[infer_value_type(_pr_vec, ctx)]
-            push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.STRUCT_GET)
-            append!(bytes, encode_leb128_unsigned(_pr_vinfo.wasm_type_idx))
-            append!(bytes, encode_leb128_unsigned(1))
-            push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.REF_CAST_NULL)
-            append!(bytes, encode_leb128_signed(Int64(_pr_arr_t)))
+            _emit_backing_array!(bytes, _pr_vec, ctx, _pr_arr_t)
             append!(bytes, compile_value(ptr_arg, ctx))
             push!(bytes, Opcode.I32_WRAP_I64)
             push!(bytes, Opcode.GC_PREFIX)
             push!(bytes, Opcode.ARRAY_GET_U)
             append!(bytes, encode_leb128_unsigned(_pr_arr_t))
+            return bytes
+        end
+        # P4-stdlib (Random digest!): CROSS-WIDTH byte reads — Ptr{UInt8}
+        # into Vector{UInt32/UInt64/...} storage (SHA reads its u32 state
+        # byte-wise). elem = arr[byteoff >> log2(s)]; byte = (elem >>
+        # (8*(byteoff & (s-1)))) & 0xFF (little-endian; mirror of the
+        # cross-width pointerset).
+        local _PRB_WIDE = (Int16, UInt16, Int32, UInt32, Int64, UInt64)
+        local _prb_tp = begin
+            local _t = ptr_arg !== nothing ? infer_value_type(ptr_arg, ctx) : nothing
+            _t isa DataType && _t <: Ptr ? eltype(_t) : nothing
+        end
+        local _prb_vec = (ptr_arg !== nothing && (_prb_tp === UInt8 || _prb_tp === Int8)) ?
+            _trace_memmove_ptr(ptr_arg, ctx; eltypes = _PRB_WIDE) : nothing
+        if _prb_vec !== nothing
+            local _prb_te = eltype(infer_value_type(_prb_vec, ctx))
+            local _prb_s = sizeof(_prb_te)
+            local _prb_arr = get_array_type!(ctx.mod, ctx.type_registry, _prb_te)
+            local _prb_w64 = _prb_s == 8
+            # scratch: byte offset (i32)
+            local _prb_lb = length(ctx.locals) + ctx.n_params
+            push!(ctx.locals, I32)
+            # byte offset = ptr + (i-1)   (pointer target is 1 byte wide)
+            append!(bytes, compile_value(ptr_arg, ctx))
+            if length(args) >= 2 && !(args[2] isa Integer && args[2] == 1)
+                append!(bytes, compile_value(args[2], ctx))
+                push!(bytes, Opcode.I64_CONST); append!(bytes, encode_leb128_signed(Int64(1)))
+                push!(bytes, Opcode.I64_SUB)
+                push!(bytes, Opcode.I64_ADD)
+            end
+            push!(bytes, Opcode.I32_WRAP_I64)
+            push!(bytes, Opcode.LOCAL_SET); append!(bytes, encode_leb128_unsigned(_prb_lb))
+            # arr ref
+            _emit_backing_array!(bytes, _prb_vec, ctx, _prb_arr)
+            # elem index = b >> log2(s)
+            push!(bytes, Opcode.LOCAL_GET); append!(bytes, encode_leb128_unsigned(_prb_lb))
+            push!(bytes, Opcode.I32_CONST); append!(bytes, encode_leb128_signed(Int64(trailing_zeros(_prb_s))))
+            push!(bytes, Opcode.I32_SHR_U)
+            push!(bytes, Opcode.GC_PREFIX)
+            push!(bytes, _prb_s <= 2 ? Opcode.ARRAY_GET_U : Opcode.ARRAY_GET)
+            append!(bytes, encode_leb128_unsigned(_prb_arr))
+            # shift = 8 * (b & (s-1))
+            push!(bytes, Opcode.LOCAL_GET); append!(bytes, encode_leb128_unsigned(_prb_lb))
+            push!(bytes, Opcode.I32_CONST); append!(bytes, encode_leb128_signed(Int64(_prb_s - 1)))
+            push!(bytes, Opcode.I32_AND)
+            push!(bytes, Opcode.I32_CONST); append!(bytes, encode_leb128_signed(Int64(3)))
+            push!(bytes, Opcode.I32_SHL)
+            if _prb_w64
+                push!(bytes, Opcode.I64_EXTEND_I32_U)
+                push!(bytes, Opcode.I64_SHR_U)
+                push!(bytes, Opcode.I32_WRAP_I64)
+            else
+                push!(bytes, Opcode.I32_SHR_U)
+            end
+            push!(bytes, Opcode.I32_CONST); append!(bytes, encode_leb128_signed(Int64(0xFF)))
+            push!(bytes, Opcode.I32_AND)
             return bytes
         end
         # P4-stdlib (Statistics median/quantile): TYPED loads through
@@ -4356,13 +4406,7 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
         local _ps_vt = length(args) >= 2 ? infer_value_type(args[2], ctx) : nothing
         if _ps_vec !== nothing && (_ps_vt === UInt8 || _ps_vt === Int8)
             local _ps_arr_t = get_array_type!(ctx.mod, ctx.type_registry, UInt8)
-            append!(bytes, compile_value(_ps_vec, ctx))
-            local _ps_vinfo = ctx.type_registry.structs[infer_value_type(_ps_vec, ctx)]
-            push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.STRUCT_GET)
-            append!(bytes, encode_leb128_unsigned(_ps_vinfo.wasm_type_idx))
-            append!(bytes, encode_leb128_unsigned(1))
-            push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.REF_CAST_NULL)
-            append!(bytes, encode_leb128_signed(Int64(_ps_arr_t)))
+            _emit_backing_array!(bytes, _ps_vec, ctx, _ps_arr_t)
             append!(bytes, compile_value(_ps_ptr, ctx))
             push!(bytes, Opcode.I32_WRAP_I64)
             append!(bytes, compile_value(args[2], ctx))
@@ -4475,13 +4519,7 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
                 local _psw_lv = length(ctx.locals) + ctx.n_params
                 push!(ctx.locals, I64)
                 # array ref
-                append!(bytes, compile_value(_psw_vec, ctx))
-                local _psw_vinfo = ctx.type_registry.structs[infer_value_type(_psw_vec, ctx)]
-                push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.STRUCT_GET)
-                append!(bytes, encode_leb128_unsigned(_psw_vinfo.wasm_type_idx))
-                append!(bytes, encode_leb128_unsigned(1))
-                push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.REF_CAST_NULL)
-                append!(bytes, encode_leb128_signed(Int64(_psw_arr)))
+                _emit_backing_array!(bytes, _psw_vec, ctx, _psw_arr)
                 push!(bytes, Opcode.LOCAL_SET); append!(bytes, encode_leb128_unsigned(_psw_la))
                 # base byte index = ptr + (i-1)*s
                 append!(bytes, compile_value(_ps_ptr, ctx))

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -4456,6 +4456,72 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
                 return bytes
             end
         end
+        # P4-stdlib (Random digest!): CROSS-WIDTH store — Ptr{UInt64/32/16}
+        # into Vector{UInt8} storage (SHA writes the bitlength into its byte
+        # buffer). Emit little-endian byte-wise array.set stores.
+        local _psw_vec = (_ps_ptr !== nothing && _psg_tp isa DataType &&
+                          isprimitivetype(_psg_tp) && sizeof(_psg_tp) in (2, 4, 8)) ?
+            _trace_memmove_ptr(_ps_ptr, ctx) : nothing
+        if _psw_vec !== nothing && length(args) >= 2
+            local _psw_te = eltype(infer_value_type(_psw_vec, ctx))
+            if _psw_te === UInt8 || _psw_te === Int8
+                local _psw_arr = get_array_type!(ctx.mod, ctx.type_registry, UInt8)
+                local _psw_s = sizeof(_psg_tp)
+                # scratch locals: array ref, base byte index, value (i64)
+                local _psw_la = length(ctx.locals) + ctx.n_params
+                push!(ctx.locals, ConcreteRef(_psw_arr, true))
+                local _psw_li = length(ctx.locals) + ctx.n_params
+                push!(ctx.locals, I32)
+                local _psw_lv = length(ctx.locals) + ctx.n_params
+                push!(ctx.locals, I64)
+                # array ref
+                append!(bytes, compile_value(_psw_vec, ctx))
+                local _psw_vinfo = ctx.type_registry.structs[infer_value_type(_psw_vec, ctx)]
+                push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.STRUCT_GET)
+                append!(bytes, encode_leb128_unsigned(_psw_vinfo.wasm_type_idx))
+                append!(bytes, encode_leb128_unsigned(1))
+                push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.REF_CAST_NULL)
+                append!(bytes, encode_leb128_signed(Int64(_psw_arr)))
+                push!(bytes, Opcode.LOCAL_SET); append!(bytes, encode_leb128_unsigned(_psw_la))
+                # base byte index = ptr + (i-1)*s
+                append!(bytes, compile_value(_ps_ptr, ctx))
+                if length(args) >= 3 && !(args[3] isa Integer && args[3] == 1)
+                    append!(bytes, compile_value(args[3], ctx))
+                    push!(bytes, Opcode.I64_CONST); append!(bytes, encode_leb128_signed(Int64(1)))
+                    push!(bytes, Opcode.I64_SUB)
+                    push!(bytes, Opcode.I64_CONST); append!(bytes, encode_leb128_signed(Int64(_psw_s)))
+                    push!(bytes, Opcode.I64_MUL)
+                    push!(bytes, Opcode.I64_ADD)
+                end
+                push!(bytes, Opcode.I32_WRAP_I64)
+                push!(bytes, Opcode.LOCAL_SET); append!(bytes, encode_leb128_unsigned(_psw_li))
+                # value as i64 (extend 32-bit values)
+                append!(bytes, compile_value(args[2], ctx))
+                local _psw_vw = julia_to_wasm_type(_psg_tp)
+                _psw_vw === I32 && push!(bytes, Opcode.I64_EXTEND_I32_U)
+                _psw_vw === F64 && push!(bytes, Opcode.I64_REINTERPRET_F64)
+                push!(bytes, Opcode.LOCAL_SET); append!(bytes, encode_leb128_unsigned(_psw_lv))
+                for _psw_k in 0:(_psw_s - 1)
+                    push!(bytes, Opcode.LOCAL_GET); append!(bytes, encode_leb128_unsigned(_psw_la))
+                    push!(bytes, Opcode.LOCAL_GET); append!(bytes, encode_leb128_unsigned(_psw_li))
+                    if _psw_k > 0
+                        push!(bytes, Opcode.I32_CONST); append!(bytes, encode_leb128_signed(Int64(_psw_k)))
+                        push!(bytes, Opcode.I32_ADD)
+                    end
+                    push!(bytes, Opcode.LOCAL_GET); append!(bytes, encode_leb128_unsigned(_psw_lv))
+                    if _psw_k > 0
+                        push!(bytes, Opcode.I64_CONST); append!(bytes, encode_leb128_signed(Int64(8 * _psw_k)))
+                        push!(bytes, Opcode.I64_SHR_U)
+                    end
+                    push!(bytes, Opcode.I32_WRAP_I64)
+                    push!(bytes, Opcode.GC_PREFIX)
+                    push!(bytes, Opcode.ARRAY_SET)
+                    append!(bytes, encode_leb128_unsigned(_psw_arr))
+                end
+                push!(bytes, Opcode.I64_CONST); push!(bytes, 0x00)   # fake ptr return
+                return bytes
+            end
+        end
         push!(bytes, Opcode.UNREACHABLE)
         ctx.last_stmt_was_stub = true  # PURE-908
         return bytes
@@ -6400,6 +6466,69 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
                     end
                 end
             else
+                # P4-stdlib (Random hash_seed): dynamic ==/!= on BOXED operands
+                # (Any-typed foldl results in anyref locals) is LIVE code — the
+                # unreachable below dead-coded the loop-exit condition. Unbox
+                # both sides as i64 boxes and compare; a non-i64 box traps
+                # LOUD on the cast (correct-or-loud) instead of silently.
+                local _dyneq_ok = false
+                if (func.name === :(==) || func.name === :!=) && length(args) == 2
+                    local _dq_all_ref = true
+                    for _dq_a in args
+                        local _dq_is = false
+                        if _dq_a isa Core.SSAValue
+                            local _dq_li = get(ctx.ssa_locals, _dq_a.id, nothing)
+                            _dq_li === nothing && (_dq_li = get(ctx.phi_locals, _dq_a.id, nothing))
+                            if _dq_li !== nothing
+                                local _dq_off = _dq_li - ctx.n_params
+                                if _dq_off >= 0 && _dq_off < length(ctx.locals)
+                                    _dq_is = ctx.locals[_dq_off + 1] === AnyRef
+                                end
+                            end
+                        end
+                        _dq_is || (_dq_all_ref = false)
+                    end
+                    if _dq_all_ref
+                        local _dq_box = get_numeric_box_type!(ctx.mod, ctx.type_registry, I64)
+                        bytes = UInt8[]
+                        for _dq_a in args
+                            append!(bytes, compile_value(_dq_a, ctx))
+                            push!(bytes, Opcode.GC_PREFIX)
+                            push!(bytes, Opcode.REF_CAST_NULL)
+                            append!(bytes, encode_leb128_signed(Int64(_dq_box)))
+                            push!(bytes, Opcode.GC_PREFIX)
+                            push!(bytes, Opcode.STRUCT_GET)
+                            append!(bytes, encode_leb128_unsigned(_dq_box))
+                            append!(bytes, encode_leb128_unsigned(UInt32(1)))
+                        end
+                        push!(bytes, Opcode.I64_EQ)
+                        func.name === :!= && push!(bytes, Opcode.I32_EQZ)
+                        # The result SSA is Any-typed (anyref local) — box the
+                        # i32 Bool; compile_condition_to_i32 unboxes at use.
+                        local _dq_dst = get(ctx.ssa_locals, idx, nothing)
+                        if _dq_dst !== nothing
+                            local _dq_doff = _dq_dst - ctx.n_params
+                            local _dq_lt = _dq_doff >= 0 && _dq_doff < length(ctx.locals) ?
+                                ctx.locals[_dq_doff + 1] : nothing
+                            if _dq_lt === AnyRef || _dq_lt isa ConcreteRef || _dq_lt === StructRef
+                                local _dq_b32 = get_numeric_box_type!(ctx.mod, ctx.type_registry, I32)
+                                local _dq_scr = length(ctx.locals) + ctx.n_params
+                                push!(ctx.locals, I32)
+                                push!(bytes, Opcode.LOCAL_SET)
+                                append!(bytes, encode_leb128_unsigned(_dq_scr))
+                                push!(bytes, Opcode.I32_CONST)
+                                push!(bytes, 0x00)   # typeId
+                                push!(bytes, Opcode.LOCAL_GET)
+                                append!(bytes, encode_leb128_unsigned(_dq_scr))
+                                push!(bytes, Opcode.GC_PREFIX)
+                                push!(bytes, Opcode.STRUCT_NEW)
+                                append!(bytes, encode_leb128_unsigned(_dq_b32))
+                            end
+                        end
+                        _dyneq_ok = true
+                    end
+                end
+                if !_dyneq_ok
                 # No matching signature - likely dead code from Union type branches
                 # Emit unreachable instead of error (the branch won't be taken at runtime)
                 # PURE-605: Suppress warning for known-safe dynamic dispatch paths where
@@ -6411,6 +6540,7 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
                 bytes = UInt8[]
                 push!(bytes, Opcode.UNREACHABLE)
                 ctx.last_stmt_was_stub = true  # PURE-908
+                end
             end
         else
             # GlobalRef constructor call: SSA return type reveals the struct being constructed

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -2802,9 +2802,32 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
                 append!(bytes, compile_value(obj_arg, ctx))
                 return bytes
             elseif field_sym === :ptr_or_offset
-                # Not needed in WasmGC - return 0 as placeholder
-                push!(bytes, Opcode.I64_CONST)
-                push!(bytes, 0x00)
+                # P4-stdlib (SHA update!): the fake-pointer VALUE is the byte
+                # offset. Base refs → 0; refs from memoryrefnew(ref, i, bc)
+                # carry (i-1)*elsize (ctx.memoryref_offsets records i), so
+                # pointer arithmetic over indexed refs stays faithful.
+                local _poo_idx = obj_arg isa Core.SSAValue ?
+                    get(ctx.memoryref_offsets, obj_arg.id, nothing) : nothing
+                local _poo_el = obj_type isa DataType && length(obj_type.parameters) >= 1 ?
+                    (obj_type.name.name === :GenericMemoryRef && length(obj_type.parameters) >= 2 ?
+                     obj_type.parameters[2] : obj_type.parameters[1]) : nothing
+                if _poo_idx !== nothing && _poo_el isa DataType && isbitstype(_poo_el)
+                    append!(bytes, compile_value(_poo_idx, ctx))
+                    local _poo_it = infer_value_type(_poo_idx, ctx)
+                    (_poo_it === Int64 || _poo_it === Int || _poo_it === UInt64) ||
+                        push!(bytes, Opcode.I64_EXTEND_I32_S)
+                    push!(bytes, Opcode.I64_CONST)
+                    append!(bytes, encode_leb128_signed(Int64(1)))
+                    push!(bytes, Opcode.I64_SUB)
+                    if sizeof(_poo_el) != 1
+                        push!(bytes, Opcode.I64_CONST)
+                        append!(bytes, encode_leb128_signed(Int64(sizeof(_poo_el))))
+                        push!(bytes, Opcode.I64_MUL)
+                    end
+                else
+                    push!(bytes, Opcode.I64_CONST)
+                    push!(bytes, 0x00)
+                end
                 return bytes
             end
         end
@@ -4244,15 +4267,83 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
         # P3 gap 450889a9cb7e: byte reads through Vector{UInt8} storage pointers
         # (Ryu digit readback). Fake base pointers compile to 0, so the pointer
         # VALUE is the 0-based byte offset.
+        local _pr_tp0 = begin
+            local _t = ptr_arg !== nothing ? infer_value_type(ptr_arg, ctx) : nothing
+            _t isa DataType && _t <: Ptr ? eltype(_t) : nothing
+        end
         local _pr_vec = ptr_arg !== nothing ? _trace_memmove_ptr(ptr_arg, ctx) : nothing
-        if _pr_vec !== nothing
+        if _pr_vec !== nothing && (_pr_tp0 === UInt8 || _pr_tp0 === Int8 || _pr_tp0 === Nothing || _pr_tp0 === nothing)
             local _pr_arr_t = get_array_type!(ctx.mod, ctx.type_registry, UInt8)
             _emit_backing_array!(bytes, _pr_vec, ctx, _pr_arr_t)
             append!(bytes, compile_value(ptr_arg, ctx))
+            if length(args) >= 2 && !(args[2] isa Integer && args[2] == 1)
+                append!(bytes, compile_value(args[2], ctx))
+                push!(bytes, Opcode.I64_CONST); append!(bytes, encode_leb128_signed(Int64(1)))
+                push!(bytes, Opcode.I64_SUB)
+                push!(bytes, Opcode.I64_ADD)
+            end
             push!(bytes, Opcode.I32_WRAP_I64)
             push!(bytes, Opcode.GC_PREFIX)
             push!(bytes, Opcode.ARRAY_GET_U)
             append!(bytes, encode_leb128_unsigned(_pr_arr_t))
+            return bytes
+        elseif _pr_vec !== nothing && _pr_tp0 isa DataType && isprimitivetype(_pr_tp0) &&
+               sizeof(_pr_tp0) in (2, 4, 8)
+            # P4-stdlib (SHA transform!): WIDE loads (Ptr{UInt32/UInt64})
+            # from Vector{UInt8} storage — the 1-byte fast path above served
+            # a single byte here, silently corrupting the message schedule.
+            # Assemble the word little-endian from s consecutive bytes.
+            local _prw_s = sizeof(_pr_tp0)
+            local _prw_arr = get_array_type!(ctx.mod, ctx.type_registry, UInt8)
+            local _prw_w64 = _prw_s == 8 || _pr_tp0 === Float64
+            # scratch: arr ref + base index
+            local _prw_la = length(ctx.locals) + ctx.n_params
+            push!(ctx.locals, ConcreteRef(_prw_arr, true))
+            local _prw_lb = length(ctx.locals) + ctx.n_params
+            push!(ctx.locals, I32)
+            _emit_backing_array!(bytes, _pr_vec, ctx, _prw_arr)
+            push!(bytes, Opcode.LOCAL_SET); append!(bytes, encode_leb128_unsigned(_prw_la))
+            append!(bytes, compile_value(ptr_arg, ctx))
+            if length(args) >= 2 && !(args[2] isa Integer && args[2] == 1)
+                append!(bytes, compile_value(args[2], ctx))
+                push!(bytes, Opcode.I64_CONST); append!(bytes, encode_leb128_signed(Int64(1)))
+                push!(bytes, Opcode.I64_SUB)
+                push!(bytes, Opcode.I64_CONST); append!(bytes, encode_leb128_signed(Int64(_prw_s)))
+                push!(bytes, Opcode.I64_MUL)
+                push!(bytes, Opcode.I64_ADD)
+            end
+            push!(bytes, Opcode.I32_WRAP_I64)
+            push!(bytes, Opcode.LOCAL_SET); append!(bytes, encode_leb128_unsigned(_prw_lb))
+            for _prw_k in 0:(_prw_s - 1)
+                push!(bytes, Opcode.LOCAL_GET); append!(bytes, encode_leb128_unsigned(_prw_la))
+                push!(bytes, Opcode.LOCAL_GET); append!(bytes, encode_leb128_unsigned(_prw_lb))
+                if _prw_k > 0
+                    push!(bytes, Opcode.I32_CONST); append!(bytes, encode_leb128_signed(Int64(_prw_k)))
+                    push!(bytes, Opcode.I32_ADD)
+                end
+                push!(bytes, Opcode.GC_PREFIX)
+                push!(bytes, Opcode.ARRAY_GET_U)
+                append!(bytes, encode_leb128_unsigned(_prw_arr))
+                if _prw_w64
+                    push!(bytes, Opcode.I64_EXTEND_I32_U)
+                    if _prw_k > 0
+                        push!(bytes, Opcode.I64_CONST); append!(bytes, encode_leb128_signed(Int64(8 * _prw_k)))
+                        push!(bytes, Opcode.I64_SHL)
+                    end
+                    _prw_k > 0 && push!(bytes, Opcode.I64_OR)
+                else
+                    if _prw_k > 0
+                        push!(bytes, Opcode.I32_CONST); append!(bytes, encode_leb128_signed(Int64(8 * _prw_k)))
+                        push!(bytes, Opcode.I32_SHL)
+                        push!(bytes, Opcode.I32_OR)
+                    end
+                end
+            end
+            if _pr_tp0 === Float64
+                push!(bytes, Opcode.F64_REINTERPRET_I64)
+            elseif _pr_tp0 === Float32
+                push!(bytes, Opcode.F32_REINTERPRET_I32)
+            end
             return bytes
         end
         # P4-stdlib (Random digest!): CROSS-WIDTH byte reads — Ptr{UInt8}

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -4559,7 +4559,12 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
                 end
             end
         end
-        if is_numeric_intrinsic && _arg_anyref
+        # Also fire for the GENERIC arithmetic operators (+,-,*,div,rem,mod):
+        # dynamic call sites with everything typed Any (e.g. `4 - %foldl` in
+        # Random.hash_seed) default to the i64 opcodes but consume raw anyref.
+        local _generic_arith = func isa GlobalRef &&
+            func.name in (:+, :-, :*, :div, :rem, :mod)
+        if (is_numeric_intrinsic || _generic_arith) && _arg_anyref
             local _aa_target = is_32bit ? I32 : I64
             local _aa_box = get_numeric_box_type!(ctx.mod, ctx.type_registry, _aa_target)
             push!(bytes, Opcode.GC_PREFIX)
@@ -5984,10 +5989,18 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
     # Julia's type inference may resolve length(::SimpleVector) to the builtin directly.
     # PURE-6021: args[1] (svec array) is already pre-pushed by the generic loop above.
     elseif ((func isa GlobalRef && func.name === :_svec_len && func.mod === Core) || (isdefined(Core, :_svec_len) && func === Core._svec_len)) && length(args) == 1
-        push!(bytes, Opcode.GC_PREFIX)
-        push!(bytes, Opcode.ARRAY_LEN)
-        # array.len returns i32 but Julia expects Int64
-        push!(bytes, Opcode.I64_EXTEND_I32_U)
+        # P4-stdlib: fold against host-constant svecs (padding/typename.names)
+        local _svl = _try_host_svec(args[1], ctx)
+        if _svl isa Core.SimpleVector
+            bytes = UInt8[]   # discard pre-pushed placeholder
+            push!(bytes, Opcode.I64_CONST)
+            append!(bytes, encode_leb128_signed(Int64(length(_svl))))
+        else
+            push!(bytes, Opcode.GC_PREFIX)
+            push!(bytes, Opcode.ARRAY_LEN)
+            # array.len returns i32 but Julia expects Int64
+            push!(bytes, Opcode.I64_EXTEND_I32_U)
+        end
 
     # PURE-4149: Core._svec_ref(sv, i) — get element from SimpleVector (externref array).
     # _svec_ref is 1-indexed in Julia, 0-indexed in Wasm → subtract 1.
@@ -6096,6 +6109,21 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
                 if _gfc_val isa Union{Integer, Bool, Char, Float32, Float64, String, Symbol} &&
                    !(_gfc_val isa Union{Int128, UInt128, BigInt})
                     append!(bytes, compile_value(_gfc_val, ctx))
+                    _gfc_done = true
+                end
+            end
+        end
+        # P4-stdlib: constant-receiver getfield yielding a SimpleVector
+        # (typename(T).names) — emit a benign null placeholder (a stub
+        # dead-codes the rest of the block); consumers fold against the
+        # host value via _try_host_svec.
+        if !_gfc_done && func.name === :getfield && length(args) == 2 && args[1] isa QuoteNode
+            local _gfc_fld2 = args[2] isa QuoteNode ? args[2].value : args[2]
+            if _gfc_fld2 isa Symbol
+                local _gfc_v2 = try getfield(args[1].value, _gfc_fld2) catch; nothing end
+                if _gfc_v2 isa Core.SimpleVector
+                    push!(bytes, Opcode.REF_NULL)
+                    push!(bytes, UInt8(ArrayRef))
                     _gfc_done = true
                 end
             end
@@ -6911,6 +6939,33 @@ is a DataType literal — the layout struct is immutable host metadata, fully
 known at compile time. Returns the host-loaded DataTypeLayout for literal
 materialization, or nothing if the chain doesn't match.
 """
+
+# P4-stdlib (Random hash_seed): resolve an IR value to a HOST SimpleVector
+# constant when its definition is compile-time evaluable — `padding(T, n)`
+# with literal args, or `getfield(typename(T), :names)`. The defs emit benign
+# null placeholders (no svec constant emission exists); consumers like
+# _svec_len/_svec_ref fold against the host value instead of reading it.
+function _try_host_svec(arg, ctx::AbstractCompilationContext)
+    arg isa Core.SSAValue || return nothing
+    (arg.id < 1 || arg.id > length(ctx.code_info.code)) && return nothing
+    st = ctx.code_info.code[arg.id]
+    if st isa Expr && (st.head === :invoke || st.head === :call)
+        a1 = st.head === :invoke ? (length(st.args) >= 2 ? st.args[2] : nothing) : st.args[1]
+        nm = a1 isa GlobalRef ? a1.name : a1 isa Function ? nameof(a1) : nothing
+        rest = st.head === :invoke ? st.args[3:end] : st.args[2:end]
+        if nm === :padding && length(rest) == 2 && rest[1] isa Type && rest[2] isa Integer
+            return try Base.padding(rest[1], Int(rest[2])) catch; nothing end
+        elseif nm === :getfield && length(rest) >= 2 && rest[1] isa QuoteNode
+            fld = rest[2] isa QuoteNode ? rest[2].value : rest[2]
+            if fld isa Symbol
+                v = try getfield(rest[1].value, fld) catch; nothing end
+                v isa Core.SimpleVector && return v
+            end
+        end
+    end
+    return nothing
+end
+
 function _try_fold_layout_pointerref(ptr_arg, ctx::AbstractCompilationContext)
     cur = ptr_arg
     for _ in 1:4

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -4542,6 +4542,34 @@ function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Ve
                 push!(bytes, Opcode.I64_EXTEND_I32_S)
             end
         end
+        # P4-stdlib (Random hash_seed): unbox ANYREF-housed numeric args —
+        # Any-returning callees (e.g. _foldl_impl) box numerics, and
+        # Union{Nothing, UInt64}-style SSAs live in AnyRef locals; consuming
+        # them raw in i64 arithmetic failed validation. Mirror of the
+        # externref unbox below, minus any_convert_extern. Gated on the
+        # ACTUAL local type (type-derived guesses say I64 for these unions).
+        local _arg_anyref = false
+        if !_is_externref_value(arg, ctx) && arg isa Core.SSAValue
+            local _aa_li = get(ctx.ssa_locals, arg.id, nothing)
+            _aa_li === nothing && (_aa_li = get(ctx.phi_locals, arg.id, nothing))
+            if _aa_li !== nothing
+                local _aa_off = _aa_li - ctx.n_params
+                if _aa_off >= 0 && _aa_off < length(ctx.locals)
+                    _arg_anyref = ctx.locals[_aa_off + 1] === AnyRef
+                end
+            end
+        end
+        if is_numeric_intrinsic && _arg_anyref
+            local _aa_target = is_32bit ? I32 : I64
+            local _aa_box = get_numeric_box_type!(ctx.mod, ctx.type_registry, _aa_target)
+            push!(bytes, Opcode.GC_PREFIX)
+            push!(bytes, Opcode.REF_CAST_NULL)
+            append!(bytes, encode_leb128_signed(Int64(_aa_box)))
+            push!(bytes, Opcode.GC_PREFIX)
+            push!(bytes, Opcode.STRUCT_GET)
+            append!(bytes, encode_leb128_unsigned(_aa_box))
+            append!(bytes, encode_leb128_unsigned(UInt32(1)))  # field 1 = value
+        end
         # PURE-904: Unbox externref args for numeric intrinsics.
         # When a param/SSA has Wasm type externref but Julia IR uses it as
         # numeric (UInt32, Int64, etc.), unbox: any_convert_extern → ref.cast → struct.get

--- a/src/codegen/flow.jl
+++ b/src/codegen/flow.jl
@@ -1456,6 +1456,28 @@ function generate_loop_code(ctx::AbstractCompilationContext)::Vector{UInt8}
 
         stmt = code[i]
 
+        # P4-stdlib (Random / FINDINGS P4 dead-coding class): mirror
+        # compile_statement's PURE-6027 boundary reset here — the walker
+        # compiles GotoIfNot CONDITIONS via compile_condition_to_i32 without
+        # passing through compile_statement, so a stub/throw flag from a
+        # previous block leaked into conditions at reachable jump targets
+        # (`i64.const 0; unreachable; i32.eqz` poisoned-condition trap).
+        if ctx.last_stmt_was_stub && i > 1
+            local _bw_prev = code[i - 1]
+            if _bw_prev isa Core.GotoNode || _bw_prev isa Core.GotoIfNot || _bw_prev isa Core.ReturnNode
+                ctx.last_stmt_was_stub = false
+            else
+                for _bw_s in code
+                    local _bw_d = _bw_s isa Core.GotoNode ? _bw_s.label :
+                                  _bw_s isa Core.GotoIfNot ? _bw_s.dest : 0
+                    if _bw_d == i
+                        ctx.last_stmt_was_stub = false
+                        break
+                    end
+                end
+            end
+        end
+
         # PURE-6024: Skip statements in dead code (after unreachable in current block)
         if dead_code_depth >= 0
             i += 1

--- a/src/codegen/interpreter.jl
+++ b/src/codegen/interpreter.jl
@@ -716,6 +716,21 @@ end
 end
 end
 
+# P4-stdlib (Random hash_seed): byte-wise reinterpret of primitive words —
+# the generic Base._reinterpret_padding walks DataType padding metadata
+# (host pointers; not compilable). Pure shift arithmetic is semantically
+# identical for padding-free primitives.
+@overlay WASM_METHOD_TABLE Base._reinterpret_padding(::Type{NTuple{4, UInt8}}, x::UInt32) =
+    (x % UInt8, (x >> 8) % UInt8, (x >> 16) % UInt8, (x >> 24) % UInt8)
+@overlay WASM_METHOD_TABLE Base._reinterpret_padding(::Type{NTuple{8, UInt8}}, x::UInt64) =
+    (x % UInt8, (x >> 8) % UInt8, (x >> 16) % UInt8, (x >> 24) % UInt8,
+     (x >> 32) % UInt8, (x >> 40) % UInt8, (x >> 48) % UInt8, (x >> 56) % UInt8)
+@overlay WASM_METHOD_TABLE Base._reinterpret_padding(::Type{UInt32}, x::NTuple{4, UInt8}) =
+    UInt32(x[1]) | (UInt32(x[2]) << 8) | (UInt32(x[3]) << 16) | (UInt32(x[4]) << 24)
+@overlay WASM_METHOD_TABLE Base._reinterpret_padding(::Type{UInt64}, x::NTuple{8, UInt8}) =
+    UInt64(x[1]) | (UInt64(x[2]) << 8) | (UInt64(x[3]) << 16) | (UInt64(x[4]) << 24) |
+    (UInt64(x[5]) << 32) | (UInt64(x[6]) << 40) | (UInt64(x[7]) << 48) | (UInt64(x[8]) << 56)
+
 @overlay WASM_METHOD_TABLE function Base.push!(v::Vector{T}, x) where T
     n = length(v)
     new_v = similar(v, n + 1)

--- a/src/codegen/invoke.jl
+++ b/src/codegen/invoke.jl
@@ -4670,6 +4670,18 @@ function compile_invoke(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::
                 push!(bytes, Opcode.THROW)
                 append!(bytes, encode_leb128_unsigned(0))
                 ctx.last_stmt_was_stub = true  # PURE-908
+            elseif name === :padding && length(args) == 2 &&
+                   args[1] isa Type && args[2] isa Integer
+                # P4-stdlib (Random hash_seed): padding(T, n) of literal args is
+                # a compile-time constant SimpleVector. No svec constant
+                # emission exists — emit a benign null placeholder (NOT a stub:
+                # a stub dead-codes the rest of the block) and let consumers
+                # (_svec_len etc.) fold against the host value via
+                # _try_host_svec.
+                bytes = UInt8[]
+                push!(bytes, Opcode.REF_NULL)
+                push!(bytes, UInt8(ArrayRef))
+
             elseif name === :array_subpadding && length(args) == 2 &&
                    args[1] isa Type && args[2] isa Type
                 # P4-stdlib (Statistics median): Base.array_subpadding is a pure

--- a/src/codegen/invoke.jl
+++ b/src/codegen/invoke.jl
@@ -2418,6 +2418,20 @@ function compile_invoke(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::
                     expected_wasm = get_concrete_wasm_type(expected_julia_type, ctx.mod, ctx.type_registry)
                     actual_julia_type = infer_value_type(arg, ctx)
                     actual_wasm = get_concrete_wasm_type(actual_julia_type, ctx.mod, ctx.type_registry)
+                    # P4-stdlib (Random hash_seed): the type-derived guess says
+                    # I64 for Union{Nothing, UInt64}, but such SSAs live in
+                    # AnyRef locals (boxed) — use the ACTUAL local type so the
+                    # bridging below sees the real representation.
+                    if arg isa Core.SSAValue
+                        local _ivl = get(ctx.ssa_locals, arg.id, nothing)
+                        _ivl === nothing && (_ivl = get(ctx.phi_locals, arg.id, nothing))
+                        if _ivl !== nothing
+                            local _ivo = _ivl - ctx.n_params
+                            if _ivo >= 0 && _ivo < length(ctx.locals)
+                                actual_wasm = ctx.locals[_ivo + 1]
+                            end
+                        end
+                    end
 
                     # PURE-3111/4155: Handle Nothing→ref conversion.
                     # compile_value emits i32_const 0 for Nothing,
@@ -2488,12 +2502,29 @@ function compile_invoke(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::
                     elseif expected_wasm === F64 && actual_wasm === F32
                         # f32 to f64 — insert f64.promote_f32
                         push!(bytes, Opcode.F64_PROMOTE_F32)
-                    elseif expected_wasm === I32 && (actual_wasm isa ConcreteRef || actual_wasm === StructRef || actual_wasm === ArrayRef || actual_wasm === ExternRef || actual_wasm === AnyRef)
+                    elseif (expected_wasm === I32 || expected_wasm === I64 || expected_wasm === F32 || expected_wasm === F64) &&
+                           (actual_wasm === AnyRef || actual_wasm === ExternRef)
+                        # P4-stdlib (Random hash_seed): boxed numeric in anyref/
+                        # externref consumed as a number — UNBOX via the numeric
+                        # box (was: drop + zero, silently wrong on live paths;
+                        # a null ref traps loud on the cast instead).
+                        if actual_wasm === ExternRef
+                            append!(bytes, UInt8[Opcode.GC_PREFIX, Opcode.ANY_CONVERT_EXTERN])
+                        end
+                        local _ub_box = get_numeric_box_type!(ctx.mod, ctx.type_registry, expected_wasm)
+                        push!(bytes, Opcode.GC_PREFIX)
+                        push!(bytes, Opcode.REF_CAST_NULL)
+                        append!(bytes, encode_leb128_signed(Int64(_ub_box)))
+                        push!(bytes, Opcode.GC_PREFIX)
+                        push!(bytes, Opcode.STRUCT_GET)
+                        append!(bytes, encode_leb128_unsigned(_ub_box))
+                        append!(bytes, encode_leb128_unsigned(UInt32(1)))  # field 1 = value
+                    elseif expected_wasm === I32 && (actual_wasm isa ConcreteRef || actual_wasm === StructRef || actual_wasm === ArrayRef)
                         # ref to i32 — drop and push 0 (type mismatch, likely dead code)
                         push!(bytes, Opcode.DROP)
                         push!(bytes, Opcode.I32_CONST)
                         push!(bytes, 0x00)
-                    elseif expected_wasm === I64 && (actual_wasm isa ConcreteRef || actual_wasm === StructRef || actual_wasm === ArrayRef || actual_wasm === ExternRef || actual_wasm === AnyRef)
+                    elseif expected_wasm === I64 && (actual_wasm isa ConcreteRef || actual_wasm === StructRef || actual_wasm === ArrayRef)
                         # ref to i64 — drop and push 0 (type mismatch, likely dead code)
                         push!(bytes, Opcode.DROP)
                         push!(bytes, Opcode.I64_CONST)

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -960,6 +960,22 @@ function compile_statement(stmt, idx::Int, ctx::AbstractCompilationContext)::Vec
                     end
                 end
 
+                # P4-stdlib (Random seed!): stmt ends with array.get_u/get_s on a
+                # packed array — those ALWAYS produce i32 — while the SSA local
+                # is i64 (seed bytes combined into UInt64 words). Append the
+                # signedness-matching extend. Forward-parsed like the struct_get
+                # check below (backward scans misfire on LEB collisions).
+                if !needs_type_safe_default && local_wasm_type === I64 && length(stmt_bytes) >= 3
+                    local _ag_li = _last_instr_start(stmt_bytes)
+                    if _ag_li > 0 && _ag_li + 1 <= length(stmt_bytes) &&
+                       stmt_bytes[_ag_li] == Opcode.GC_PREFIX &&
+                       (stmt_bytes[_ag_li + 1] == Opcode.ARRAY_GET_U ||
+                        stmt_bytes[_ag_li + 1] == Opcode.ARRAY_GET_S)
+                        push!(stmt_bytes, stmt_bytes[_ag_li + 1] == Opcode.ARRAY_GET_U ?
+                              Opcode.I64_EXTEND_I32_U : Opcode.I64_EXTEND_I32_S)
+                    end
+                end
+
                 # Check if stmt_bytes ends with struct_get whose result type is incompatible
                 # with the target local. struct_get = [0xFB, 0x02, type_leb, field_leb]
                 # P3 gap a6c6091b2a80: FORWARD-parse to the last instruction — the

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -297,6 +297,22 @@ function compile_statement(stmt, idx::Int, ctx::AbstractCompilationContext)::Vec
                 pi_local_type = local_array_idx >= 1 && local_array_idx <= length(ctx.locals) ? ctx.locals[local_array_idx] : nothing
                 # Determine the value's wasm type
                 val_wasm_type = get_phi_edge_wasm_type(stmt.val, ctx)
+                # P4-stdlib (Random hash_seed): prefer the ACTUAL local type of
+                # the source when one exists — the type-derived guess says I64
+                # for Union{Nothing, UInt64}, but such unions live in AnyRef
+                # locals (boxed; an i64 cannot encode `nothing`), so the
+                # AnyRef→numeric unbox below never fired and raw anyref reached
+                # i64 arithmetic.
+                if stmt.val isa Core.SSAValue
+                    local _pv_li = get(ctx.ssa_locals, stmt.val.id, nothing)
+                    _pv_li === nothing && (_pv_li = get(ctx.phi_locals, stmt.val.id, nothing))
+                    if _pv_li !== nothing
+                        local _pv_off = _pv_li - ctx.n_params
+                        if _pv_off >= 0 && _pv_off < length(ctx.locals)
+                            val_wasm_type = ctx.locals[_pv_off + 1]
+                        end
+                    end
+                end
                 # Check if source is a multi-value expression (e.g., multi-arg memoryrefnew)
                 # that would push >1 value on the stack — local_set only consumes 1.
                 is_multi_value_src = false

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -3798,7 +3798,11 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
         push!(bytes, Opcode.I64_CONST)
         push!(bytes, 0x00)
     end
-    ctx.last_stmt_was_stub = true  # PURE-908
+    # P4-stdlib (Random digest!, the CONDSTUB class root): this path EMITS A
+    # VALUE — execution continues past it — so it must NOT set
+    # last_stmt_was_stub: the flag dead-codes the rest of the block,
+    # poisoning live conditions into `unreachable` (the value-vs-dead
+    # contradiction behind the FINDINGS P4 family).
     return bytes
 end
 

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -40,6 +40,24 @@ getfield(vec,:ref)→:ptr_or_offset) back to its backing Vector. Returns
 nothing unless the base is a Vector with 1-byte elements (memmove counts
 bytes; element index == byte offset only for elsize 1).
 """
+# Emit the backing wasm ARRAY ref for a walk result: Vector{T} structs read
+# field 1 (.ref); Memory{T} values ARE the array. Always cast to `arr_t`.
+function _emit_backing_array!(bytes::Vector{UInt8}, vec, ctx::AbstractCompilationContext, arr_t)
+    vt = infer_value_type(vec, ctx)
+    append!(bytes, compile_value(vec, ctx))
+    is_mem = vt isa DataType && (vt.name.name === :Memory || vt.name.name === :GenericMemory ||
+                                 vt.name.name === :MemoryRef || vt.name.name === :GenericMemoryRef)
+    if !is_mem
+        vinfo = ctx.type_registry.structs[vt]
+        push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.STRUCT_GET)
+        append!(bytes, encode_leb128_unsigned(vinfo.wasm_type_idx))
+        append!(bytes, encode_leb128_unsigned(1))
+    end
+    push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.REF_CAST_NULL)
+    append!(bytes, encode_leb128_signed(Int64(arr_t)))
+    return bytes
+end
+
 function _trace_memmove_ptr(arg, ctx::AbstractCompilationContext;
                             eltypes = (UInt8, Int8), allow_ref::Bool = false)
     # Walk permissively (through bitcast/add_ptr/sub_ptr/PiNode and any phi
@@ -83,6 +101,15 @@ function _trace_memmove_ptr(arg, ctx::AbstractCompilationContext;
                 cur = st.args[3]
             elseif cfn === :add_ptr || cfn === :sub_ptr
                 cur = st.args[2]
+            elseif cfn === :memorynew
+                # P4-stdlib: pointer into a freshly-allocated Memory{T} —
+                # Memory compiles DIRECTLY as a wasm array; valid terminal
+                # (callers use _emit_backing_array! which skips the Vector
+                # struct deref for Memory values).
+                local _mn_t = infer_value_type(cur, ctx)
+                local _mn_el = _mn_t isa DataType && length(_mn_t.parameters) >= 2 ? _mn_t.parameters[2] : nothing
+                _mn_el in eltypes || return _fail("memorynew-elty: $_mn_t", st)
+                return cur
             elseif cfn === :memoryrefnew && (length(st.args) == 2 || st.args[3] == 1)
                 # P4-stdlib: base memoryref (index 1) — pure identity hop.
                 # Variable-index refs are NOT walked: their byte offset would
@@ -102,6 +129,13 @@ function _trace_memmove_ptr(arg, ctx::AbstractCompilationContext;
                      eltype(vt) in eltypes) || return _fail("elty-not-allowed: $vt", vec)
                     return vec
                 else
+                    # P4-stdlib (SHA update!): getfield(obj, fld) whose RESULT
+                    # type is an allowed Vector (ctx.buffer::Vector{UInt8}) is
+                    # itself the backing-store identity.
+                    local _gf_vt = infer_value_type(cur, ctx)
+                    if _gf_vt isa DataType && _gf_vt <: Vector && eltype(_gf_vt) in eltypes
+                        return cur
+                    end
                     return _fail("getfield-fld=$fld", st)
                 end
             else
@@ -3384,23 +3418,15 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
         # width 4/8 → array.copy with byte offsets/count scaled to elements.
         # (Byte vectors keep the established paths below; array.copy is
         # overlap-safe per the WasmGC spec, matching memmove semantics.)
-        local _MMV_PRIMS = (Int16, UInt16, Int32, UInt32, Int64, UInt64, Float32, Float64)
+        local _MMV_PRIMS = (Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Float32, Float64)
         local _mmv_d = _trace_memmove_ptr(dest_ptr_arg, ctx; eltypes = _MMV_PRIMS)
         local _mmv_s = _mmv_d !== nothing ? _trace_memmove_ptr(src_ptr_arg, ctx; eltypes = _MMV_PRIMS) : nothing
         if _mmv_d !== nothing && _mmv_s !== nothing
             local _mmv_te = eltype(infer_value_type(_mmv_d, ctx))
-            if _mmv_te === eltype(infer_value_type(_mmv_s, ctx)) && sizeof(_mmv_te) in (4, 8)
+            if _mmv_te === eltype(infer_value_type(_mmv_s, ctx)) && sizeof(_mmv_te) in (1, 4, 8)
                 local _mmv_arr = get_array_type!(ctx.mod, ctx.type_registry, _mmv_te)
                 local _mmv_sh = trailing_zeros(sizeof(_mmv_te))
-                local _mmv_emit_arr = vec -> begin
-                    append!(bytes, compile_value(vec, ctx))
-                    local _vi = ctx.type_registry.structs[infer_value_type(vec, ctx)]
-                    push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.STRUCT_GET)
-                    append!(bytes, encode_leb128_unsigned(_vi.wasm_type_idx))
-                    append!(bytes, encode_leb128_unsigned(1))
-                    push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.REF_CAST_NULL)
-                    append!(bytes, encode_leb128_signed(Int64(_mmv_arr)))
-                end
+                local _mmv_emit_arr = vec -> _emit_backing_array!(bytes, vec, ctx, _mmv_arr)
                 local _mmv_emit_off = a -> begin
                     append!(bytes, compile_value(a, ctx))
                     push!(bytes, Opcode.I32_WRAP_I64)
@@ -3606,13 +3632,7 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
         if _mm_d !== nothing && _mm_s !== nothing
             _arr_t = get_array_type!(ctx.mod, ctx.type_registry, UInt8)
             _mm_emit_arr! = function (vec)
-                append!(bytes, compile_value(vec, ctx))
-                _vinfo = ctx.type_registry.structs[infer_value_type(vec, ctx)]
-                push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.STRUCT_GET)
-                append!(bytes, encode_leb128_unsigned(_vinfo.wasm_type_idx))
-                append!(bytes, encode_leb128_unsigned(1))  # field 1 = data array
-                push!(bytes, Opcode.GC_PREFIX); push!(bytes, Opcode.REF_CAST_NULL)
-                append!(bytes, encode_leb128_signed(Int64(_arr_t)))
+                _emit_backing_array!(bytes, vec, ctx, _arr_t)
             end
             _mm_emit_ptr_off! = function (ptr_arg)
                 # fake base pointer compiles to 0 → pointer value == byte offset
@@ -3802,7 +3822,12 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
     # VALUE — execution continues past it — so it must NOT set
     # last_stmt_was_stub: the flag dead-codes the rest of the block,
     # poisoning live conditions into `unreachable` (the value-vs-dead
-    # contradiction behind the FINDINGS P4 family).
+    # contradiction behind the FINDINGS P4 family). It must still be LOUD:
+    # record the unsupported foreigncall so strict mode surfaces it instead
+    # of silently no-opping effectful calls (a missed memmove made SHA
+    # digest its own zeros — input-independent output).
+    record_unsupported!(ctx, :unsupported_method,
+        "foreigncall `$(name)` (no handler; emitted type-default value)"; idx=idx, detail=expr)
     return bytes
 end
 

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -3730,6 +3730,29 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
     # as dead code and abort the rest of the block, poisoning later
     # conditions into `unreachable`.
     local _fc_sym = expr.args[1] isa QuoteNode ? expr.args[1].value : expr.args[1]
+    if _fc_sym === :jl_type_intersection && length(expr.args) >= 7
+        # P4-stdlib (Random hash_seed): dispatch guards compare
+        # typeintersect(T1, T2) === Union{} with CONSTANT type args — fold on
+        # the host and emit the resulting type constant (NOT a stub: the
+        # stub flag dead-coded the live loop-exit condition that follows).
+        local _ti_a = expr.args[6]
+        local _ti_b = expr.args[7]
+        _ti_a isa QuoteNode && (_ti_a = _ti_a.value)
+        _ti_b isa QuoteNode && (_ti_b = _ti_b.value)
+        if _ti_a isa GlobalRef
+            _ti_a = try getfield(_ti_a.mod, _ti_a.name) catch; _ti_a end
+        end
+        if _ti_b isa GlobalRef
+            _ti_b = try getfield(_ti_b.mod, _ti_b.name) catch; _ti_b end
+        end
+        if _ti_a isa Type && _ti_b isa Type
+            local _ti_r = try typeintersect(_ti_a, _ti_b) catch; nothing end
+            if _ti_r !== nothing
+                append!(bytes, compile_value(_ti_r, ctx))
+                return bytes
+            end
+        end
+    end
     if _fc_sym === :jl_value_ptr
         # pointer_from_objref-style base pointer — in the fake-pointer model
         # every base is byte offset 0. A benign value, NOT a stub: typed

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -78,8 +78,7 @@ function _trace_memmove_ptr(arg, ctx::AbstractCompilationContext;
         if st isa Core.PiNode
             cur = st.val
         elseif st isa Expr && st.head === :foreigncall && length(st.args) >= 6 &&
-               (st.args[1] === QuoteNode(:jl_value_ptr) ||
-                (st.args[1] isa QuoteNode && st.args[1].value === :jl_value_ptr))
+               extract_foreigncall_name(st.args[1]) === :jl_value_ptr
             # P4-stdlib: pointer_from_objref-style base pointers
             # (jl_value_ptr(obj)) — in the fake-pointer model the base is 0,
             # so just hop to the object and keep walking toward the vector.
@@ -110,10 +109,11 @@ function _trace_memmove_ptr(arg, ctx::AbstractCompilationContext;
                 local _mn_el = _mn_t isa DataType && length(_mn_t.parameters) >= 2 ? _mn_t.parameters[2] : nothing
                 _mn_el in eltypes || return _fail("memorynew-elty: $_mn_t", st)
                 return cur
-            elseif cfn === :memoryrefnew && (length(st.args) == 2 || st.args[3] == 1)
-                # P4-stdlib: base memoryref (index 1) — pure identity hop.
-                # Variable-index refs are NOT walked: their byte offset would
-                # be lost (the fake base compiles to 0), so they stay stubbed.
+            elseif cfn === :memoryrefnew
+                # P4-stdlib: identity hop through memoryrefnew — base refs are
+                # offset 0, and INDEXED refs now encode (i-1)*elsize in the
+                # pointer VALUE (getfield(:ptr_or_offset) reads
+                # ctx.memoryref_offsets), so the walk only needs the identity.
                 cur = st.args[2]
             elseif cfn === :getfield && length(st.args) >= 3
                 fld = st.args[3] isa QuoteNode ? st.args[3].value : st.args[3]
@@ -3407,7 +3407,7 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
     # In WasmGC, we emit array.copy between the underlying array<i32> representations.
     # Trace: memmove args come from getfield(memoryref, :ptr_or_offset) which is i64.const 0.
     # The real arrays are found by tracing back through memoryrefnew to the backing Memory.
-    if name === :memmove && length(expr.args) >= 8
+    if (name === :memmove || name === :memcpy) && length(expr.args) >= 8
         dest_ptr_arg = expr.args[6]   # Ptr{Nothing} — traces to dest MemoryRef
         src_ptr_arg = expr.args[7]    # Ptr{Nothing} — traces to src MemoryRef
         nbytes_arg = expr.args[8]     # UInt64 — byte count
@@ -3626,7 +3626,7 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
     # Ryu's writeshortest shifts digit bytes in-buffer (decimal point
     # insertion). Trace both pointers through add_ptr/sub_ptr chains to the
     # backing vector and emit array.copy (overlap-safe per the wasm spec).
-    if name === :memmove && length(expr.args) >= 8
+    if (name === :memmove || name === :memcpy) && length(expr.args) >= 8
         _mm_d = _trace_memmove_ptr(expr.args[6], ctx)
         _mm_s = _trace_memmove_ptr(expr.args[7], ctx)
         if _mm_d !== nothing && _mm_s !== nothing
@@ -3708,7 +3708,7 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
     # dest_off_ptr, src_mem, src_off_ptr, n_elements) — Memory{T} compiles
     # directly as a wasm array, so this is a plain array.copy; the ptr args
     # are byte offsets (fake-base model) scaled to element indices.
-    local _gmc_sym = expr.args[1] isa QuoteNode ? expr.args[1].value : expr.args[1]
+    local _gmc_sym = extract_foreigncall_name(expr.args[1])
     if _gmc_sym === :jl_genericmemory_copyto && length(expr.args) >= 10
         local _gmc_mt = infer_value_type(expr.args[6], ctx)
         local _gmc_te = _gmc_mt isa DataType && length(_gmc_mt.parameters) >= 2 ? _gmc_mt.parameters[2] : nothing
@@ -3749,7 +3749,7 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
     # must NOT set the stub flag — range compilers treat a stubbed statement
     # as dead code and abort the rest of the block, poisoning later
     # conditions into `unreachable`.
-    local _fc_sym = expr.args[1] isa QuoteNode ? expr.args[1].value : expr.args[1]
+    local _fc_sym = extract_foreigncall_name(expr.args[1])
     if _fc_sym === :jl_type_intersection && length(expr.args) >= 7
         # P4-stdlib (Random hash_seed): dispatch guards compare
         # typeintersect(T1, T2) === Union{} with CONSTANT type args — fold on

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -174,6 +174,12 @@ the raw compile_value would push anyref, but i32.eqz needs i32. This helper unbo
 ref.cast + struct.get when needed.
 """
 function compile_condition_to_i32(cond, ctx::AbstractCompilationContext)::Vector{UInt8}
+    if haskey(ENV, "WT_TRACE_CONDSTUB") && ctx.last_stmt_was_stub
+        println(stderr, "CONDSTUB cond=", first(repr(cond), 30))
+        for fr in stacktrace()[2:9]
+            println(stderr, "   ", fr)
+        end
+    end
     bytes = compile_value(cond, ctx)
     # Check if the condition value is in a non-i32 local
     if cond isa Core.SSAValue

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -315,16 +315,31 @@ function compile_value(val, ctx::AbstractCompilationContext)::Vector{UInt8}
                     # e.g., π(x::Union{Int32,Float64}, Int32) → ref.cast $BoxedInt32 + struct.get 1
                     local _pi_target_wasm = julia_to_wasm_type(pi_type)
                     if (_pi_target_wasm === I32 || _pi_target_wasm === I64 || _pi_target_wasm === F32 || _pi_target_wasm === F64)
-                        # Check if the underlying value is anyref (boxed)
+                        # Check if the underlying value is anyref (boxed).
+                        # P4-stdlib (Random hash_seed): read the ACTUAL local type
+                        # when one exists — get_concrete_wasm_type guesses I64 for
+                        # Union{Nothing, UInt64}, but such unions are allocated as
+                        # AnyRef locals (an i64 cannot encode `nothing`), so the
+                        # guess skipped the unbox and raw anyref reached i64.sub.
                         local _pi_src_wasm = nothing
-                        if stmt.val isa Core.Argument
+                        if stmt.val isa Core.SSAValue
+                            local _pi_li = get(ctx.ssa_locals, stmt.val.id, nothing)
+                            _pi_li === nothing && (_pi_li = get(ctx.phi_locals, stmt.val.id, nothing))
+                            if _pi_li !== nothing
+                                local _pi_off = _pi_li - ctx.n_params
+                                if _pi_off >= 0 && _pi_off < length(ctx.locals)
+                                    _pi_src_wasm = ctx.locals[_pi_off + 1]
+                                end
+                            end
+                            if _pi_src_wasm === nothing
+                                local _pi_src_type = get(ctx.ssa_types, stmt.val.id, Any)
+                                _pi_src_wasm = get_concrete_wasm_type(_pi_src_type, ctx.mod, ctx.type_registry)
+                            end
+                        elseif stmt.val isa Core.Argument
                             local _pi_arg_idx = ctx.is_compiled_closure ? stmt.val.n : stmt.val.n - 1
                             if _pi_arg_idx >= 1 && _pi_arg_idx <= length(ctx.arg_types)
                                 _pi_src_wasm = get_concrete_wasm_type(ctx.arg_types[_pi_arg_idx], ctx.mod, ctx.type_registry)
                             end
-                        elseif stmt.val isa Core.SSAValue
-                            local _pi_src_type = get(ctx.ssa_types, stmt.val.id, Any)
-                            _pi_src_wasm = get_concrete_wasm_type(_pi_src_type, ctx.mod, ctx.type_registry)
                         end
                         if _pi_src_wasm === AnyRef || _pi_src_wasm === StructRef || _pi_src_wasm isa ConcreteRef
                             # Value is boxed in anyref — unbox via ref.cast + struct.get

--- a/test/fuzz/Project.toml
+++ b/test/fuzz/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,6 +103,8 @@ using WasmTarget: add_array_type!, add_export!, add_function!, add_import!, add_
 using Test
 import Statistics
 import Dates
+import Random
+import SHA
 using Dates: Dates, @dateformat_str
 
 # Package-level QA runs first so structural failures surface
@@ -10456,6 +10458,41 @@ console.log(JSON.stringify({
         @test compare_julia_wasm(_dates_strsum, 5).pass
         @test compare_julia_wasm(_dates_strdtsum, 123).pass
         @test compare_julia_wasm(_dates_strdtsum, 0).pass
+    end
+
+    # ── P4-stdlib: Random (stdlib #3) ──────────────────────────────────────
+    # Seeded Xoshiro streams compile from the real implementations and match
+    # native bit-exactly; WasmTargetRandomExt reroutes hash_seed through
+    # SHA's type-stable byte-vector path (identical digests). Unseeded RNGs
+    # (TaskLocalRNG, OS entropy) defer to embedding-side imports.
+    _rand_i64(x::Int64)::Int64 = rand(Random.Xoshiro(x), Int64)
+    _rand_f64(x::Int64)::Float64 = rand(Random.Xoshiro(x))
+    _rand_range(x::Int64)::Int64 = rand(Random.Xoshiro(x), 1:100)
+    _rand_randn(x::Int64)::Float64 = randn(Random.Xoshiro(x))
+    function _rand_stream(x::Int64)::Int64
+        rng = Random.Xoshiro(x)
+        a = rand(rng, Int64)
+        b = rand(rng, Int64)
+        return a ⊻ b
+    end
+    _rand_bool(x::Int64)::Bool = rand(Random.Xoshiro(x), Bool)
+
+    @pphase "Random stdlib" begin
+        # 1.13's Random IR shapes hit the ledgered memoryrefnew pair-to-local
+        # family (a517b4c8372d) across the board — the whole phase is gated
+        # until pair-locals land. 1.12: all seeded streams bit-exact.
+        @static if VERSION < v"1.13-"
+            @test compare_julia_wasm(_rand_i64, 42).pass
+            @test compare_julia_wasm(_rand_i64, -3).pass
+            @test compare_julia_wasm(_rand_f64, 42).pass
+            @test compare_julia_wasm(_rand_range, 7).pass
+            @test compare_julia_wasm(_rand_randn, 42).pass
+            @test compare_julia_wasm(_rand_stream, 7).pass
+            @test compare_julia_wasm(_rand_bool, 42).pass
+            @test compare_julia_wasm(_rand_bool, -3).pass
+        else
+            @test_skip false
+        end
     end
 
 end  # end of phase-registration block


### PR DESCRIPTION
## Summary

Third stdlib integration. **Seeded Xoshiro streams — `rand(Xoshiro(seed), Int64/Float64/range/Bool)`, `randn`, multi-draw streams — compile from the real Random+SHA implementations and match native bit-exactly on Julia 1.12** (verified across positive/negative/wide seeds; Random 1.12 seeds via SHA-256, so this transitively brought up the SHA stdlib's core too: `sha256` digests bit-exact).

The dig flushed out the deepest core fixes of the campaign:
- **Wide-from-narrow pointer reads** (`Ptr{UInt32}` over byte storage) — were silently served one byte, corrupting SHA's message schedule; now assemble words little-endian
- **Offset-faithful indexed memoryrefs** — `getfield(:ptr_or_offset)` of `memoryrefnew(ref, i, bc)` emitted 0, silently losing offsets; now emits `(i-1)*elsize`
- **The CONDSTUB dead-coding class root fix** — the value-emitting foreigncall fallback no longer dead-codes live conditions (and records a diagnostic so strict mode stays loud)
- Generic `==`/arith on boxed-Any operands, host-folds for `jl_type_intersection`/`padding`/`typename(...).names`, cross-width pointer stores, foreigncall-name canonicalization for 1.13 tuple forms
- **`ext/WasmTargetRandomExt.jl`** (weakdeps Random+SHA): reroutes `hash_seed` through SHA's type-stable byte-vector path — bit-identical digests, verified natively across seed ranges (1.12 one-arg + 1.13 two-arg forms)

**Known gap:** the whole Random surface on **1.13** hits the ledgered `memoryrefnew` pair-to-local family (`a517b4c8372d`) — the test phase is version-gated, and pair-locals is now the top architectural backlog item (it also blocks Int64 median/quantile).

## Test plan
- "Random stdlib" phase: 8 checks bit-exact on 1.12 (gated on 1.13 per above)
- Full Pkg.test suites green on 1.12 + 1.13
