### PR TITLE
docs: consolidate ledger notes (pair-locals attempt log, Printf scouting)

### DIFF
--- a/test/fuzz/FINDINGS.md
+++ b/test/fuzz/FINDINGS.md
@@ -157,3 +157,20 @@ dead-value emissions; WT_TRACE_STUBARGS / WT_TRAP_STACK exist. A
 depth-5+ fuzz sweep over boundscheck-arm + jump-target compositions is
 the likely organic reproducer source; until then this note is the
 tracking entry.
+
+## P4-stdlib: Printf probe results (stdlib #4 scouting)
+
+1.12 out-of-box via bridge probes: **float formats PASS** (`%.3f`, `%e`
+— riding the Ryu machinery) — the hard part of Printf already works.
+Integer/string formats (`%d`, `%08x`, `%s`, padded `%6d`) trap in
+`format` (wasm-function ~0xbc7): the byte shape is a phi-edge store
+sequence where the edge VALUE compiled to bare `unreachable` ×2 then
+`local.set` — a merge after a flattened throw arm (Union{}-rettype
+catchable throws at invoke.jl ~2975/4641 set the dead flag; the arm's
+phi-edge stores then compile dead values on what is at runtime a LIVE
+path). A dead-context guard in emit_phi_local_set! did NOT change the
+emitted bytes (reverted) — the emitting walker is elsewhere; next dig
+should attribute via a stacktrace instrument inside emit_phi_local_set!
+(mirror the WT_TRACE_CONDSTUB recipe that cracked the type-intersection
+fold). Printf integration is otherwise the established playbook once
+this one shape is fixed.

--- a/test/fuzz/failures/a517b4c8372d.md
+++ b/test/fuzz/failures/a517b4c8372d.md
@@ -79,3 +79,19 @@ ctx maps the SSA to a pair. Alternatively normalize at IR level:
 rewrite φ-over-memoryrefnew into φ-over-(mem, idx) pairs before
 codegen. Either way it touches context allocation + phi emission +
 the 3 consumer sites.
+
+### Failed-attempt log (pair-locals prep)
+
+Two incremental pokes REGRESSED the 1.12 gate and were reverted (do
+NOT retry as-is): (1) chained-memoryrefnew index folding in the
+emitter (i32.add of pair idx + new idx, gated on
+memoryref_offsets+no-local) — broke a covered shard-9 path; (2) an
+invoke-bridge arith unbox for Any-specTypes operands — never fired for
+the 1.13 `4 - %foldl` shape (offset 0xe34 unchanged). Conclusions: the
+1.13 Random tail involves at least (a) chained indexed refs feeding
+ref-consumers and (b) an unidentified arith emission path for
+Any-typed invokes; both want the FULL pair-locals design implemented
+coherently (allocation + emission + all consumers) rather than spot
+adapters. Session-order matters when probing: native pre-calls change
+inference; the compile cache can serve stale modules across
+bridge_run_args calls in one session (disable_cache! when comparing).


### PR DESCRIPTION
Folds the two stranded docs-only branch commits into main: the pair-locals failed-attempt log on a517b4c8372d and the Printf scouting findings. No code changes.
