### PR TITLE
fix(codegen): reset module-level io/type caches at start of each fresh compile

### DIFF
--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -1443,6 +1443,20 @@ function compile_module(functions::Vector;
     if existing_module !== nothing
         mod = existing_module
     else
+        # SOUNDNESS: reset all per-module task-local caches BEFORE building a fresh
+        # module. These are cleared on the success path at end-of-module (below), but
+        # NOT in a finally — so a PRIOR compile that threw before reaching the clears
+        # leaks a stale type/func index into this fresh module. The PI pipeline compiles
+        # many cells in one task with many throwing compiles, so the stale
+        # `_CHAR_ARRAY_TYPE_IDX` (i16-char-array index) got baked into this module's
+        # `utf8_to_js` helper as `array.new_default <stale>`, where that slot is now the
+        # `fromCharCodeArray` *func* type → "expected array type at index N, found (func …)".
+        # Clearing at the start of every fresh-module build makes each compile leak-proof.
+        clear_io_imports!()
+        clear_rng_globals!()
+        clear_perf_now!()
+        clear_char_array_type!()
+        clear_utf8_to_js_func!()
         mod = WasmModule()
         # WASM-060: Add Math.pow import for float power operations
         # This enables x^y for Float32/Float64 types


### PR DESCRIPTION
## Summary

Fixes a **soundness bug** where WasmTarget emitted **invalid wasm** — the single highest-frequency validation failure in the PlutoIslands featured corpus (**13 occurrences** across CollatzConjecture, convolution_2d, images, turtles-art).

```
func N failed to validate: expected array type at index 6,
found (func (param (ref null (id 6)) i32 i32) (result (ref extern)))
```

## Root cause

The per-module task-local caches — `_CHAR_ARRAY_TYPE_IDX`, `_UTF8_TO_JS_FUNC_IDX`, `_IO_IMPORTS`, `_PERF_NOW_IDX`, `_RNG_GLOBALS` — were cleared only on `compile_module`'s **success path**, not in a `finally`. A compile that **throws** before reaching the end-of-module clears leaks a stale index into the *next* fresh module.

The PlutoIslands pipeline compiles many cells in one task, and many throw. The stale i16-char-array index (`_CHAR_ARRAY_TYPE_IDX`) then got baked into the next module's `utf8_to_js` helper as `array.new_default <stale>` — but that slot is now the `fromCharCodeArray` **func** type, so the module fails GC validation.

## Fix

Reset all five module-level caches at the **start** of every fresh-module build (`existing_module === nothing`). Covers both single- and multi-function compiles (`compile_function` delegates to `compile_module`).

## Verification

- **Exact repro**: Module A (IO + throws) leaks char-array idx 6; Module B (IO) previously failed validation, now compiles clean.
- **Full `Pkg.test` green**: 10 shards (2742 tests) + differential fuzz pass.
- `loop_guard.sh` clean.
