### PR TITLE
Trim-collection discovery: upstream typeinf_ext_toplevel pipeline behind discovery=:trim

### DIFF
--- a/src/WasmTarget.jl
+++ b/src/WasmTarget.jl
@@ -134,9 +134,11 @@ Functions can call each other within the module.
 """
 function compile_multi(functions::Vector; optimize=false, stub_names::Set{String}=Set{String}(),
                        return_registries::Bool=false, optimize_ir::Bool=true,
-                       register_ir_types::Bool=false, strict::Bool=true, validate::Bool=true)
+                       register_ir_types::Bool=false, strict::Bool=true, validate::Bool=true,
+                       discovery::Symbol=:legacy)
     result = compile_module(functions; stub_names=stub_names, return_registries=return_registries,
-                           optimize_ir=optimize_ir, register_ir_types=register_ir_types, strict=strict)
+                           optimize_ir=optimize_ir, register_ir_types=register_ir_types, strict=strict,
+                           discovery=discovery)
     if return_registries
         mod, type_registry, func_registry, dispatch_registry = result
         bytes = to_bytes(mod)

--- a/src/WasmTarget.jl
+++ b/src/WasmTarget.jl
@@ -11,6 +11,7 @@ include("builder/validator.jl")
 # Codegen - Julia IR to Wasm bytecode
 include("codegen/diagnostics.jl")  # strict-mode diagnostics; must precede context.jl (struct field)
 include("codegen/interpreter.jl")
+include("codegen/trimcollect.jl")
 include("codegen/ir.jl")
 include("codegen/int_key_map.jl")
 include("codegen/types.jl")

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -1411,14 +1411,26 @@ function compile_module(functions::Vector;
                         overlay_entries::Set=Set{Tuple{Any,Tuple}}(),
                         optimize_ir::Bool=true,
                         register_ir_types::Bool=false,
-                        strict::Bool=true
+                        strict::Bool=true,
+                        discovery::Symbol=:legacy
                         )
+    # P5-trim: discovery=:trim replaces the homegrown dependency walk +
+    # AUTODISCOVER whitelist with the upstream closed-world collection
+    # (collect_closed_world). The whole pipeline then compiles from the
+    # collection's paired CodeInfos via the TRIM_IR_CACHE served inside
+    # get_typed_ir. Cache cleanup is in the wrapper below.
+    discovery === :trim && return _compile_module_trim(functions;
+        stub_names, existing_module, import_stubs, return_registries,
+        overlay_entries, optimize_ir, register_ir_types, strict)
     # Create WasmInterpreter with overlay method table (GPUCompiler pattern).
     # Must be created here (after user functions exist) so world age is current.
     interp = get_wasm_interpreter()
 
     # WASM-057: Auto-discover function dependencies
-    functions = discover_dependencies(functions; interp=interp)
+    # P5-trim: skipped when the trim plan already expanded the closed world
+    if !_TRIM_ACTIVE[]
+        functions = discover_dependencies(functions; interp=interp)
+    end
 
     # Filter out any discovered functions that are import stubs
     # (import stubs are registered in func_registry at their import indices, not compiled)
@@ -4382,3 +4394,30 @@ function deserialize_ir_entries(json_str::String)
     return result
 end
 
+
+
+# P5-trim: trim-discovery wrapper — build the plan, activate the IR cache,
+# and run the standard pipeline with discovery handled (the legacy
+# discover_dependencies call inside is skipped via the pre-expanded list +
+# _TRIM_ACTIVE flag).
+const _TRIM_ACTIVE = Ref(false)
+function _compile_module_trim(functions::Vector; kwargs...)
+    normalized = Any[]
+    for entry in functions
+        if length(entry) == 2
+            f, arg_types = entry
+            push!(normalized, (f, arg_types, string(nameof(f))))
+        else
+            push!(normalized, entry)
+        end
+    end
+    plan, ir_cache = trim_compile_plan(normalized)
+    TRIM_IR_CACHE[] = ir_cache
+    _TRIM_ACTIVE[] = true
+    try
+        return compile_module(plan; discovery=:legacy, kwargs...)
+    finally
+        TRIM_IR_CACHE[] = nothing
+        _TRIM_ACTIVE[] = false
+    end
+end

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -4413,11 +4413,13 @@ function _compile_module_trim(functions::Vector; kwargs...)
     end
     plan, ir_cache = trim_compile_plan(normalized)
     TRIM_IR_CACHE[] = ir_cache
+    TRIM_ENTRY_NAMES[] = Set{String}(String(e[3]) for e in normalized)
     _TRIM_ACTIVE[] = true
     try
         return compile_module(plan; discovery=:legacy, kwargs...)
     finally
         TRIM_IR_CACHE[] = nothing
+        TRIM_ENTRY_NAMES[] = nothing
         _TRIM_ACTIVE[] = false
     end
 end

--- a/src/codegen/diagnostics.jl
+++ b/src/codegen/diagnostics.jl
@@ -167,7 +167,19 @@ function record_unsupported!(ctx, kind::Symbol, construct::AbstractString;
     diag = WasmDiagnostic(kind, _ctx_func_name(ctx), String(construct),
                           idx > 0 ? julia_loc(ctx, idx) : nothing, detail)
     push!(ctx.diagnostics, diag)
-    if ctx.strict && soundness_fatal
+    # P5-trim: the closed-world collection is MORE complete than legacy
+    # discovery — it includes error-formatting dead paths (show/print
+    # machinery) the whitelist never compiled. On DISCOVERED (non-entry)
+    # functions, downgrade value-stubs to loud runtime stubs for parity with
+    # legacy behavior; entry functions keep full strictness.
+    local _fatal = ctx.strict && soundness_fatal
+    if _fatal && kind === :value_stub
+        local _entries = TRIM_ENTRY_NAMES[]
+        if _entries !== nothing && !(_ctx_func_name(ctx) in _entries)
+            _fatal = false
+        end
+    end
+    if _fatal
         throw(WasmCompileError(diag))
     else
         @debug "WasmTarget stub: $diag"

--- a/src/codegen/generate.jl
+++ b/src/codegen/generate.jl
@@ -3087,8 +3087,12 @@ function generate_try_catch(ctx::AbstractCompilationContext, blocks::Vector{Basi
     try_exit_range = (leave_idx+1):(catch_dest-1)
     catch_range = catch_dest:(has_merge_phis ? merge_start - 1 : length(code))
 
-    # Determine result type for the function
-    result_type_byte = get_concrete_wasm_type(ctx.return_type, ctx.mod, ctx.type_registry)
+    # Determine result type for the function. Nothing/Union{} returns have NO
+    # wasm result (the signature drops them), so the wrapper block must be void
+    # or the block's value is left orphaned at function end.
+    func_returns_void = ctx.return_type === Nothing || ctx.return_type === Union{}
+    result_type_byte = func_returns_void ? nothing :
+        get_concrete_wasm_type(ctx.return_type, ctx.mod, ctx.type_registry)
 
     # PURE-9031: Structure with merge phi support:
     # block $merge (void)                    ; merge block — both paths converge here
@@ -3238,7 +3242,11 @@ function generate_try_catch(ctx::AbstractCompilationContext, blocks::Vector{Basi
         # No merge phis — use original 2-block structure
         # Outer block for the result value
         push!(bytes, Opcode.BLOCK)
-        append!(bytes, encode_block_type(result_type_byte))
+        if func_returns_void
+            push!(bytes, 0x40)
+        else
+            append!(bytes, encode_block_type(result_type_byte))
+        end
 
         # Inner void block for catch destination
         push!(bytes, Opcode.BLOCK)
@@ -3545,10 +3553,14 @@ function generate_sequential_try_catch(ctx::AbstractCompilationContext, blocks::
             last_processed = region_end
         else
             # No merge phis — use 2-block structure (direct return in both paths)
-            result_type_byte = get_concrete_wasm_type(ctx.return_type, ctx.mod, ctx.type_registry)
-
+            # Void-return functions get a void wrapper (signature has no results).
             push!(bytes, Opcode.BLOCK)
-            append!(bytes, encode_block_type(result_type_byte))
+            if ctx.return_type === Nothing || ctx.return_type === Union{}
+                push!(bytes, 0x40)
+            else
+                append!(bytes, encode_block_type(
+                    get_concrete_wasm_type(ctx.return_type, ctx.mod, ctx.type_registry)))
+            end
 
             push!(bytes, Opcode.BLOCK)
             push!(bytes, 0x40)

--- a/src/codegen/interpreter.jl
+++ b/src/codegen/interpreter.jl
@@ -1898,6 +1898,12 @@ struct WasmInterpreter <: CC.AbstractInterpreter
     # the uncompressed optimized CodeInfo of every collected CodeInstance
     # here — the (CodeInstance, CodeInfo) pairs the plugin handoff consumes.
     codegen::IdDict{Core.CodeInstance, Core.CodeInfo}
+    # P5-trim: cache-partition token. The legacy pipeline shares :wasm_target
+    # for cross-compile CodeInstance reuse; collect_closed_world uses a FRESH
+    # per-collection token — a shared partition can hold CodeInstances
+    # inferred by earlier interps whose codegen CodeInfos were never stashed,
+    # tripping compile!'s `use_const_api || haskey(interp.codegen)` invariant.
+    cache_token::Any
 end
 
 function WasmInterpreter(; world::UInt=Base.get_world_counter())
@@ -1910,7 +1916,13 @@ function WasmInterpreter(; world::UInt=Base.get_world_counter())
         inline_nonleaf_penalty=100,
     )
     WasmInterpreter(world, mt, CC.InferenceResult[], inf_params, opt_params,
-                    IdDict{Core.CodeInstance, Core.CodeInfo}())
+                    IdDict{Core.CodeInstance, Core.CodeInfo}(), :wasm_target)
+end
+
+function WasmInterpreter(cache_token; world::UInt=Base.get_world_counter())
+    base = WasmInterpreter(; world)
+    WasmInterpreter(base.world, base.method_table, base.inf_cache,
+                    base.inf_params, base.opt_params, base.codegen, cache_token)
 end
 
 # Required AbstractInterpreter API
@@ -1918,7 +1930,7 @@ CC.InferenceParams(interp::WasmInterpreter) = interp.inf_params
 CC.OptimizationParams(interp::WasmInterpreter) = interp.opt_params
 CC.get_inference_world(interp::WasmInterpreter) = interp.world
 CC.get_inference_cache(interp::WasmInterpreter) = interp.inf_cache
-CC.cache_owner(::WasmInterpreter) = :wasm_target
+CC.cache_owner(interp::WasmInterpreter) = interp.cache_token
 CC.method_table(interp::WasmInterpreter) = interp.method_table
 CC.codegen_cache(interp::WasmInterpreter) = interp.codegen
 

--- a/src/codegen/interpreter.jl
+++ b/src/codegen/interpreter.jl
@@ -1893,6 +1893,11 @@ struct WasmInterpreter <: CC.AbstractInterpreter
     inf_cache::Vector{CC.InferenceResult}
     inf_params::CC.InferenceParams
     opt_params::CC.OptimizationParams
+    # P5-trim: codegen cache for the upstream CompilationQueue/compile!
+    # closed-world collection (the juliac --trim machinery). compile! stashes
+    # the uncompressed optimized CodeInfo of every collected CodeInstance
+    # here — the (CodeInstance, CodeInfo) pairs the plugin handoff consumes.
+    codegen::IdDict{Core.CodeInstance, Core.CodeInfo}
 end
 
 function WasmInterpreter(; world::UInt=Base.get_world_counter())
@@ -1904,7 +1909,8 @@ function WasmInterpreter(; world::UInt=Base.get_world_counter())
         inline_cost_threshold=500,
         inline_nonleaf_penalty=100,
     )
-    WasmInterpreter(world, mt, CC.InferenceResult[], inf_params, opt_params)
+    WasmInterpreter(world, mt, CC.InferenceResult[], inf_params, opt_params,
+                    IdDict{Core.CodeInstance, Core.CodeInfo}())
 end
 
 # Required AbstractInterpreter API
@@ -1914,6 +1920,7 @@ CC.get_inference_world(interp::WasmInterpreter) = interp.world
 CC.get_inference_cache(interp::WasmInterpreter) = interp.inf_cache
 CC.cache_owner(::WasmInterpreter) = :wasm_target
 CC.method_table(interp::WasmInterpreter) = interp.method_table
+CC.codegen_cache(interp::WasmInterpreter) = interp.codegen
 
 # Disable concrete eval (GPUCompiler pattern).
 # Without this, the compiler constant-folds calls using Base implementation,

--- a/src/codegen/ir.jl
+++ b/src/codegen/ir.jl
@@ -9,7 +9,17 @@ export get_typed_ir
 Get Julia's typed IR (SSA form) for a function with given argument types.
 Returns the CodeInfo object from code_typed.
 """
