### PR TITLE
fix: don't corrupt select_t / if ref-type operands in the wrap fixer

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,79 @@
+name: Downstream
+# Reactant.jl-style downstream integration testing. WasmTarget is a compiler;
+# the packages that compile THROUGH it (WasmMakie figures, Therapy reactive
+# islands) are where a codegen regression actually shows up. So run THEIR test
+# suites against this checkout of WasmTarget — a green WasmTarget unit suite is
+# necessary but not sufficient. Pairs with the in-suite regression in
+# test/runtests.jl (Phase 76: select_t / if-blocktype operand preservation),
+# which locks the specific bug this guards against.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
+jobs:
+  downstream:
+    name: ${{ matrix.pkg }} (downstream)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: [WasmMakie.jl, Therapy.jl]
+    steps:
+      # This WasmTarget checkout is the version under test. The downstream test
+      # environments resolve it via a sibling path (WasmMakie's test [sources]
+      # points at ../../WasmTarget.jl) or via Pkg.develop (Therapy), so their
+      # suites exercise THIS codegen rather than a registered release.
+      - uses: actions/checkout@v4
+        with:
+          path: WasmTarget.jl
+      - uses: actions/checkout@v4
+        with:
+          repository: GroupTherapyOrg/WasmMakie.jl
+          path: WasmMakie.jl
+      - uses: actions/checkout@v4
+        with:
+          repository: GroupTherapyOrg/Therapy.jl
+          path: Therapy.jl
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.12'
+      - uses: julia-actions/cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-tools
+
+      # WasmMakie's suite compiles dozens of real Makie figures through
+      # WasmTarget and validates every emitted module — the densest downstream
+      # codegen signal. Its test env already sources WasmTarget from
+      # ../../WasmTarget.jl (this checkout).
+      - name: WasmMakie.jl test suite
+        if: matrix.pkg == 'WasmMakie.jl'
+        working-directory: WasmMakie.jl
+        env:
+          WASMMAKIE_SKIP_C002: '1'
+        run: |
+          julia --project=test -e 'import Pkg; Pkg.instantiate()'
+          julia --project=test test/c002_parity.jl
+          julia --project=test test/runtests.jl || julia --project=test test/runtests.jl
+
+      # Therapy compiles reactive @island components (the dashboard that the
+      # select_t fix unblocked). Point its env at this WasmTarget and run its
+      # suite.
+      - name: Therapy.jl test suite
+        if: matrix.pkg == 'Therapy.jl'
+        working-directory: Therapy.jl
+        run: |
+          julia --project=. -e 'import Pkg; Pkg.develop(Pkg.PackageSpec(path="../WasmTarget.jl")); Pkg.instantiate()'
+          julia --project=. -e 'import Pkg; Pkg.test()'

--- a/src/codegen/generate.jl
+++ b/src/codegen/generate.jl
@@ -444,12 +444,49 @@ function fix_i32_wrap_after_i32_ops(bytes::Vector{UInt8})::Vector{UInt8}
                 i += 1
                 done && break
             end
-        elseif op == 0x02 || op == 0x03 || op == 0x04  # block/loop/if — 1 byte blocktype
+        elseif op == 0x1C  # select_t: count:LEB then `count` valtypes (1 byte, or 0x63/0x64 + heaptype LEB)
+            # Skip the whole instruction. Without this the scanner walks INTO the
+            # type operands: a (ref null $T) operand is 0x63 + LEB, and that LEB's
+            # first byte is 0xA7 for type index 167 (=i32.wrap_i64's opcode), which
+            # this pass then strips as a "spurious wrap" — corrupting the select's
+            # result type (ref null 167 → ref null 1, "type mismatch: expected
+            # (ref null $A), found (ref null $B)" in reactive figure islands).
+            last_opcode = 0x00
+            i += 1
+            cnt = 0; sh = 0
+            while i <= length(bytes)
+                b = bytes[i]; push!(result, b); i += 1
+                cnt |= Int(b & 0x7f) << sh
+                (b & 0x80) == 0 && break
+                sh += 7
+            end
+            for _ in 1:cnt
+                i <= length(bytes) || break
+                vt = bytes[i]; push!(result, vt); i += 1
+                if vt == 0x63 || vt == 0x64  # (ref null ht)/(ref ht): heaptype LEB follows
+                    while i <= length(bytes)
+                        push!(result, bytes[i])
+                        done = (bytes[i] & 0x80) == 0
+                        i += 1
+                        done && break
+                    end
+                end
+            end
+        elseif op == 0x02 || op == 0x03 || op == 0x04  # block/loop/if — blocktype
             last_opcode = op
             i += 1
             if i <= length(bytes)
