### PR TITLE
feat(codegen): render type names (string/show of Type) + abstract-Dict-key analysis

### DIFF
--- a/src/codegen/interpreter.jl
+++ b/src/codegen/interpreter.jl
@@ -2039,6 +2039,26 @@ end
     return String(out)
 end
 
+# ─── Type-name rendering Overlays ─────────────────────────────────────────────
+# Why: `string(typeof(x))`, `"$(typeof(x))"`, `show(io, T)` etc. all route through
+#      Base's type-show machinery, which navigates DataType→TypeName→Symbol at
+#      runtime — WT can't materialize the name and produces an EMPTY string (PI
+#      Interactivity island: wasm "" != native "Int64"). But the type is ALWAYS a
+#      compile-time constant at the call site (typeof of a typed value), so the name
+#      is a compile-time literal.
+# Fix: a @generated helper bakes `string(T)` as a String literal at specialization
+#      time; overlay string/show of a Type to use it. Covers string(), repr(),
+#      interpolation, and embedded `print(io, T)` (all funnel through show).
+# Remove when: WT can navigate DataType.name.name to a string at runtime.
+@generated _wt_type_name_str(::Type{T}) where {T} = :($(string(T)))
+
+@overlay WASM_METHOD_TABLE Base.string(::Type{T}) where {T} = _wt_type_name_str(T)
+
+@overlay WASM_METHOD_TABLE function Base.show(io::IO, ::Type{T}) where {T}
+    print(io, _wt_type_name_str(T))
+    return nothing
+end
+
 # Concrete 2-arg specializations: the Vararg method's invoke widens elements
 # to the Union (heterogeneous-union tuple reads still miscompile — the
 # hetero-Dict class), so give inference concrete signatures to prefer for the

--- a/test/fuzz/failures/05b2b084ef65.md
+++ b/test/fuzz/failures/05b2b084ef65.md
@@ -70,3 +70,19 @@ call → trap. So closing this cluster needs **Tier-1 dynamic dispatch** (the ga
 `WT_DYNDISPATCH` frontier), OR a narrow special-case (abstract-but-all-integer key →
 represent boxed key, unbox to i64 for a consistent hash/eq) — intricate, deferred.
 Re-tiered from T0→T1; folded into the T1 dispatch frontier (task #33). See LOOP.md §1-2.
+
+**UPDATE 2026-06-21 — the overlay approach does NOT work; analysis above is incomplete.**
+Tried `@overlay Base.hash(::Signed,::UInt)` + `isequal(::Signed,::Signed)` unboxing the key to
+Int64 via an isa-ladder (the isa-ladder itself is verified to compile+run correctly in WT —
+`x isa Int32 ? Int64(x) : …` works). It had ZERO effect: the helper never appears in the
+compiled module, and BOTH the constant-keyed (`Dict(Int32(0)=>0,0=>0)`) AND runtime-keyed
+(`repro2(a::Int32,b::Int64)=length(Dict(a=>0,b=>0))`) cases still trap. Crucially:
+**`WT.compile(...; strict=true)` COMPILES CLEAN** for both — so this is NOT a compile-time
+"can't resolve hash(::Signed)" dispatch failure (which strict would raise). It's a **runtime
+`unreachable`** reached inside WT's *compiled* Dict construction/indexing logic for abstract
+`Signed`-keyed storage (hashindex / ht_keyindex2_shorthash! / Memory{Signed} slot handling).
+i.e. WT compiles the abstract-keyed Dict but the emitted indexing logic is wrong → traps. The
+real fix needs debugging the compiled Dict internals (find which of the 10 `unreachable`s in
+the ~5KB module is hit — the bridge gives no JS stack trace, so needs instrumentation), NOT a
+hash/isequal overlay. Deferred: deeper than first thought, low PI relevance (mixed-int-width
+keys are a fuzzer artifact). Repros: /tmp/dict_repro2.jl, /tmp/dict_runtime.jl, /tmp/isa_probe.jl.

--- a/test/integration/pi_island_status.json
+++ b/test/integration/pi_island_status.json
@@ -297,7 +297,7 @@
   },
   "Interactivity with HTML.jl#6#cb65a4ee-02e5-4779-8728-b994d8af645d": {
     "notebook": "Interactivity with HTML.jl",
-    "status": "mismatch"
+    "status": "green"
   },
   "PlutoUI.jl.jl#1#c07c5a9e-61f9-4247-86e7-7c3f9956d0ff": {
     "notebook": "PlutoUI.jl.jl",


### PR DESCRIPTION
## Summary
Three commits from the soundness marathon:

1. **feat(codegen): type-name rendering** — `string(typeof(x))`, `"$(typeof(x))"`, `show(io, T)` routed through Base's type-show machinery (DataType→TypeName→Symbol navigation) which WT can't materialize at runtime → emitted an **empty string**. The type is always a compile-time constant at the call site, so a `@generated` helper bakes `string(T)` as a literal; overlay `string(::Type{T})`/`show(io, ::Type{T})` use it. Fixes PI **Interactivity → 6/6 all-island** (was 5+1 partial).
2. **test(integration): relock** the one PI fixture this flips (Interactivity#6 mismatch→green).
3. **docs(fuzz): correct** the abstract-Dict-key cluster root-cause analysis (overlay doesn't work — it's a runtime-unreachable in compiled Dict internals, not a compile dispatch failure).

## Verification
Full `Pkg.test` green (10 shards + differential fuzz); the only status flip is the intended Interactivity#6 improvement (relocked). `string(typeof(x))` → "Int64"/"Float64"/interpolation all correct.