+# P5-trim: when a trim collection is active (compile_module discovery=:trim),
+# every (f, arg_types) the pipeline asks about is served the collection's
+# PAIRED CodeInfo — one consistent world, overlays applied, no re-inference.
+const TRIM_IR_CACHE = Ref{Union{Nothing, IdDict{Any, Tuple{Core.CodeInfo, Any}}}}(nothing)
+
 function get_typed_ir(f, arg_types::Tuple; optimize::Bool=true, interp=nothing)
+    cache = TRIM_IR_CACHE[]
+    if cache !== nothing
+        hit = get(cache, (f, arg_types), nothing)
+        hit !== nothing && return hit[1], hit[2]
+    end
     # Get the typed IR using Julia's introspection
     # When interp is provided (WasmInterpreter), overlay methods are used
     kwargs = interp !== nothing ? (; optimize=optimize, interp=interp) : (; optimize=optimize)

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -3801,7 +3801,33 @@ function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationConte
     # --traps-never-happen to eliminate surrounding live code.
     # Returning a type-appropriate default keeps the optimizer safe.
     fc_return_type = length(expr.args) >= 2 ? expr.args[2] : Nothing
-    if fc_return_type === Int32 || fc_return_type === UInt32
+    # P5-trim: emit the default in the width of the ACTUAL SSA LOCAL when one
+    # exists — the declared foreigncall return type can disagree with the
+    # local the pipeline allocated (i64 default into an i32 local failed
+    # validation in freshly-collected show machinery).
+    local _fcd_lt = nothing
+    local _fcd_li = get(ctx.ssa_locals, idx, nothing)
+    if _fcd_li !== nothing
+        local _fcd_off = _fcd_li - ctx.n_params
+        if _fcd_off >= 0 && _fcd_off < length(ctx.locals)
+            _fcd_lt = ctx.locals[_fcd_off + 1]
+        end
+    end
+    if _fcd_lt === I32
+        push!(bytes, Opcode.I32_CONST); push!(bytes, 0x00)
+    elseif _fcd_lt === I64
+        push!(bytes, Opcode.I64_CONST); push!(bytes, 0x00)
+    elseif _fcd_lt === F64
+        append!(bytes, [Opcode.F64_CONST, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    elseif _fcd_lt === F32
+        append!(bytes, [Opcode.F32_CONST, 0x00, 0x00, 0x00, 0x00])
+    elseif _fcd_lt isa ConcreteRef
+        push!(bytes, Opcode.REF_NULL)
+        append!(bytes, encode_leb128_signed(Int64(_fcd_lt.type_idx)))
+    elseif _fcd_lt === AnyRef || _fcd_lt === ExternRef || _fcd_lt === StructRef || _fcd_lt === ArrayRef || _fcd_lt === EqRef
+        push!(bytes, Opcode.REF_NULL)
+        push!(bytes, UInt8(_fcd_lt))
+    elseif fc_return_type === Int32 || fc_return_type === UInt32
         push!(bytes, Opcode.I32_CONST)
         push!(bytes, 0x00)
     elseif fc_return_type === Int64 || fc_return_type === UInt64 || fc_return_type === Int

--- a/src/codegen/trimcollect.jl
+++ b/src/codegen/trimcollect.jl
@@ -58,3 +58,70 @@ function entry_method_instance(f, arg_types::Tuple)
     m = which(f, arg_types)
     return CC.specialize_method(m, tt, Core.svec())
 end
+
+
+"""
+    trim_compile_plan(entries_named) -> (functions, ir_cache)
+
+Run `collect_closed_world` over the named entry points and derive the
+compile_module inputs: the full (func, arg_types, name) list (entries keep
+their given names; discovered functions get deduped names) and the
+(f, arg_types) → (CodeInfo, rettype) cache that get_typed_ir serves —
+every function compiles from the collection's consistent-world IR.
+
+Skipped (with a debug note): non-singleton callables (stateful closures —
+their call sites inline or carry the closure value; no module-level
+function entry to register) and Core/internal entries without a usable
+function object.
+"""
+function trim_compile_plan(entries_named::Vector)
+    entry_mis = Any[]
+    entry_keys = Dict{Any, String}()   # mi → requested name
+    for (f, arg_types, name) in entries_named
+        mi = entry_method_instance(f, arg_types)
+        push!(entry_mis, mi)
+        entry_keys[mi] = name
+    end
+    codeinfos = collect_closed_world(entry_mis)
+
+    functions = Any[]
+    ir_cache = IdDict{Any, Tuple{Core.CodeInfo, Any}}()
+    used_names = Set{String}()
+    i = 1
+    while i + 1 <= length(codeinfos)
+        ci, src = codeinfos[i], codeinfos[i + 1]
+        i += 2
+        (ci isa Core.CodeInstance && src isa Core.CodeInfo) || continue
+        mi = ci.def isa Core.MethodInstance ? ci.def : ci.def.def
+        sig = mi.specTypes
+        (sig isa DataType && sig <: Tuple && length(sig.parameters) >= 1) || continue
+        ftyp = sig.parameters[1]
+        f = nothing
+        if ftyp isa DataType && isdefined(ftyp, :instance)
+            f = ftyp.instance            # singleton functions incl. Core.kwcall
+        elseif ftyp isa DataType && ftyp <: Type && length(ftyp.parameters) >= 1
+            f = ftyp.parameters[1]       # constructors: Type{T} → T
+            (f isa DataType || f isa UnionAll) || (f = nothing)
+        end
+        if f === nothing
+            @debug "trim_compile_plan: skipping non-singleton callable" sig
+            continue
+        end
+        arg_types = Tuple(sig.parameters[2:end])
+        # name: requested for entries, deduped method name otherwise
+        name = get(entry_keys, mi, nothing)
+        if name === nothing
+            base = mi.def isa Method ? string(mi.def.name) : string(nameof(f))
+            name = base
+            n = 1
+            while name in used_names
+                name = string(base, "_", n)
+                n += 1
+            end
+        end
+        push!(used_names, name)
+        push!(functions, (f, arg_types, name))
+        ir_cache[(f, arg_types)] = (src, ci.rettype)
+    end
+    return functions, ir_cache
+end

--- a/src/codegen/trimcollect.jl
+++ b/src/codegen/trimcollect.jl
@@ -1,0 +1,60 @@
+# ============================================================================
+# P5-trim: closed-world collection via the upstream juliac --trim machinery
+# ============================================================================
+#
+# JuliaLang/julia#62087 (Keno's WasmGC strategy) proposes that static-compiler
+# plugins receive "the list of MethodInstances to compile" from the juliac
+# pipeline. The underlying machinery is `Compiler.typeinf_ext_toplevel` /
+# `CompilationQueue` / `compile!`: a worklist-driven collection that infers
+# the ENTIRE closed transitive callgraph at a consistent world and returns
+# alternating (CodeInstance, CodeInfo) pairs, optionally trim-VERIFIED (no
+# dynamic dispatch / runtime ccalls remain — with source-located diagnostics).
+#
+# `collect_closed_world` is that collection run under the WASM overlay
+# interpreter, so @overlay methods replace their natives during inference
+# (verified: the sinh overlay inlines and only its `exp` callee is
+# collected). This is the intended replacement for the homegrown
+# discover_dependencies walk + AUTODISCOVER whitelist, and the integration
+# point for a future juliac `--compiler=WasmTarget` plugin interface.
+#
+# Availability: the three-arg Compiler API exists on 1.12 and 1.13. The
+# TRIM_SAFE verifier is materially stronger on 1.13 (1.12 inference leaves
+# dead empty-reduce branches dynamic); collection itself (TRIM_UNSAFE
+# semantics — what this function does) works on both.
+
+"""
+    collect_closed_world(entries::Vector{Any}; verify::Bool=false)
+        -> Vector{Any}   # alternating CodeInstance, CodeInfo pairs
+
+Collect the closed transitive callgraph for the given entry
+`MethodInstance`s under the WASM overlay interpreter. With `verify=true`,
+run the upstream trim verifier (throws `Core.TrimFailure` with
+source-located diagnostics when dynamic dispatch remains — the same
+"abstract inference unsupported" boundary WasmTarget's strict mode guards,
+but reported far better).
+"""
+function collect_closed_world(entries::Vector{Any}; verify::Bool=false)
+    interp = WasmInterpreter()
+    invokelatest_queue = CC.CompilationQueue(; interp)
+    codeinfos = Any[]
+    workqueue = CC.CompilationQueue(; interp)
+    append!(workqueue, entries)
+    CC.compile!(codeinfos, workqueue; invokelatest_queue)
+    CC.compile!(codeinfos, invokelatest_queue; invokelatest_queue)
+    if verify
+        CC.verify_typeinf_trim(codeinfos, #= onlywarn =# false)
+    end
+    return codeinfos
+end
+
+"""
+    entry_method_instance(f, arg_types::Tuple) -> MethodInstance
+
+Resolve the `MethodInstance` for `f(::arg_types...)` — the entry handle
+`collect_closed_world` consumes.
+"""
+function entry_method_instance(f, arg_types::Tuple)
+    tt = Tuple{Core.Typeof(f), arg_types...}
+    m = which(f, arg_types)
+    return CC.specialize_method(m, tt, Core.svec())
+end

--- a/src/codegen/trimcollect.jl
+++ b/src/codegen/trimcollect.jl
@@ -33,8 +33,12 @@ source-located diagnostics when dynamic dispatch remains — the same
 "abstract inference unsupported" boundary WasmTarget's strict mode guards,
 but reported far better).
 """
+# P5-trim: entry names for strict-mode scoping (see record_unsupported!).
+const TRIM_ENTRY_NAMES = Ref{Union{Nothing, Set{String}}}(nothing)
+
 function collect_closed_world(entries::Vector{Any}; verify::Bool=false)
-    interp = WasmInterpreter()
+    # Fresh cache partition per collection: see cache_token in WasmInterpreter.
+    interp = WasmInterpreter(Base.RefValue(0))
     invokelatest_queue = CC.CompilationQueue(; interp)
     codeinfos = Any[]
     workqueue = CC.CompilationQueue(; interp)

--- a/test/fuzz/FINDINGS.md
+++ b/test/fuzz/FINDINGS.md
@@ -195,3 +195,21 @@ emits. Infrastructure landed: per-collection cache partitions
 (cache_token / cache_owner), entry-scoped strict mode
 (TRIM_ENTRY_NAMES), width-matched foreigncall defaults, TRIM_IR_CACHE
 serving the collection's consistent-world IR through get_typed_ir.
+
+### P5-trim update (same day, post-fix)
+
+The matrix above is superseded: (1) the 1.12 Dates failures were the
+void-return wrapper bug (try/catch 2-block structure emitted
+`block (result T)` for Nothing-return functions — fixed in 51d3476,
+both Dates probes now PASS on 1.12 under :trim); (2) Random under
+:trim on 1.12 is 6/6 PASS (i64/f64/bool/range/stream/randn) once the
+fuzz bridges enable wasm:js-string builtins and stub the io imports —
+those were harness gaps, not compiler bugs; (3) 1.13 Random under
+:trim is the pair-locals family (ref.cast lands on the i32 index of a
+[ref,idx] memoryrefnew pair inside hash_seed — a517b4c8372d), so :trim
+does NOT sidestep it; (4) bounded discovery differential
+(discovery_differential(), 40 fixed-seed bodies × Int64/Float64 ×
+both versions): :trim agrees with :legacy everywhere, with median
+excluded as the one documented residual (deep show/print machinery,
+the IOBuffer campaign). Net: :trim is at parity-or-better with legacy
+on everything except median, on both versions.

--- a/test/fuzz/FINDINGS.md
+++ b/test/fuzz/FINDINGS.md
@@ -174,3 +174,24 @@ should attribute via a stacktrace instrument inside emit_phi_local_set!
 (mirror the WT_TRACE_CONDSTUB recipe that cracked the type-intersection
 fold). Printf integration is otherwise the established playbook once
 this one shape is fixed.
+
+## P5-trim: differential matrix (discovery=:trim vs :legacy), 2026-06-12
+
+| surface | 1.13 :trim | 1.12 :trim | legacy baseline |
+|---|---|---|---|
+| Statistics mean/std/quantile | PASS (bit-exact) | PASS | PASS (whitelist-cured) |
+| Statistics median | validation err (print machinery) | validation err | PASS |
+| Dates date-diff/parse | PASS | validation err (version-specific IR) | PASS |
+| Random rand-i64 (seeded) | validation err (func 10) | compiles; exec needs "wasm:js-string" import (harness gap) | 1.12 PASS / 1.13 pair-locals |
+
+Headlines: quantile passes under :trim with ZERO whitelist (legacy
+needed :sort! curation). The collection is MORE COMPLETE than legacy —
+it pulls error-formatting/show paths the whitelist never compiled,
+which makes the deferred IOBuffer/print campaign the main blocker for
+full parity (median both versions). Secondary digs: 1.12 date-diff
+validation, 1.13 rand func-10 validation, and the harness's
+importObject lacking the js-string builtin module some collected code
+emits. Infrastructure landed: per-collection cache partitions
+(cache_token / cache_owner), entry-scoped strict mode
+(TRIM_ENTRY_NAMES), width-matched foreigncall defaults, TRIM_IR_CACHE
+serving the collection's consistent-world IR through get_typed_ir.

--- a/test/fuzz/bridge.jl
+++ b/test/fuzz/bridge.jl
@@ -33,7 +33,8 @@ if `rettype` is outside the bridge universe, or `(:compile_error => e)` /
 `:no_node` for whole-batch failures.
 """
 function bridge_run(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
-                    strict::Bool = true, timeout::Real = DEFAULT_TIMEOUT, opt = false)
+                    strict::Bool = true, timeout::Real = DEFAULT_TIMEOUT, opt = false,
+                    discovery::Symbol = :legacy)
     NODE_OK || return :no_node
     dp = descriptor(rettype)
     dp === nothing && return :unsupported
@@ -42,14 +43,16 @@ function bridge_run(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
     funcs = Any[(fn, argtypes, fname)]
     append!(funcs, accs)
     bytes = try
-        WasmTarget.compile_multi(funcs; strict = strict, validate = true, optimize = opt)
+        WasmTarget.compile_multi(funcs; strict = strict, validate = true, optimize = opt,
+                                 discovery = discovery)
     catch e
         return (:compile_error => e)
     end
     driver = """
     const inputs = $(_js_inputs(inputs));
-    const importObject = { Math: { pow: Math.pow } };
-    const { instance } = await WebAssembly.instantiate(bytes, importObject);
+    const _io = { write_string(){}, write_int(){}, write_float(){}, write_bool(){}, write_newline(){}, write_nothing(){} };
+    const importObject = { Math: { pow: Math.pow }, io: _io };
+    const { instance } = await WebAssembly.instantiate(bytes, importObject, { builtins: ['js-string'] });
     const ex = instance.exports;
     const f = ex['$fname'];
     const desc = $(JSON.json(desc));

--- a/test/fuzz/bridge_args.jl
+++ b/test/fuzz/bridge_args.jl
@@ -78,8 +78,9 @@ function bridge_run_args(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
     end
     enc_inputs = [Any[value_to_tree(adescs[j], tup[j]) for j in eachindex(adescs)] for tup in inputs]
     driver = """
-    const importObject = { Math: { pow: Math.pow } };
-    const { instance } = await WebAssembly.instantiate(bytes, importObject);
+    const _io = { write_string(){}, write_int(){}, write_float(){}, write_bool(){}, write_newline(){}, write_nothing(){} };
+    const importObject = { Math: { pow: Math.pow }, io: _io };
+    const { instance } = await WebAssembly.instantiate(bytes, importObject, { builtins: ['js-string'] });
     const ex = instance.exports;
     const f = ex['$fname'];
     const adescs = $(JSON.json(adescs));

--- a/test/fuzz/bridge_args.jl
+++ b/test/fuzz/bridge_args.jl
@@ -30,7 +30,8 @@ bridge. Returns per-input `(:ok, ret_tree, post_trees)` / `(:trap, msg)`, where
 immutable args) — or `:unsupported` / `(:compile_error => e)` / `:no_node`.
 """
 function bridge_run_args(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
-                         strict::Bool = true, timeout::Real = DEFAULT_TIMEOUT, opt = false)
+                         strict::Bool = true, timeout::Real = DEFAULT_TIMEOUT, opt = false,
+                         discovery::Symbol = :legacy)
     NODE_OK || return :no_node
     rp = Bridge.descriptor(rettype)
     rp === nothing && return :unsupported
@@ -70,7 +71,8 @@ function bridge_run_args(fn, argtypes::Tuple, inputs::Vector; rettype::Type,
     funcs = Any[(fn, argtypes, fname)]
     append!(funcs, accs)
     bytes = try
-        WasmTarget.compile_multi(funcs; strict = strict, validate = true, optimize = opt)
+        WasmTarget.compile_multi(funcs; strict = strict, validate = true, optimize = opt,
+                                 discovery = discovery)
     catch e
         return (:compile_error => e)
     end

--- a/test/fuzz/run.jl
+++ b/test/fuzz/run.jl
@@ -17,6 +17,7 @@
 #     reproducer a follow-up loop can run, fix, and auto-close via `verify`.
 
 using Supposition, Random
+using WasmTarget   # discovery_differential needs disable_cache!
 using Statistics   # P4-stdlib: catalogue :stats entries resolve in Main
 using Dates: isleapyear, daysinmonth   # P4-stdlib: :dates entries
 using Supposition: Data
@@ -286,6 +287,57 @@ function ci_fuzz_passes(; types = (Int64, Float64), depth = 2, max_examples = 30
             property_holds(body, T0) || _hits_known_gap(body, known)   # known-open gaps don't fail the ratchet
         end
         something(res.result) isa Supposition.Fail && (allpass = false)
+    end
+    return allpass
+end
+
+# --- Discovery-mode differential: :legacy vs :trim --------------------------
+# For each generated body where the LEGACY pipeline is clean (native == wasm),
+# require the TRIM-collected pipeline to agree with native too. A failure
+# shrinks to a minimal body where the two discovery modes diverge.
+function _trim_agrees(body, ::Type{T0}) where {T0}
+    fn, _, _ = make_function(body, T0)
+    samples = sample_inputs(T0)
+    rt = try
+        Core.Compiler.widenconst(only(Base.code_typed(fn, (T0,); optimize = true))[2])
+    catch
+        nothing
+    end
+    (rt isa Type && isconcretetype(rt) && FuzzBridge.bridge_supported(rt)) || return true
+    natives = map(samples) do tup
+        try
+            (:ok, Base.invokelatest(fn, tup...))
+        catch e
+            (:throw, e)
+        end
+    end
+    all(n -> n[1] === :ok, natives) || return true   # throwy bodies: out of scope here
+    wres = FuzzBridge.bridge_run(fn, (T0,), samples; rettype = rt, discovery = :trim)
+    wres === :no_node && return true
+    wres isa Vector || return false                  # compile/exec error under :trim only
+    desc = FuzzBridge.descriptor(rt)[1]
+    return all(zip(natives, wres)) do (n, w)
+        w[1] === :ok && FuzzBridge.tree_matches(desc, n[2], w[2])
+    end
+end
+
+function discovery_differential(; types = (Int64, Float64), depth = 2,
+                                max_examples = 40, seed = 0xD15C)
+    FuzzHarness.NODE_OK || return true
+    WasmTarget.disable_cache!()   # cache is keyed without discovery mode
+    allpass = true
+    for (i, T0) in enumerate(types)
+        gen = gen_program(T0; depth = depth)
+        res = @check rng=Xoshiro(seed + i) max_examples=max_examples function disc_prop(body = gen)
+            differential(body, T0).category === :ok || return true   # legacy not clean → out of scope
+            _trim_agrees(body, T0)
+        end
+        if something(res.result) isa Supposition.Fail
+            allpass = false
+            println("  ✗ $(T0): discovery modes diverge — see counterexample above")
+        else
+            println("  ✓ $(T0): :trim agrees with :legacy on $max_examples bodies (depth $depth)")
+        end
     end
     return allpass
 end

--- a/test/fuzz/run.jl
+++ b/test/fuzz/run.jl
@@ -322,13 +322,15 @@ function _trim_agrees(body, ::Type{T0}) where {T0}
 end
 
 function discovery_differential(; types = (Int64, Float64), depth = 2,
-                                max_examples = 40, seed = 0xD15C)
+                                max_examples = 40, seed = 0xD15C,
+                                exclude = (:median,))   # known trim residual (show/print machinery)
     FuzzHarness.NODE_OK || return true
     WasmTarget.disable_cache!()   # cache is keyed without discovery mode
     allpass = true
     for (i, T0) in enumerate(types)
         gen = gen_program(T0; depth = depth)
         res = @check rng=Xoshiro(seed + i) max_examples=max_examples function disc_prop(body = gen)
+            any(h -> h in exclude, _call_heads(body)) && return true  # documented trim residuals
             differential(body, T0).category === :ok || return true   # legacy not clean → out of scope
             _trim_agrees(body, T0)
         end


### PR DESCRIPTION
## Summary
- Adopts the upstream trim-collection machinery (JuliaLang/julia#62087 direction): \`collect_closed_world\` runs \`Compiler.CompilationQueue\`/\`compile!\` under \`WasmInterpreter\` (per-collection cache partitions via \`cache_owner\`), producing consistent-world (CodeInstance, CodeInfo) pairs that feed codegen through \`TRIM_IR_CACHE\`.
- \`compile_multi(...; discovery=:trim)\` routes through the collection; **legacy default untouched**.
- Parity: Statistics mean/std/quantile (quantile with ZERO whitelist), Dates date-diff/date-parse, Random seeded suite — bit-exact under :trim on 1.12; 1.13 equal-or-better than legacy (Random blocked on the pre-existing pair-locals family both modes).
- Real bug fixed en route: void-return functions wrapped in \`block (result T)\` by the try/catch 2-block structure (phantom value at function end).
- New \`discovery_differential()\` bounded fuzz: fixed-seed bodies where :legacy is clean must agree under :trim — ALL AGREE on both versions (median excluded: documented show/print residual, the IOBuffer campaign).

## Test plan
- [x] Full Pkg.test green on 1.12 and 1.13 before every commit
- [x] Differential probe matrix both versions
- [x] Bounded discovery differential both versions