-                push!(result, bytes[i])
-                i += 1
+                bt = bytes[i]; push!(result, bt); i += 1
+                # ref-typed blocktypes ((ref null ht)/(ref ht)) carry a heaptype LEB
+                # beyond the first byte; skipping only 1 byte desyncs the scanner.
+                if bt == 0x63 || bt == 0x64
+                    while i <= length(bytes)
+                        push!(result, bytes[i])
+                        done = (bytes[i] & 0x80) == 0
+                        i += 1
+                        done && break
+                    end
+                end
             end
         else
             # Single-byte instruction (no operands): comparisons, arithmetic, drops, etc.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10735,6 +10735,42 @@ console.log(JSON.stringify({
         @test compare_julia_wasm(_wt_ho_entry, 5).pass
     end
 
+    # Downstream regression (WasmMakie figure islands via Therapy): a byte-fixer
+    # pass must not corrupt a `select_t`/`if` REF type operand. Type index 167
+    # LEB128-encodes as `0xA7 0x01`, and 0xA7 is also `i32.wrap_i64`'s opcode, so
+    # fix_i32_wrap_after_i32_ops — which lacked select_t/ref-blocktype operand
+    # skipping — walked INTO the operand, saw 0xA7, and stripped it, rewriting
+    # `(ref null 167)` → `(ref null 1)`. That broke the 2×2 reactive dashboard
+    # island ("type mismatch: expected (ref null $A), found (ref null $B)").
+    @pphase "Phase 76: select_t / if-blocktype operand preservation (downstream)" begin
+        fixwrap = WasmTarget.fix_i32_wrap_after_i32_ops
+        SELECT_T = 0x1c; REF_NULL = 0x63; WRAP = 0xa7; IFOP = 0x04; ENDOP = 0x0b
+        leb167 = UInt8[0xa7, 0x01]  # unsigned LEB128 of type index 167
+
+        @testset "select_t (ref null 167) operand survives the wrap fixer" begin
+            # local.get 0/1/2 ; select_t 1 (ref null 167) ; ref.cast 167 ; end
+            sel = UInt8[0x20,0x00, 0x20,0x01, 0x20,0x02,
+                        SELECT_T, 0x01, REF_NULL, leb167...,
+                        0xfb, 0x17, leb167...,  # ref.cast 167
+                        ENDOP]
+            out = fixwrap(copy(sel))
+            @test out == sel                                  # untouched
+            si = findfirst(==(SELECT_T), out)
+            @test out[si:si+4] == UInt8[SELECT_T, 0x01, REF_NULL, 0xa7, 0x01]
+        end
+
+        @testset "if (ref null 167) blocktype operand survives" begin
+            blk = UInt8[IFOP, REF_NULL, leb167..., 0x20,0x00, ENDOP, ENDOP]
+            @test fixwrap(copy(blk)) == blk
+        end
+
+        @testset "a genuinely spurious i32.wrap_i64 is still stripped" begin
+            # i32.eq (i32-producing, 0x46) followed by i32.wrap_i64 → wrap removed
+            spur = UInt8[0x20,0x00, 0x20,0x01, 0x46, WRAP, ENDOP]
+            @test fixwrap(copy(spur)) == UInt8[0x20,0x00, 0x20,0x01, 0x46, ENDOP]
+        end
+    end
+
 end  # end of phase-registration block
 
 # The dedicated fuzz pass (WT_FUZZ=1) skips the codegen phases entirely — it exists


### PR DESCRIPTION
## The bug

`fix_i32_wrap_after_i32_ops` (a post-codegen byte pass that strips spurious `i32.wrap_i64` = `0xA7` after i32-producing ops) had **no case for `select_t` (0x1C) or ref-typed block/if blocktypes**, so it walked into their type operands. A `(ref null $T)` operand encodes as `0x63 + LEB`; for type index **167** that LEB is `0xA7 0x01`. The pass read the `0xA7` as an `i32.wrap_i64` opcode and stripped it, rewriting `(ref null 167)` → `(ref null 1)`.

That produced an invalid `select` in WasmMakie's 2×2 reactive dashboard island (compiled via Therapy): `func N failed to validate: type mismatch: expected (ref null $A), found (ref null $B)`. `generate_structured` emitted the select correctly (type 167) — only this post-pass corrupted it.

## The fix

Add proper operand skipping for `select_t` and ref-typed blocktypes in the scanner.

## Tests
- **Phase 76** (`test/runtests.jl`): byte-level regression — the fixer preserves a `select_t (ref null 167)` operand and a `(ref null 167)` if-blocktype, while still stripping a genuinely spurious `i32.wrap_i64`.
- **`downstream.yml`**: Reactant.jl-style downstream integration CI that runs the **WasmMakie + Therapy** test suites against this WasmTarget checkout, so a codegen change here can't silently break the packages that compile through it.

Full `Pkg.test()` (correctness shards + Aqua + fuzz) passes. Verified the dashboard island validates, instantiates, and renders in headless Chromium + Firefox.
