### PR TITLE
test: refresh PI island fixtures + regen lock; add bind-completeness audit

### DIFF
--- a/test/integration/pi_bind_audit.json
+++ b/test/integration/pi_bind_audit.json
@@ -1,0 +1,98 @@
+[
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 12,
+    "notebook": "Interactivity with HTML.jl",
+    "registered": 12,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 1,
+    "notebook": "Basic mathematics.jl",
+    "registered": 1,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 22,
+    "notebook": "CollatzConjecture.jl",
+    "registered": 22,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 3,
+    "notebook": "newton.jl",
+    "registered": 3,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 28,
+    "notebook": "PlutoUI.jl.jl",
+    "registered": 28,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 17,
+    "notebook": "fractals.jl",
+    "registered": 17,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 12,
+    "notebook": "convolution_1d.jl",
+    "registered": 12,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 5,
+    "notebook": "convolution_2d.jl",
+    "registered": 5,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 13,
+    "notebook": "images.jl",
+    "registered": 13,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 2,
+    "notebook": "dither.jl",
+    "registered": 2,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 6,
+    "notebook": "turtles-art.jl",
+    "registered": 6,
+    "registered_not_extracted": []
+  },
+  {
+    "complete": true,
+    "errored_bind_cells": [],
+    "extracted": 5,
+    "notebook": "Titration.jl",
+    "registered": 5,
+    "registered_not_extracted": []
+  }
+]

--- a/test/integration/pi_island_fixtures.json
+++ b/test/integration/pi_island_fixtures.json
@@ -272,13 +272,13 @@
         ]
       },
       {
-        "cell_id": "cb65a4ee-02e5-4779-8728-b994d8af645d",
+        "cell_id": "1ebba747-47f8-4ecd-809d-359e6d803ddc",
         "extract_ok": true,
-        "fn_src": "function (x::Int64,)\n    var\"##cellval#337\" = typeof(x)\n    return (PlutoIslands._plain_body)(var\"##cellval#337\")\nend",
+        "fn_src": "function (x::Int64,)\n    y = x ^ 2\n    var\"##cellval#337\" = y\n    return (PlutoIslands._plain_body)(var\"##cellval#337\")\nend",
         "golden": [
-          "\"Int64\"",
-          "\"Int64\"",
-          "\"Int64\""
+          "\"2500\"",
+          "\"0\"",
+          "\"10000\""
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -297,13 +297,13 @@
         ]
       },
       {
-        "cell_id": "1ebba747-47f8-4ecd-809d-359e6d803ddc",
+        "cell_id": "cb65a4ee-02e5-4779-8728-b994d8af645d",
         "extract_ok": true,
-        "fn_src": "function (x::Int64,)\n    y = x ^ 2\n    var\"##cellval#338\" = y\n    return (PlutoIslands._plain_body)(var\"##cellval#338\")\nend",
+        "fn_src": "function (x::Int64,)\n    var\"##cellval#338\" = typeof(x)\n    return (PlutoIslands._plain_body)(var\"##cellval#338\")\nend",
         "golden": [
-          "\"2500\"",
-          "\"0\"",
-          "\"10000\""
+          "\"Int64\"",
+          "\"Int64\"",
+          "\"Int64\""
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -367,88 +367,59 @@
     "group_reasons": [],
     "notebook": "Basic mathematics.jl",
     "preamble": [
-      "correct(text = md\"Great! You got the right answer! Let's move on to the next section.\") = begin\n        #= none:1 =#\n        Markdown.MD(Markdown.Admonition(\"correct\", \"Got it!\", [text]))\n    end",
+      "keep_working(text = md\"The answer is not quite right.\") = begin\n        #= none:1 =#\n        Markdown.MD(Markdown.Admonition(\"danger\", \"Keep working on it!\", [text]))\n    end",
       "function pieces(n)\n    #= none:1 =#\n    #= none:2 =#\n    return n\nend",
-      "keep_working(text = md\"The answer is not quite right.\") = begin\n        #= none:1 =#\n        Markdown.MD(Markdown.Admonition(\"danger\", \"Keep working on it!\", [text]))\n    end"
+      "correct(text = md\"Great! You got the right answer! Let's move on to the next section.\") = begin\n        #= none:1 =#\n        Markdown.MD(Markdown.Admonition(\"correct\", \"Got it!\", [text]))\n    end"
     ]
   },
   {
     "argtypes": [
-      "@NamedTuple{P::Int64, a::Int64, b::Int64}",
-      "Bool",
       "String",
-      "Vector{String}",
-      "@NamedTuple{start_value::Int64, orbit::Int64}",
-      "@NamedTuple{start_value::Int64}",
-      "@NamedTuple{ub::Int64}",
-      "Vector{String}",
-      "@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}",
-      "@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}",
-      "@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}",
-      "@NamedTuple{window_height::Float64, window_width::Float64}"
+      "Bool",
+      "Int64",
+      "Int64",
+      "Int64",
+      "Bool",
+      "Int64",
+      "Int64",
+      "Float64",
+      "Int64",
+      "Float64",
+      "Bool",
+      "Int64",
+      "String",
+      "Float64",
+      "Float64",
+      "Bool",
+      "Float64",
+      "Float64",
+      "Float64",
+      "Float64"
     ],
     "bonds": [
-      "collatz_parameters",
-      "do_generalize_collatz",
-      "filename",
-      "generalize_collatz",
-      "graph_parameters",
-      "hailstone_params",
-      "stopping_parameters",
-      "viz_colors_options",
-      "viz_extra_options",
-      "viz_parameters",
-      "viz_specs_parameters",
-      "window_size_parameters"
+      "background_color",
+      "chris_style",
+      "collatz_P",
+      "collatz_a",
+      "collatz_b",
+      "edmund_style",
+      "graph_start_value",
+      "hailstone_start_value",
+      "init_angle",
+      "line_length",
+      "num_traject",
+      "random_shade",
+      "stopping_ub",
+      "stroke_color",
+      "stroke_width",
+      "turn_scale",
+      "vary_shade",
+      "window_height",
+      "window_width",
+      "x_start",
+      "y_start"
     ],
     "cells": [
-      {
-        "cell_id": "af0c36ee-0534-4143-b59b-4ee041ef0f04",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    var\"##cellval#447\" = if do_generalize_collatz\n            md\"!!! warning \\\"Divergence\\\"\n\tSome parameters will not behave as the traditional problem and will lead to some numbers diverging up to infinity. In that case, the calculations will stop at a stopping time of 1000. However, this still can still result in high latency so beware! .\n\"\n        else\n            md\"\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#447\")\nend",
-        "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported"
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "\"MyCoolVisualization\"",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)",
-            "(start_value = 15,)",
-            "(ub = 1000,)",
-            "[\"#e68282\", \"#000000\"]",
-            "(random_shade = false, vary_shade = false, edmund_style = false, chris_style = false)",
-            "(num_traject = 1000.0, line_length = 20, turn_scale = 9.9)",
-            "(init_angle = 19.8, x_start = 249.7, y_start = 700.0, stroke_width = 5.0)",
-            "(window_height = 700.0, window_width = 500.0)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "8a64e9e3-477e-4a7e-97f7-61cf5e428731",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    var\"##cellval#448\" = #= none:1 =# @unpack((window_height, window_width) = window_size_parameters)\n    return (PlutoIslands._plain_body)(var\"##cellval#448\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "1c3f1bea-f1ba-4d64-90ad-584391c01da5",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
       {
         "cell_id": "7dbfb4dc-c9d0-464d-83b2-18db90d76878",
         "extract_ok": false,
@@ -460,49 +431,85 @@
         ]
       },
       {
-        "cell_id": "5f074850-b967-4de5-8ca3-b85a74052499",
+        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    generalize_collatz\n    stopping_times = Dict()\n    var\"##cellval#449\" = stopping_times\n    return (PlutoIslands._plain_body)(var\"##cellval#449\")\nend",
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, graph_start_value::Int64, hailstone_start_value::Int64, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stopping_ub::Int64, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    st_x = Float64[]\n    st_y = Float64[]\n    let\n        #= none:8 =#\n        ub = Int64(stopping_ub)\n        #= none:9 =#\n        Pv = Int64(collatz_P)\n        #= none:10 =#\n        av = Int64(collatz_a)\n        #= none:11 =#\n        bv = Int64(collatz_b)\n        #= none:12 =#\n        n0 = Int64(1)\n        #= none:13 =#\n        while n0 <= ub\n            #= none:14 =#\n            push!(st_x, Float64(n0))\n            #= none:15 =#\n            push!(st_y, Float64(collatz_stopping_time(n0, Pv, av, bv, Int64(1000))))\n            #= none:16 =#\n            n0 += 1\n            #= none:17 =#\n        end\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#475\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#475\")\nend",
         "golden": [
-          "\"Dict{Any, Any}()\""
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#497\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
-        "mime": "text/plain",
+        "mime": "text/html",
         "reasons": [],
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
+            "\"#000000\"",
             "false",
-            "\"MyCoolVisualization\"",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)",
-            "(start_value = 15,)",
-            "(ub = 1000,)",
-            "[\"#e68282\", \"#000000\"]",
-            "(random_shade = false, vary_shade = false, edmund_style = false, chris_style = false)",
-            "(num_traject = 1000.0, line_length = 20, turn_scale = 9.9)",
-            "(init_angle = 19.8, x_start = 249.7, y_start = 700.0, stroke_width = 5.0)",
-            "(window_height = 700.0, window_width = 500.0)"
+            "2",
+            "3",
+            "1",
+            "false",
+            "12",
+            "15",
+            "19.8",
+            "20",
+            "80.0",
+            "false",
+            "1000",
+            "\"#e68282\"",
+            "5.0",
+            "9.9",
+            "false",
+            "700.0",
+            "500.0",
+            "249.7",
+            "700.0"
           ]
         ]
       },
       {
-        "cell_id": "f21f1e3e-a3ab-458e-a101-ce824731f0b6",
-        "extract_ok": false,
-        "fn_src": null,
+        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
+        "extract_ok": true,
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, graph_start_value::Int64, hailstone_start_value::Int64, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stopping_ub::Int64, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    fig_conv = Figure(size = (700, 460))\n    ax_conv = Axis(fig_conv[1, 1]; title = \"Hailstone paths for 1 … \" * string(graph_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    top = Int64(graph_start_value)\n    n0 = Int64(1)\n    while n0 <= top\n        #= none:16 =#\n        seq = collatz_hailstone(n0, Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:22 =#\n        cx = Float64[]\n        #= none:23 =#\n        cy = Float64[]\n        #= none:24 =#\n        i = 1\n        #= none:25 =#\n        for v = seq\n            #= none:26 =#\n            push!(cx, Float64(i))\n            #= none:27 =#\n            push!(cy, Float64(v))\n            #= none:28 =#\n            i += 1\n            #= none:29 =#\n        end\n        #= none:30 =#\n        shade = Float64(n0 % 7) / 7.0\n        #= none:31 =#\n        lines!(ax_conv, cx, cy; color = (0.25 + 0.5shade, 0.45, 0.85 - 0.4shade, 0.55), linewidth = 1.5)\n        #= none:34 =#\n        n0 += 1\n        #= none:35 =#\n    end\n    var\"##cellval#476\" = fig_conv\n    return (PlutoIslands._html_body)(var\"##cellval#476\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#497\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
         "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "\"#000000\"",
+            "false",
+            "2",
+            "3",
+            "1",
+            "false",
+            "12",
+            "15",
+            "19.8",
+            "20",
+            "80.0",
+            "false",
+            "1000",
+            "\"#e68282\"",
+            "5.0",
+            "9.9",
+            "false",
+            "700.0",
+            "500.0",
+            "249.7",
+            "700.0"
+          ]
         ]
       },
       {
         "cell_id": "66fe673a-7679-4c55-bf59-146a8dd1241c",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    hailstone_seq = if \"Hailstone Sequence\" ∈ generalize_collatz\n            hailstone_sequence(hailstone_params.start_value; collatz_parameters..., verbose = false)\n        else\n            hailstone_sequence(hailstone_params.start_value; verbose = false)\n        end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_params.start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    hail_x = Float64[]\n    hail_y = Float64[]\n    for (i, v) = enumerate(hailstone_seq)\n        #= none:13 =#\n        push!(hail_x, Float64(i))\n        #= none:14 =#\n        push!(hail_y, Float64(v))\n        #= none:15 =#\n    end\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#450\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#450\")\nend",
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, graph_start_value::Int64, hailstone_start_value::Int64, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stopping_ub::Int64, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    hail_x = Float64[]\n    hail_y = Float64[]\n    let\n        #= none:5 =#\n        seq = collatz_hailstone(Int64(hailstone_start_value), Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:11 =#\n        i = 1\n        #= none:12 =#\n        for v = seq\n            #= none:13 =#\n            push!(hail_x, Float64(i))\n            #= none:14 =#\n            push!(hail_y, Float64(v))\n            #= none:15 =#\n            i += 1\n            #= none:16 =#\n        end\n    end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#477\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#477\")\nend",
         "golden": [
-          "ERR:UndefVarError: `hailstone_sequence` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#497\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -510,94 +517,75 @@
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
+            "\"#000000\"",
             "false",
-            "\"MyCoolVisualization\"",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)",
-            "(start_value = 15,)",
-            "(ub = 1000,)",
-            "[\"#e68282\", \"#000000\"]",
-            "(random_shade = false, vary_shade = false, edmund_style = false, chris_style = false)",
-            "(num_traject = 1000.0, line_length = 20, turn_scale = 9.9)",
-            "(init_angle = 19.8, x_start = 249.7, y_start = 700.0, stroke_width = 5.0)",
-            "(window_height = 700.0, window_width = 500.0)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "6693800b-e2bc-46e4-b5f8-004184ef472b",
-        "eval_err": "syntax: type of \"record\" declared in inner scope",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    md\"!!! info \\\"Numerical Packages\\\"\n\t[Collatz](https://juliapackages.com/p/collatz): This package provide the methods to generate the hailstone sequence, the tree graph and stopping time for the collatz conjecture. \n\n\t[Graphs](https://www.juliapackages.com/p/graphs): Used to deal with creating and modifying graphs. \n\n\t[FixedPointNumbers](https://www.juliapackages.com/p/fixedpointnumbers): Package to deal with fixed point number, only used to handle colors.\n\"\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  key::Int64, previous::Collatz._CC.CC, depth::Int=0)\\n\\nTo handle the case where the search hits a cycle and previous is of type Collatz._CC.CC\\n\\n## Args \\n\\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Collatz._CC.CC`: The cycle value.\\n- `depth::Int`: The current depth of the search  \\n\\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, key::Int64, previous::Collatz._CC.CC, depth::Int = 0)\n            #= none:15 =#\n            #= none:18 =#\n            previous_index = findfirst((x->begin\n                            #= none:18 =#\n                            x == previous\n                        end), map((x->begin\n                                #= none:18 =#\n                                x[2]\n                            end), record))\n            #= none:21 =#\n            if isnothing(previous_index)\n                \"\"\n            else\n                add_edge!(g, previous, length(record) + 1)\n            end\n            #= none:24 =#\n            push!(record, (depth, key))\n            #= none:25 =#\n            return\n        end\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  tree::Dict, previous::Number=collect(keys(tree))[1], depth::Int=0)\\n\\t\\nThis function is used to explore the tree return by `tree_graph` from Collatz.jl and modify the graph g given as input. \\n\\n## Args \\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values. Each value is stored as (depth, value) in order to keep track of what depth the value was encountered\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Number`: The number passed by the previous call to the function \\n- `depth::Int`: The current depth of the search  \\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, tree::Dict, previous::Number = (collect(keys(tree)))[1], depth::Int = 0)\n            #= none:13 =#\n            #= none:16 =#\n            for key = keys(tree)\n                #= none:18 =#\n                add_vertex!(g)\n                #= none:21 =#\n                previous_index = findfirst((x->begin\n                                #= none:21 =#\n                                x == previous\n                            end), map((x->begin\n                                    #= none:21 =#\n                                    x[2]\n                                end), record))\n                #= none:24 =#\n                if isnothing(previous_index)\n                    \"\"\n                else\n                    add_edge!(g, previous_index, length(record) + 1)\n                end\n                #= none:27 =#\n                if key isa Number\n                    #= none:28 =#\n                    push!(record, (depth, key))\n                end\n                #= none:32 =#\n                descend_tree!(g, record, tree[key], key, depth + 1)\n                #= none:33 =#\n            end\n        end\n    #= none:1 =# Core.@doc \"\\tmake_collatz_graph(initial_value::Int, max_orbit_distance::Int; P=2, a=3, b=1)\\n\\nThis function returns a graph that represent the different branches that each number takes.\\n\\n## Args\\n\\n- `initial_value::Integer`: The starting value of the directed tree graph.\\n\\n- `max_orbit_distance::Integer`: Degree of seperation between the initial value and each value encountered. \\n\\n## Kwargs\\n\\n- ```P::Integer=2```: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n\\n- ```a::Integer=3```: Factor by which to multiply n.\\n\\n- ```b::Integer=1```: Value to add to the scaled value of n.\\n\\n\\n## See also\\n[`tree_graph`](@ref)\\n\" function make_collatz_graph(initial_value::Int, max_orbit_distance::Int; P = 2, a = 3, b = 1)\n            #= none:24 =#\n            #= none:25 =#\n            g = SimpleGraph()\n            #= none:26 =#\n            record::Array{Tuple{Number, Number}} = []\n            #= none:27 =#\n            tree = tree_graph(initial_value, max_orbit_distance; P, a, b)\n            #= none:28 =#\n            descend_tree!(g, record, tree)\n            #= none:29 =#\n            return (g, record)\n        end\n    (g, record) = if \"Graph\" ∈ generalize_collatz\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; collatz_parameters...)\n        else\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; )\n        end\n    graph_colors = [RGB(rescale((record[i])[1], 1, graph_parameters.orbit, 1, 0.3), 0.1, 0.3) for i = 1:nv(g)]\n    var\"##cellval#451\" = graph_colors\n    return (PlutoIslands._plain_body)(var\"##cellval#451\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "image/svg+xml",
-        "reasons": [
-          "unsupported output mime image/svg+xml in v0 (text/plain & md-text/html only)"
-        ]
-      },
-      {
-        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    generalize_collatz\n    stopping_times = Dict()\n    newValues = filter((x->begin\n                    #= none:3 =#\n                    !(x ∈ keys(stopping_times))\n                end), collect(range(1, stopping_parameters.ub, step = 1)))\n    for newValue = newValues\n        #= none:7 =#\n        push!(stopping_times, newValue => if \"Stopping Time\" ∈ generalize_collatz\n                    stopping_time(newValue; collatz_parameters..., total_stopping_time = true)\n                else\n                    stopping_time(newValue, total_stopping_time = true)\n                end)\n        #= none:10 =#\n    end\n    st_vals = collect(values(sort(filter((key->begin\n                                #= none:14 =#\n                                key[1] ∈ range(1, stopping_parameters.ub, step = 1)\n                            end), stopping_times))))\n    st_x = Float64[]\n    st_y = Float64[]\n    for (i, v) = enumerate(st_vals)\n        #= none:21 =#\n        push!(st_x, Float64(i))\n        #= none:22 =#\n        push!(st_y, Float64(v))\n        #= none:23 =#\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_parameters.ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#453\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#453\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `stopping_time` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
+            "2",
+            "3",
+            "1",
             "false",
-            "\"MyCoolVisualization\"",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)",
-            "(start_value = 15,)",
-            "(ub = 1000,)",
-            "[\"#e68282\", \"#000000\"]",
-            "(random_shade = false, vary_shade = false, edmund_style = false, chris_style = false)",
-            "(num_traject = 1000.0, line_length = 20, turn_scale = 9.9)",
-            "(init_angle = 19.8, x_start = 249.7, y_start = 700.0, stroke_width = 5.0)",
-            "(window_height = 700.0, window_width = 500.0)"
+            "12",
+            "15",
+            "19.8",
+            "20",
+            "80.0",
+            "false",
+            "1000",
+            "\"#e68282\"",
+            "5.0",
+            "9.9",
+            "false",
+            "700.0",
+            "500.0",
+            "249.7",
+            "700.0"
           ]
         ]
       },
       {
         "cell_id": "50a423ad-ca90-4015-9ef6-577f60e4efe7",
-        "eval_err": "LoadError: UndefVarError: `@htl` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.\nHint: a global variable of this name also exists in HypertextLiteral.\nin expression starting at none:2",
+        "eval_err": "LoadError: UndefVarError: `@htl` not defined in `Main.var\"##hv#497\"`\nSuggestion: check for spelling errors or missing imports.\nHint: a global variable of this name also exists in HypertextLiteral.\nin expression starting at none:2",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    var\"##cellval#454\" = #= none:2 =# @htl(\"<div class=\\\"slider_group sidebar-left\\\">\\n\\t<div class=\\\"on_big_show\\\">\\n\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t$(viz_sliders)\\n\\t\\t</div>\\n\\n\\t</div>\\t\\n</div>\\n\\n<div class=\\\"slider_group sidebar-right\\\">\\n\\t<div class=\\\"on_small_show\\\">\\n\\t\\t<div class=\\\"slider_group_inner \\\">\\n\\t\\t\\t$(viz_sliders)\\n\\t\\t</div>\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(viz_specs_sliders)\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(colors_sliders)\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(viz_extra_sliders)\\n\\t</div>\\n</div>\\n<div class=\\\"sidebar-bottom\\\">\\n\\t<div class=\\\"on_tiny_show\\\">\\n\\t\\t<div class=\\\"slider_group\\\">\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\n\\t\\t\\t<div class=\\\"slider_group_inner \\\">\\n\\t\\t\\t\\t$(viz_sliders)\\n\\t\\t\\t</div>\\n\\t\\t</div>\\n\\t\\n\\t\\t<div class=\\\"slider_group\\\">\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_specs_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(colors_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_extra_sliders)\\n\\t\\t\\t</div>\\n\\t\\t</div>\\n\\t</div>\\n\\t<div>\\n\\t\\t\\t\\n\\t</div>\\n</div>\\n\")\n    return (PlutoIslands._html_body)(var\"##cellval#454\")\nend",
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, graph_start_value::Int64, hailstone_start_value::Int64, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stopping_ub::Int64, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    var\"##cellval#478\" = #= none:2 =# @htl(\"<div class=\\\"slider_group sidebar-left\\\">\\n\\t<div class=\\\"on_big_show\\\">\\n\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t$(viz_sliders)\\n\\t\\t</div>\\n\\n\\t</div>\\t\\n</div>\\n\\n<div class=\\\"slider_group sidebar-right\\\">\\n\\t<div class=\\\"on_small_show\\\">\\n\\t\\t<div class=\\\"slider_group_inner \\\">\\n\\t\\t\\t$(viz_sliders)\\n\\t\\t</div>\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(viz_specs_sliders)\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(colors_sliders)\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(viz_extra_sliders)\\n\\t</div>\\n</div>\\n<div class=\\\"sidebar-bottom\\\">\\n\\t<div class=\\\"on_tiny_show\\\">\\n\\t\\t<div class=\\\"slider_group\\\">\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\n\\t\\t\\t<div class=\\\"slider_group_inner \\\">\\n\\t\\t\\t\\t$(viz_sliders)\\n\\t\\t\\t</div>\\n\\t\\t</div>\\n\\t\\n\\t\\t<div class=\\\"slider_group\\\">\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_specs_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(colors_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_extra_sliders)\\n\\t\\t\\t</div>\\n\\t\\t</div>\\n\\t</div>\\n\\t<div>\\n\\t\\t\\t\\n\\t</div>\\n</div>\\n\")\n    return (PlutoIslands._html_body)(var\"##cellval#478\")\nend",
         "kind": "string",
         "mime": "text/html",
         "reasons": []
       },
       {
         "cell_id": "6d225dce-3362-4f5d-bba9-0b5312f6be5a",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    #= none:1 =# @unpack (window_height, window_width) = window_size_parameters\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#455\" = interactive_viz\n    return (PlutoIslands._plain_body)(var\"##cellval#455\")\nend",
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, graph_start_value::Int64, hailstone_start_value::Int64, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stopping_ub::Int64, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    viz_trajectories = Vector{Vector{Int64}}()\n    let\n        #= none:11 =#\n        Pv = Int64(collatz_P)\n        #= none:12 =#\n        av = Int64(collatz_a)\n        #= none:13 =#\n        bv = Int64(collatz_b)\n        #= none:14 =#\n        n0 = Int64(1)\n        #= none:15 =#\n        ntop = Int64(round(Int, num_traject))\n        #= none:16 =#\n        while n0 <= ntop\n            #= none:17 =#\n            push!(viz_trajectories, reverse(collatz_hailstone(n0, Pv, av, bv, Int64(1000))))\n            #= none:18 =#\n            n0 += 1\n            #= none:19 =#\n        end\n    end\n    interactive_viz = let\n            #= none:26 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:27 =#\n            ax = Axis(fig[1, 1])\n            #= none:28 =#\n            hidedecorations!(ax)\n            #= none:29 =#\n            hidespines!(ax)\n            #= none:31 =#\n            base_r = Float64(red(stroke_color))\n            #= none:32 =#\n            base_g = Float64(green(stroke_color))\n            #= none:33 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:35 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:36 =#\n                xs = Float64[]\n                #= none:37 =#\n                ys = Float64[]\n                #= none:38 =#\n                x = Float64(x_start)\n                #= none:39 =#\n                y = Float64(y_start)\n                #= none:40 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:41 =#\n                push!(xs, x)\n                #= none:42 =#\n                push!(ys, y)\n                #= none:43 =#\n                for v = seq\n                    #= none:44 =#\n                    if chris_style\n                        #= none:45 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:46 =# mod(v, 2) == 0\n                        #= none:47 =#\n                        θ += turn_scale\n                    else\n                        #= none:49 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:51 =#\n                    x += line_length * cosd(θ)\n                    #= none:52 =#\n                    y += line_length * sind(θ)\n                    #= none:53 =#\n                    push!(xs, x)\n                    #= none:54 =#\n                    push!(ys, y)\n                    #= none:55 =#\n                end\n                #= none:59 =#\n                col = if random_shade\n                        #= none:60 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:63 =# vary_shade\n                        #= none:64 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:65 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:69 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:71 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:72 =#\n            end\n            #= none:73 =#\n            fig\n        end\n    var\"##cellval#479\" = interactive_viz\n    return (PlutoIslands._html_body)(var\"##cellval#479\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#497\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
         "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "1b48b435-e959-477f-a8d2-3507da73fc28",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64}, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    #= none:1 =# @unpack (window_height, window_width) = window_size_parameters\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#456\" = #= none:1 =# @htl(\"$(PlutoUI.DownloadButton(\"<!doctype html><html><body>\" * html_snippet(interactive_viz) * \"</body></html>\", if filename == \"\"\n            \"MyCoolVisualization\"\n        else\n            filename\n        end * \".html\"))\\n\")\n    return (PlutoIslands._plain_body)(var\"##cellval#456\")\nend",
-        "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "\"#000000\"",
+            "false",
+            "2",
+            "3",
+            "1",
+            "false",
+            "12",
+            "15",
+            "19.8",
+            "20",
+            "80.0",
+            "false",
+            "1000",
+            "\"#e68282\"",
+            "5.0",
+            "9.9",
+            "false",
+            "700.0",
+            "500.0",
+            "249.7",
+            "700.0"
+          ]
+        ]
       }
     ],
     "group": 1,
@@ -605,85 +593,63 @@
     "group_reasons": [],
     "notebook": "CollatzConjecture.jl",
     "preamble": [
+      "function collatz_stopping_time(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:7 =#\n    #= none:8 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:9 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:10 =#\n    steps = 0\n    #= none:11 =#\n    while n != 1 && steps < maxlen\n        #= none:12 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:13 =#\n        steps += 1\n        #= none:14 =#\n        if n < 1\n            #= none:15 =#\n            break\n        end\n        #= none:17 =#\n    end\n    #= none:18 =#\n    return steps\nend",
       "using Collatz",
       "using Graphs",
       "using FixedPointNumbers",
       "using PlutoUI",
-      "import PlutoUI: combine",
       "using HypertextLiteral: @htl",
       "using Parameters",
       "using WasmMakie",
       "using Colors",
       "using Luxor",
       "using Karnak, NetworkLayout",
-      "using ImageIO, ImageShow"
+      "using ImageIO, ImageShow",
+      "function collatz_hailstone(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:8 =#\n    #= none:9 =#\n    out = Int64[]\n    #= none:10 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:11 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:12 =#\n    push!(out, n)\n    #= none:13 =#\n    steps = 0\n    #= none:14 =#\n    while n != 1 && steps < maxlen\n        #= none:15 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:16 =#\n        push!(out, n)\n        #= none:17 =#\n        steps += 1\n        #= none:18 =#\n        if n < 1\n            #= none:19 =#\n            break\n        end\n        #= none:21 =#\n    end\n    #= none:22 =#\n    return out\nend"
     ]
   },
   {
     "argtypes": [
-      "@NamedTuple{P::Int64, a::Int64, b::Int64}",
+      "String",
+      "Bool",
+      "Int64",
+      "Int64",
+      "Int64",
+      "Bool",
+      "Float64",
+      "Int64",
+      "Float64",
       "Bool",
       "String",
-      "Vector{String}",
-      "@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}",
-      "@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}",
-      "@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}",
-      "@NamedTuple{window_height::Float64, window_width::Float64}"
+      "Float64",
+      "Float64",
+      "Bool",
+      "Float64",
+      "Float64",
+      "Float64",
+      "Float64"
     ],
     "bonds": [
-      "collatz_parameters",
-      "do_generalize_collatz",
-      "filename",
-      "viz_colors_options",
-      "viz_extra_options",
-      "viz_parameters",
-      "viz_specs_parameters",
-      "window_size_parameters"
+      "background_color",
+      "chris_style",
+      "collatz_P",
+      "collatz_a",
+      "collatz_b",
+      "edmund_style",
+      "init_angle",
+      "line_length",
+      "num_traject",
+      "random_shade",
+      "stroke_color",
+      "stroke_width",
+      "turn_scale",
+      "vary_shade",
+      "window_height",
+      "window_width",
+      "x_start",
+      "y_start"
     ],
     "cells": [
-      {
-        "cell_id": "af0c36ee-0534-4143-b59b-4ee041ef0f04",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    var\"##cellval#457\" = if do_generalize_collatz\n            md\"!!! warning \\\"Divergence\\\"\n\tSome parameters will not behave as the traditional problem and will lead to some numbers diverging up to infinity. In that case, the calculations will stop at a stopping time of 1000. However, this still can still result in high latency so beware! .\n\"\n        else\n            md\"\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#457\")\nend",
-        "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported"
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "\"MyCoolVisualization\"",
-            "[\"#e68282\", \"#000000\"]",
-            "(random_shade = false, vary_shade = false, edmund_style = false, chris_style = false)",
-            "(num_traject = 1000.0, line_length = 20, turn_scale = 9.9)",
-            "(init_angle = 19.8, x_start = 249.7, y_start = 700.0, stroke_width = 5.0)",
-            "(window_height = 700.0, window_width = 500.0)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "8a64e9e3-477e-4a7e-97f7-61cf5e428731",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    var\"##cellval#458\" = #= none:1 =# @unpack((window_height, window_width) = window_size_parameters)\n    return (PlutoIslands._plain_body)(var\"##cellval#458\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "1c3f1bea-f1ba-4d64-90ad-584391c01da5",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
       {
         "cell_id": "7dbfb4dc-c9d0-464d-83b2-18db90d76878",
         "extract_ok": false,
@@ -695,45 +661,79 @@
         ]
       },
       {
-        "cell_id": "5f074850-b967-4de5-8ca3-b85a74052499",
+        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    generalize_collatz\n    stopping_times = Dict()\n    var\"##cellval#459\" = stopping_times\n    return (PlutoIslands._plain_body)(var\"##cellval#459\")\nend",
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    st_x = Float64[]\n    st_y = Float64[]\n    let\n        #= none:8 =#\n        ub = Int64(stopping_ub)\n        #= none:9 =#\n        Pv = Int64(collatz_P)\n        #= none:10 =#\n        av = Int64(collatz_a)\n        #= none:11 =#\n        bv = Int64(collatz_b)\n        #= none:12 =#\n        n0 = Int64(1)\n        #= none:13 =#\n        while n0 <= ub\n            #= none:14 =#\n            push!(st_x, Float64(n0))\n            #= none:15 =#\n            push!(st_y, Float64(collatz_stopping_time(n0, Pv, av, bv, Int64(1000))))\n            #= none:16 =#\n            n0 += 1\n            #= none:17 =#\n        end\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#480\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#480\")\nend",
         "golden": [
-          "ERR:UndefVarError: `generalize_collatz` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `stopping_ub` not defined in `Main.var\"##hv#498\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
-        "mime": "text/plain",
+        "mime": "text/html",
         "reasons": [],
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
+            "\"#000000\"",
             "false",
-            "\"MyCoolVisualization\"",
-            "[\"#e68282\", \"#000000\"]",
-            "(random_shade = false, vary_shade = false, edmund_style = false, chris_style = false)",
-            "(num_traject = 1000.0, line_length = 20, turn_scale = 9.9)",
-            "(init_angle = 19.8, x_start = 249.7, y_start = 700.0, stroke_width = 5.0)",
-            "(window_height = 700.0, window_width = 500.0)"
+            "2",
+            "3",
+            "1",
+            "false",
+            "19.8",
+            "20",
+            "80.0",
+            "false",
+            "\"#e68282\"",
+            "5.0",
+            "9.9",
+            "false",
+            "700.0",
+            "500.0",
+            "249.7",
+            "700.0"
           ]
         ]
       },
       {
-        "cell_id": "f21f1e3e-a3ab-458e-a101-ce824731f0b6",
-        "extract_ok": false,
-        "fn_src": null,
+        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
+        "extract_ok": true,
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    fig_conv = Figure(size = (700, 460))\n    ax_conv = Axis(fig_conv[1, 1]; title = \"Hailstone paths for 1 … \" * string(graph_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    top = Int64(graph_start_value)\n    n0 = Int64(1)\n    while n0 <= top\n        #= none:16 =#\n        seq = collatz_hailstone(n0, Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:22 =#\n        cx = Float64[]\n        #= none:23 =#\n        cy = Float64[]\n        #= none:24 =#\n        i = 1\n        #= none:25 =#\n        for v = seq\n            #= none:26 =#\n            push!(cx, Float64(i))\n            #= none:27 =#\n            push!(cy, Float64(v))\n            #= none:28 =#\n            i += 1\n            #= none:29 =#\n        end\n        #= none:30 =#\n        shade = Float64(n0 % 7) / 7.0\n        #= none:31 =#\n        lines!(ax_conv, cx, cy; color = (0.25 + 0.5shade, 0.45, 0.85 - 0.4shade, 0.55), linewidth = 1.5)\n        #= none:34 =#\n        n0 += 1\n        #= none:35 =#\n    end\n    var\"##cellval#481\" = fig_conv\n    return (PlutoIslands._html_body)(var\"##cellval#481\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#498\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
         "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "\"#000000\"",
+            "false",
+            "2",
+            "3",
+            "1",
+            "false",
+            "19.8",
+            "20",
+            "80.0",
+            "false",
+            "\"#e68282\"",
+            "5.0",
+            "9.9",
+            "false",
+            "700.0",
+            "500.0",
+            "249.7",
+            "700.0"
+          ]
         ]
       },
       {
         "cell_id": "66fe673a-7679-4c55-bf59-146a8dd1241c",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    hailstone_seq = if \"Hailstone Sequence\" ∈ generalize_collatz\n            hailstone_sequence(hailstone_params.start_value; collatz_parameters..., verbose = false)\n        else\n            hailstone_sequence(hailstone_params.start_value; verbose = false)\n        end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_params.start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    hail_x = Float64[]\n    hail_y = Float64[]\n    for (i, v) = enumerate(hailstone_seq)\n        #= none:13 =#\n        push!(hail_x, Float64(i))\n        #= none:14 =#\n        push!(hail_y, Float64(v))\n        #= none:15 =#\n    end\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#460\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#460\")\nend",
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    hail_x = Float64[]\n    hail_y = Float64[]\n    let\n        #= none:5 =#\n        seq = collatz_hailstone(Int64(hailstone_start_value), Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:11 =#\n        i = 1\n        #= none:12 =#\n        for v = seq\n            #= none:13 =#\n            push!(hail_x, Float64(i))\n            #= none:14 =#\n            push!(hail_y, Float64(v))\n            #= none:15 =#\n            i += 1\n            #= none:16 =#\n        end\n    end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#482\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#482\")\nend",
         "golden": [
-          "ERR:UndefVarError: `generalize_collatz` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#498\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -741,86 +741,69 @@
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
+            "\"#000000\"",
             "false",
-            "\"MyCoolVisualization\"",
-            "[\"#e68282\", \"#000000\"]",
-            "(random_shade = false, vary_shade = false, edmund_style = false, chris_style = false)",
-            "(num_traject = 1000.0, line_length = 20, turn_scale = 9.9)",
-            "(init_angle = 19.8, x_start = 249.7, y_start = 700.0, stroke_width = 5.0)",
-            "(window_height = 700.0, window_width = 500.0)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "6693800b-e2bc-46e4-b5f8-004184ef472b",
-        "eval_err": "syntax: type of \"record\" declared in inner scope",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    md\"!!! info \\\"Numerical Packages\\\"\n\t[Collatz](https://juliapackages.com/p/collatz): This package provide the methods to generate the hailstone sequence, the tree graph and stopping time for the collatz conjecture. \n\n\t[Graphs](https://www.juliapackages.com/p/graphs): Used to deal with creating and modifying graphs. \n\n\t[FixedPointNumbers](https://www.juliapackages.com/p/fixedpointnumbers): Package to deal with fixed point number, only used to handle colors.\n\"\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  key::Int64, previous::Collatz._CC.CC, depth::Int=0)\\n\\nTo handle the case where the search hits a cycle and previous is of type Collatz._CC.CC\\n\\n## Args \\n\\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Collatz._CC.CC`: The cycle value.\\n- `depth::Int`: The current depth of the search  \\n\\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, key::Int64, previous::Collatz._CC.CC, depth::Int = 0)\n            #= none:15 =#\n            #= none:18 =#\n            previous_index = findfirst((x->begin\n                            #= none:18 =#\n                            x == previous\n                        end), map((x->begin\n                                #= none:18 =#\n                                x[2]\n                            end), record))\n            #= none:21 =#\n            if isnothing(previous_index)\n                \"\"\n            else\n                add_edge!(g, previous, length(record) + 1)\n            end\n            #= none:24 =#\n            push!(record, (depth, key))\n            #= none:25 =#\n            return\n        end\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  tree::Dict, previous::Number=collect(keys(tree))[1], depth::Int=0)\\n\\t\\nThis function is used to explore the tree return by `tree_graph` from Collatz.jl and modify the graph g given as input. \\n\\n## Args \\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values. Each value is stored as (depth, value) in order to keep track of what depth the value was encountered\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Number`: The number passed by the previous call to the function \\n- `depth::Int`: The current depth of the search  \\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, tree::Dict, previous::Number = (collect(keys(tree)))[1], depth::Int = 0)\n            #= none:13 =#\n            #= none:16 =#\n            for key = keys(tree)\n                #= none:18 =#\n                add_vertex!(g)\n                #= none:21 =#\n                previous_index = findfirst((x->begin\n                                #= none:21 =#\n                                x == previous\n                            end), map((x->begin\n                                    #= none:21 =#\n                                    x[2]\n                                end), record))\n                #= none:24 =#\n                if isnothing(previous_index)\n                    \"\"\n                else\n                    add_edge!(g, previous_index, length(record) + 1)\n                end\n                #= none:27 =#\n                if key isa Number\n                    #= none:28 =#\n                    push!(record, (depth, key))\n                end\n                #= none:32 =#\n                descend_tree!(g, record, tree[key], key, depth + 1)\n                #= none:33 =#\n            end\n        end\n    #= none:1 =# Core.@doc \"\\tmake_collatz_graph(initial_value::Int, max_orbit_distance::Int; P=2, a=3, b=1)\\n\\nThis function returns a graph that represent the different branches that each number takes.\\n\\n## Args\\n\\n- `initial_value::Integer`: The starting value of the directed tree graph.\\n\\n- `max_orbit_distance::Integer`: Degree of seperation between the initial value and each value encountered. \\n\\n## Kwargs\\n\\n- ```P::Integer=2```: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n\\n- ```a::Integer=3```: Factor by which to multiply n.\\n\\n- ```b::Integer=1```: Value to add to the scaled value of n.\\n\\n\\n## See also\\n[`tree_graph`](@ref)\\n\" function make_collatz_graph(initial_value::Int, max_orbit_distance::Int; P = 2, a = 3, b = 1)\n            #= none:24 =#\n            #= none:25 =#\n            g = SimpleGraph()\n            #= none:26 =#\n            record::Array{Tuple{Number, Number}} = []\n            #= none:27 =#\n            tree = tree_graph(initial_value, max_orbit_distance; P, a, b)\n            #= none:28 =#\n            descend_tree!(g, record, tree)\n            #= none:29 =#\n            return (g, record)\n        end\n    (g, record) = if \"Graph\" ∈ generalize_collatz\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; collatz_parameters...)\n        else\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; )\n        end\n    graph_colors = [RGB(rescale((record[i])[1], 1, graph_parameters.orbit, 1, 0.3), 0.1, 0.3) for i = 1:nv(g)]\n    var\"##cellval#461\" = graph_colors\n    return (PlutoIslands._plain_body)(var\"##cellval#461\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "image/svg+xml",
-        "reasons": [
-          "unsupported output mime image/svg+xml in v0 (text/plain & md-text/html only)"
-        ]
-      },
-      {
-        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    generalize_collatz\n    stopping_times = Dict()\n    newValues = filter((x->begin\n                    #= none:3 =#\n                    !(x ∈ keys(stopping_times))\n                end), collect(range(1, stopping_parameters.ub, step = 1)))\n    for newValue = newValues\n        #= none:7 =#\n        push!(stopping_times, newValue => if \"Stopping Time\" ∈ generalize_collatz\n                    stopping_time(newValue; collatz_parameters..., total_stopping_time = true)\n                else\n                    stopping_time(newValue, total_stopping_time = true)\n                end)\n        #= none:10 =#\n    end\n    st_vals = collect(values(sort(filter((key->begin\n                                #= none:14 =#\n                                key[1] ∈ range(1, stopping_parameters.ub, step = 1)\n                            end), stopping_times))))\n    st_x = Float64[]\n    st_y = Float64[]\n    for (i, v) = enumerate(st_vals)\n        #= none:21 =#\n        push!(st_x, Float64(i))\n        #= none:22 =#\n        push!(st_y, Float64(v))\n        #= none:23 =#\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_parameters.ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#463\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#463\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `generalize_collatz` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
+            "2",
+            "3",
+            "1",
             "false",
-            "\"MyCoolVisualization\"",
-            "[\"#e68282\", \"#000000\"]",
-            "(random_shade = false, vary_shade = false, edmund_style = false, chris_style = false)",
-            "(num_traject = 1000.0, line_length = 20, turn_scale = 9.9)",
-            "(init_angle = 19.8, x_start = 249.7, y_start = 700.0, stroke_width = 5.0)",
-            "(window_height = 700.0, window_width = 500.0)"
+            "19.8",
+            "20",
+            "80.0",
+            "false",
+            "\"#e68282\"",
+            "5.0",
+            "9.9",
+            "false",
+            "700.0",
+            "500.0",
+            "249.7",
+            "700.0"
           ]
         ]
       },
       {
         "cell_id": "50a423ad-ca90-4015-9ef6-577f60e4efe7",
-        "eval_err": "LoadError: UndefVarError: `@htl` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports.\nHint: a global variable of this name also exists in HypertextLiteral.\nin expression starting at none:2",
+        "eval_err": "LoadError: UndefVarError: `@htl` not defined in `Main.var\"##hv#498\"`\nSuggestion: check for spelling errors or missing imports.\nHint: a global variable of this name also exists in HypertextLiteral.\nin expression starting at none:2",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    var\"##cellval#464\" = #= none:2 =# @htl(\"<div class=\\\"slider_group sidebar-left\\\">\\n\\t<div class=\\\"on_big_show\\\">\\n\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t$(viz_sliders)\\n\\t\\t</div>\\n\\n\\t</div>\\t\\n</div>\\n\\n<div class=\\\"slider_group sidebar-right\\\">\\n\\t<div class=\\\"on_small_show\\\">\\n\\t\\t<div class=\\\"slider_group_inner \\\">\\n\\t\\t\\t$(viz_sliders)\\n\\t\\t</div>\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(viz_specs_sliders)\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(colors_sliders)\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(viz_extra_sliders)\\n\\t</div>\\n</div>\\n<div class=\\\"sidebar-bottom\\\">\\n\\t<div class=\\\"on_tiny_show\\\">\\n\\t\\t<div class=\\\"slider_group\\\">\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\n\\t\\t\\t<div class=\\\"slider_group_inner \\\">\\n\\t\\t\\t\\t$(viz_sliders)\\n\\t\\t\\t</div>\\n\\t\\t</div>\\n\\t\\n\\t\\t<div class=\\\"slider_group\\\">\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_specs_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(colors_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_extra_sliders)\\n\\t\\t\\t</div>\\n\\t\\t</div>\\n\\t</div>\\n\\t<div>\\n\\t\\t\\t\\n\\t</div>\\n</div>\\n\")\n    return (PlutoIslands._html_body)(var\"##cellval#464\")\nend",
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    var\"##cellval#483\" = #= none:2 =# @htl(\"<div class=\\\"slider_group sidebar-left\\\">\\n\\t<div class=\\\"on_big_show\\\">\\n\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t$(viz_sliders)\\n\\t\\t</div>\\n\\n\\t</div>\\t\\n</div>\\n\\n<div class=\\\"slider_group sidebar-right\\\">\\n\\t<div class=\\\"on_small_show\\\">\\n\\t\\t<div class=\\\"slider_group_inner \\\">\\n\\t\\t\\t$(viz_sliders)\\n\\t\\t</div>\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(viz_specs_sliders)\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(colors_sliders)\\n\\t</div>\\n\\n\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t$(viz_extra_sliders)\\n\\t</div>\\n</div>\\n<div class=\\\"sidebar-bottom\\\">\\n\\t<div class=\\\"on_tiny_show\\\">\\n\\t\\t<div class=\\\"slider_group\\\">\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\n\\t\\t\\t<div class=\\\"slider_group_inner \\\">\\n\\t\\t\\t\\t$(viz_sliders)\\n\\t\\t\\t</div>\\n\\t\\t</div>\\n\\t\\n\\t\\t<div class=\\\"slider_group\\\">\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_specs_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(colors_sliders)\\n\\t\\t\\t</div>\\n\\t\\t\\t<div class=\\\"slider_group_inner\\\">\\n\\t\\t\\t\\t$(viz_extra_sliders)\\n\\t\\t\\t</div>\\n\\t\\t</div>\\n\\t</div>\\n\\t<div>\\n\\t\\t\\t\\n\\t</div>\\n</div>\\n\")\n    return (PlutoIslands._html_body)(var\"##cellval#483\")\nend",
         "kind": "string",
         "mime": "text/html",
         "reasons": []
       },
       {
         "cell_id": "6d225dce-3362-4f5d-bba9-0b5312f6be5a",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    #= none:1 =# @unpack (window_height, window_width) = window_size_parameters\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#465\" = interactive_viz\n    return (PlutoIslands._plain_body)(var\"##cellval#465\")\nend",
+        "fn_src": "function (background_color::String, chris_style::Bool, collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, edmund_style::Bool, init_angle::Float64, line_length::Int64, num_traject::Float64, random_shade::Bool, stroke_color::String, stroke_width::Float64, turn_scale::Float64, vary_shade::Bool, window_height::Float64, window_width::Float64, x_start::Float64, y_start::Float64)\n    viz_trajectories = Vector{Vector{Int64}}()\n    let\n        #= none:11 =#\n        Pv = Int64(collatz_P)\n        #= none:12 =#\n        av = Int64(collatz_a)\n        #= none:13 =#\n        bv = Int64(collatz_b)\n        #= none:14 =#\n        n0 = Int64(1)\n        #= none:15 =#\n        ntop = Int64(round(Int, num_traject))\n        #= none:16 =#\n        while n0 <= ntop\n            #= none:17 =#\n            push!(viz_trajectories, reverse(collatz_hailstone(n0, Pv, av, bv, Int64(1000))))\n            #= none:18 =#\n            n0 += 1\n            #= none:19 =#\n        end\n    end\n    interactive_viz = let\n            #= none:26 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:27 =#\n            ax = Axis(fig[1, 1])\n            #= none:28 =#\n            hidedecorations!(ax)\n            #= none:29 =#\n            hidespines!(ax)\n            #= none:31 =#\n            base_r = Float64(red(stroke_color))\n            #= none:32 =#\n            base_g = Float64(green(stroke_color))\n            #= none:33 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:35 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:36 =#\n                xs = Float64[]\n                #= none:37 =#\n                ys = Float64[]\n                #= none:38 =#\n                x = Float64(x_start)\n                #= none:39 =#\n                y = Float64(y_start)\n                #= none:40 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:41 =#\n                push!(xs, x)\n                #= none:42 =#\n                push!(ys, y)\n                #= none:43 =#\n                for v = seq\n                    #= none:44 =#\n                    if chris_style\n                        #= none:45 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:46 =# mod(v, 2) == 0\n                        #= none:47 =#\n                        θ += turn_scale\n                    else\n                        #= none:49 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:51 =#\n                    x += line_length * cosd(θ)\n                    #= none:52 =#\n                    y += line_length * sind(θ)\n                    #= none:53 =#\n                    push!(xs, x)\n                    #= none:54 =#\n                    push!(ys, y)\n                    #= none:55 =#\n                end\n                #= none:59 =#\n                col = if random_shade\n                        #= none:60 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:63 =# vary_shade\n                        #= none:64 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:65 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:69 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:71 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:72 =#\n            end\n            #= none:73 =#\n            fig\n        end\n    var\"##cellval#484\" = interactive_viz\n    return (PlutoIslands._html_body)(var\"##cellval#484\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#498\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
         "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "1b48b435-e959-477f-a8d2-3507da73fc28",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, filename::String, viz_colors_options::Vector{String}, viz_extra_options::@NamedTuple{random_shade::Bool, vary_shade::Bool, edmund_style::Bool, chris_style::Bool}, viz_parameters::@NamedTuple{num_traject::Float64, line_length::Int64, turn_scale::Float64}, viz_specs_parameters::@NamedTuple{init_angle::Float64, x_start::Float64, y_start::Float64, stroke_width::Float64}, window_size_parameters::@NamedTuple{window_height::Float64, window_width::Float64})\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    #= none:1 =# @unpack (window_height, window_width) = window_size_parameters\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#466\" = #= none:1 =# @htl(\"$(PlutoUI.DownloadButton(\"<!doctype html><html><body>\" * html_snippet(interactive_viz) * \"</body></html>\", if filename == \"\"\n            \"MyCoolVisualization\"\n        else\n            filename\n        end * \".html\"))\\n\")\n    return (PlutoIslands._plain_body)(var\"##cellval#466\")\nend",
-        "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "\"#000000\"",
+            "false",
+            "2",
+            "3",
+            "1",
+            "false",
+            "19.8",
+            "20",
+            "80.0",
+            "false",
+            "\"#e68282\"",
+            "5.0",
+            "9.9",
+            "false",
+            "700.0",
+            "500.0",
+            "249.7",
+            "700.0"
+          ]
+        ]
       }
     ],
     "group": 2,
@@ -828,108 +811,126 @@
     "group_reasons": [],
     "notebook": "CollatzConjecture.jl",
     "preamble": [
+      "function collatz_stopping_time(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:7 =#\n    #= none:8 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:9 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:10 =#\n    steps = 0\n    #= none:11 =#\n    while n != 1 && steps < maxlen\n        #= none:12 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:13 =#\n        steps += 1\n        #= none:14 =#\n        if n < 1\n            #= none:15 =#\n            break\n        end\n        #= none:17 =#\n    end\n    #= none:18 =#\n    return steps\nend",
       "using Collatz",
       "using Graphs",
       "using FixedPointNumbers",
       "using PlutoUI",
-      "import PlutoUI: combine",
       "using HypertextLiteral: @htl",
       "using Parameters",
       "using WasmMakie",
       "using Colors",
       "using Luxor",
       "using Karnak, NetworkLayout",
-      "using ImageIO, ImageShow"
+      "using ImageIO, ImageShow",
+      "function collatz_hailstone(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:8 =#\n    #= none:9 =#\n    out = Int64[]\n    #= none:10 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:11 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:12 =#\n    push!(out, n)\n    #= none:13 =#\n    steps = 0\n    #= none:14 =#\n    while n != 1 && steps < maxlen\n        #= none:15 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:16 =#\n        push!(out, n)\n        #= none:17 =#\n        steps += 1\n        #= none:18 =#\n        if n < 1\n            #= none:19 =#\n            break\n        end\n        #= none:21 =#\n    end\n    #= none:22 =#\n    return out\nend"
     ]
   },
   {
     "argtypes": [
-      "@NamedTuple{P::Int64, a::Int64, b::Int64}",
-      "Bool",
-      "Vector{String}",
-      "@NamedTuple{start_value::Int64, orbit::Int64}",
-      "@NamedTuple{start_value::Int64}",
-      "@NamedTuple{ub::Int64}"
+      "Int64",
+      "Int64",
+      "Int64",
+      "Int64"
     ],
     "bonds": [
-      "collatz_parameters",
-      "do_generalize_collatz",
-      "generalize_collatz",
-      "graph_parameters",
-      "hailstone_params",
-      "stopping_parameters"
+      "collatz_P",
+      "collatz_a",
+      "collatz_b",
+      "graph_start_value"
     ],
     "cells": [
       {
-        "cell_id": "af0c36ee-0534-4143-b59b-4ee041ef0f04",
+        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64})\n    var\"##cellval#467\" = if do_generalize_collatz\n            md\"!!! warning \\\"Divergence\\\"\n\tSome parameters will not behave as the traditional problem and will lead to some numbers diverging up to infinity. In that case, the calculations will stop at a stopping time of 1000. However, this still can still result in high latency so beware! .\n\"\n        else\n            md\"\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#467\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, graph_start_value::Int64)\n    st_x = Float64[]\n    st_y = Float64[]\n    let\n        #= none:8 =#\n        ub = Int64(stopping_ub)\n        #= none:9 =#\n        Pv = Int64(collatz_P)\n        #= none:10 =#\n        av = Int64(collatz_a)\n        #= none:11 =#\n        bv = Int64(collatz_b)\n        #= none:12 =#\n        n0 = Int64(1)\n        #= none:13 =#\n        while n0 <= ub\n            #= none:14 =#\n            push!(st_x, Float64(n0))\n            #= none:15 =#\n            push!(st_y, Float64(collatz_stopping_time(n0, Pv, av, bv, Int64(1000))))\n            #= none:16 =#\n            n0 += 1\n            #= none:17 =#\n        end\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#485\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#485\")\nend",
         "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported"
+          "ERR:UndefVarError: `stopping_ub` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `stopping_ub` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `stopping_ub` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `stopping_ub` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
         "reasons": [],
-        "rettype": "Union{}",
+        "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)",
-            "(start_value = 15,)",
-            "(ub = 1000,)"
+            "2",
+            "3",
+            "1",
+            "12"
+          ],
+          [
+            "9",
+            "3",
+            "1",
+            "12"
+          ],
+          [
+            "2",
+            "10",
+            "1",
+            "12"
+          ],
+          [
+            "2",
+            "3",
+            "10",
+            "12"
           ]
         ]
       },
       {
-        "cell_id": "1c3f1bea-f1ba-4d64-90ad-584391c01da5",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
-      {
-        "cell_id": "5f074850-b967-4de5-8ca3-b85a74052499",
+        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64})\n    generalize_collatz\n    stopping_times = Dict()\n    var\"##cellval#468\" = stopping_times\n    return (PlutoIslands._plain_body)(var\"##cellval#468\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, graph_start_value::Int64)\n    fig_conv = Figure(size = (700, 460))\n    ax_conv = Axis(fig_conv[1, 1]; title = \"Hailstone paths for 1 … \" * string(graph_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    top = Int64(graph_start_value)\n    n0 = Int64(1)\n    while n0 <= top\n        #= none:16 =#\n        seq = collatz_hailstone(n0, Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:22 =#\n        cx = Float64[]\n        #= none:23 =#\n        cy = Float64[]\n        #= none:24 =#\n        i = 1\n        #= none:25 =#\n        for v = seq\n            #= none:26 =#\n            push!(cx, Float64(i))\n            #= none:27 =#\n            push!(cy, Float64(v))\n            #= none:28 =#\n            i += 1\n            #= none:29 =#\n        end\n        #= none:30 =#\n        shade = Float64(n0 % 7) / 7.0\n        #= none:31 =#\n        lines!(ax_conv, cx, cy; color = (0.25 + 0.5shade, 0.45, 0.85 - 0.4shade, 0.55), linewidth = 1.5)\n        #= none:34 =#\n        n0 += 1\n        #= none:35 =#\n    end\n    var\"##cellval#486\" = fig_conv\n    return (PlutoIslands._html_body)(var\"##cellval#486\")\nend",
         "golden": [
-          "\"Dict{Any, Any}()\""
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
-        "mime": "text/plain",
+        "mime": "text/html",
         "reasons": [],
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)",
-            "(start_value = 15,)",
-            "(ub = 1000,)"
+            "2",
+            "3",
+            "1",
+            "12"
+          ],
+          [
+            "9",
+            "3",
+            "1",
+            "12"
+          ],
+          [
+            "2",
+            "10",
+            "1",
+            "12"
+          ],
+          [
+            "2",
+            "3",
+            "10",
+            "12"
           ]
-        ]
-      },
-      {
-        "cell_id": "f21f1e3e-a3ab-458e-a101-ce824731f0b6",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
         ]
       },
       {
         "cell_id": "66fe673a-7679-4c55-bf59-146a8dd1241c",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64})\n    hailstone_seq = if \"Hailstone Sequence\" ∈ generalize_collatz\n            hailstone_sequence(hailstone_params.start_value; collatz_parameters..., verbose = false)\n        else\n            hailstone_sequence(hailstone_params.start_value; verbose = false)\n        end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_params.start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    hail_x = Float64[]\n    hail_y = Float64[]\n    for (i, v) = enumerate(hailstone_seq)\n        #= none:13 =#\n        push!(hail_x, Float64(i))\n        #= none:14 =#\n        push!(hail_y, Float64(v))\n        #= none:15 =#\n    end\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#469\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#469\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, graph_start_value::Int64)\n    hail_x = Float64[]\n    hail_y = Float64[]\n    let\n        #= none:5 =#\n        seq = collatz_hailstone(Int64(hailstone_start_value), Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:11 =#\n        i = 1\n        #= none:12 =#\n        for v = seq\n            #= none:13 =#\n            push!(hail_x, Float64(i))\n            #= none:14 =#\n            push!(hail_y, Float64(v))\n            #= none:15 =#\n            i += 1\n            #= none:16 =#\n        end\n    end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#487\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#487\")\nend",
         "golden": [
-          "ERR:UndefVarError: `hailstone_sequence` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -937,73 +938,71 @@
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)",
-            "(start_value = 15,)",
-            "(ub = 1000,)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "6693800b-e2bc-46e4-b5f8-004184ef472b",
-        "eval_err": "syntax: type of \"record\" declared in inner scope",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64})\n    md\"!!! info \\\"Numerical Packages\\\"\n\t[Collatz](https://juliapackages.com/p/collatz): This package provide the methods to generate the hailstone sequence, the tree graph and stopping time for the collatz conjecture. \n\n\t[Graphs](https://www.juliapackages.com/p/graphs): Used to deal with creating and modifying graphs. \n\n\t[FixedPointNumbers](https://www.juliapackages.com/p/fixedpointnumbers): Package to deal with fixed point number, only used to handle colors.\n\"\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  key::Int64, previous::Collatz._CC.CC, depth::Int=0)\\n\\nTo handle the case where the search hits a cycle and previous is of type Collatz._CC.CC\\n\\n## Args \\n\\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Collatz._CC.CC`: The cycle value.\\n- `depth::Int`: The current depth of the search  \\n\\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, key::Int64, previous::Collatz._CC.CC, depth::Int = 0)\n            #= none:15 =#\n            #= none:18 =#\n            previous_index = findfirst((x->begin\n                            #= none:18 =#\n                            x == previous\n                        end), map((x->begin\n                                #= none:18 =#\n                                x[2]\n                            end), record))\n            #= none:21 =#\n            if isnothing(previous_index)\n                \"\"\n            else\n                add_edge!(g, previous, length(record) + 1)\n            end\n            #= none:24 =#\n            push!(record, (depth, key))\n            #= none:25 =#\n            return\n        end\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  tree::Dict, previous::Number=collect(keys(tree))[1], depth::Int=0)\\n\\t\\nThis function is used to explore the tree return by `tree_graph` from Collatz.jl and modify the graph g given as input. \\n\\n## Args \\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values. Each value is stored as (depth, value) in order to keep track of what depth the value was encountered\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Number`: The number passed by the previous call to the function \\n- `depth::Int`: The current depth of the search  \\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, tree::Dict, previous::Number = (collect(keys(tree)))[1], depth::Int = 0)\n            #= none:13 =#\n            #= none:16 =#\n            for key = keys(tree)\n                #= none:18 =#\n                add_vertex!(g)\n                #= none:21 =#\n                previous_index = findfirst((x->begin\n                                #= none:21 =#\n                                x == previous\n                            end), map((x->begin\n                                    #= none:21 =#\n                                    x[2]\n                                end), record))\n                #= none:24 =#\n                if isnothing(previous_index)\n                    \"\"\n                else\n                    add_edge!(g, previous_index, length(record) + 1)\n                end\n                #= none:27 =#\n                if key isa Number\n                    #= none:28 =#\n                    push!(record, (depth, key))\n                end\n                #= none:32 =#\n                descend_tree!(g, record, tree[key], key, depth + 1)\n                #= none:33 =#\n            end\n        end\n    #= none:1 =# Core.@doc \"\\tmake_collatz_graph(initial_value::Int, max_orbit_distance::Int; P=2, a=3, b=1)\\n\\nThis function returns a graph that represent the different branches that each number takes.\\n\\n## Args\\n\\n- `initial_value::Integer`: The starting value of the directed tree graph.\\n\\n- `max_orbit_distance::Integer`: Degree of seperation between the initial value and each value encountered. \\n\\n## Kwargs\\n\\n- ```P::Integer=2```: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n\\n- ```a::Integer=3```: Factor by which to multiply n.\\n\\n- ```b::Integer=1```: Value to add to the scaled value of n.\\n\\n\\n## See also\\n[`tree_graph`](@ref)\\n\" function make_collatz_graph(initial_value::Int, max_orbit_distance::Int; P = 2, a = 3, b = 1)\n            #= none:24 =#\n            #= none:25 =#\n            g = SimpleGraph()\n            #= none:26 =#\n            record::Array{Tuple{Number, Number}} = []\n            #= none:27 =#\n            tree = tree_graph(initial_value, max_orbit_distance; P, a, b)\n            #= none:28 =#\n            descend_tree!(g, record, tree)\n            #= none:29 =#\n            return (g, record)\n        end\n    (g, record) = if \"Graph\" ∈ generalize_collatz\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; collatz_parameters...)\n        else\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; )\n        end\n    graph_colors = [RGB(rescale((record[i])[1], 1, graph_parameters.orbit, 1, 0.3), 0.1, 0.3) for i = 1:nv(g)]\n    var\"##cellval#470\" = graph_colors\n    return (PlutoIslands._plain_body)(var\"##cellval#470\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "image/svg+xml",
-        "reasons": [
-          "unsupported output mime image/svg+xml in v0 (text/plain & md-text/html only)"
-        ]
-      },
-      {
-        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64})\n    generalize_collatz\n    stopping_times = Dict()\n    newValues = filter((x->begin\n                    #= none:3 =#\n                    !(x ∈ keys(stopping_times))\n                end), collect(range(1, stopping_parameters.ub, step = 1)))\n    for newValue = newValues\n        #= none:7 =#\n        push!(stopping_times, newValue => if \"Stopping Time\" ∈ generalize_collatz\n                    stopping_time(newValue; collatz_parameters..., total_stopping_time = true)\n                else\n                    stopping_time(newValue, total_stopping_time = true)\n                end)\n        #= none:10 =#\n    end\n    st_vals = collect(values(sort(filter((key->begin\n                                #= none:14 =#\n                                key[1] ∈ range(1, stopping_parameters.ub, step = 1)\n                            end), stopping_times))))\n    st_x = Float64[]\n    st_y = Float64[]\n    for (i, v) = enumerate(st_vals)\n        #= none:21 =#\n        push!(st_x, Float64(i))\n        #= none:22 =#\n        push!(st_y, Float64(v))\n        #= none:23 =#\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_parameters.ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#472\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#472\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `stopping_time` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
+            "2",
+            "3",
+            "1",
+            "12"
+          ],
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)",
-            "(start_value = 15,)",
-            "(ub = 1000,)"
+            "9",
+            "3",
+            "1",
+            "12"
+          ],
+          [
+            "2",
+            "10",
+            "1",
+            "12"
+          ],
+          [
+            "2",
+            "3",
+            "10",
+            "12"
           ]
         ]
       },
       {
         "cell_id": "6d225dce-3362-4f5d-bba9-0b5312f6be5a",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64})\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    window_height = $(QuoteNode(700.0))\n    window_width = $(QuoteNode(500.0))\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#473\" = interactive_viz\n    return (PlutoIslands._plain_body)(var\"##cellval#473\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, graph_start_value::Int64)\n    viz_trajectories = Vector{Vector{Int64}}()\n    let\n        #= none:11 =#\n        Pv = Int64(collatz_P)\n        #= none:12 =#\n        av = Int64(collatz_a)\n        #= none:13 =#\n        bv = Int64(collatz_b)\n        #= none:14 =#\n        n0 = Int64(1)\n        #= none:15 =#\n        ntop = Int64(round(Int, num_traject))\n        #= none:16 =#\n        while n0 <= ntop\n            #= none:17 =#\n            push!(viz_trajectories, reverse(collatz_hailstone(n0, Pv, av, bv, Int64(1000))))\n            #= none:18 =#\n            n0 += 1\n            #= none:19 =#\n        end\n    end\n    interactive_viz = let\n            #= none:26 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:27 =#\n            ax = Axis(fig[1, 1])\n            #= none:28 =#\n            hidedecorations!(ax)\n            #= none:29 =#\n            hidespines!(ax)\n            #= none:31 =#\n            base_r = Float64(red(stroke_color))\n            #= none:32 =#\n            base_g = Float64(green(stroke_color))\n            #= none:33 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:35 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:36 =#\n                xs = Float64[]\n                #= none:37 =#\n                ys = Float64[]\n                #= none:38 =#\n                x = Float64(x_start)\n                #= none:39 =#\n                y = Float64(y_start)\n                #= none:40 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:41 =#\n                push!(xs, x)\n                #= none:42 =#\n                push!(ys, y)\n                #= none:43 =#\n                for v = seq\n                    #= none:44 =#\n                    if chris_style\n                        #= none:45 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:46 =# mod(v, 2) == 0\n                        #= none:47 =#\n                        θ += turn_scale\n                    else\n                        #= none:49 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:51 =#\n                    x += line_length * cosd(θ)\n                    #= none:52 =#\n                    y += line_length * sind(θ)\n                    #= none:53 =#\n                    push!(xs, x)\n                    #= none:54 =#\n                    push!(ys, y)\n                    #= none:55 =#\n                end\n                #= none:59 =#\n                col = if random_shade\n                        #= none:60 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:63 =# vary_shade\n                        #= none:64 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:65 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:69 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:71 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:72 =#\n            end\n            #= none:73 =#\n            fig\n        end\n    var\"##cellval#488\" = interactive_viz\n    return (PlutoIslands._html_body)(var\"##cellval#488\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#499\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
         "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "1b48b435-e959-477f-a8d2-3507da73fc28",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64}, hailstone_params::@NamedTuple{start_value::Int64}, stopping_parameters::@NamedTuple{ub::Int64})\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    window_height = $(QuoteNode(700.0))\n    window_width = $(QuoteNode(500.0))\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#474\" = #= none:1 =# @htl(\"$(PlutoUI.DownloadButton(\"<!doctype html><html><body>\" * html_snippet(interactive_viz) * \"</body></html>\", if filename == \"\"\n            \"MyCoolVisualization\"\n        else\n            filename\n        end * \".html\"))\\n\")\n    return (PlutoIslands._plain_body)(var\"##cellval#474\")\nend",
-        "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "2",
+            "3",
+            "1",
+            "12"
+          ],
+          [
+            "9",
+            "3",
+            "1",
+            "12"
+          ],
+          [
+            "2",
+            "10",
+            "1",
+            "12"
+          ],
+          [
+            "2",
+            "3",
+            "10",
+            "12"
+          ]
+        ]
       }
     ],
     "group": 3,
@@ -1011,100 +1010,81 @@
     "group_reasons": [],
     "notebook": "CollatzConjecture.jl",
     "preamble": [
+      "function collatz_stopping_time(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:7 =#\n    #= none:8 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:9 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:10 =#\n    steps = 0\n    #= none:11 =#\n    while n != 1 && steps < maxlen\n        #= none:12 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:13 =#\n        steps += 1\n        #= none:14 =#\n        if n < 1\n            #= none:15 =#\n            break\n        end\n        #= none:17 =#\n    end\n    #= none:18 =#\n    return steps\nend",
       "using Collatz",
       "using Graphs",
       "using FixedPointNumbers",
       "using PlutoUI",
-      "import PlutoUI: combine",
       "using HypertextLiteral: @htl",
       "using Parameters",
       "using WasmMakie",
       "using Colors",
       "using Luxor",
       "using Karnak, NetworkLayout",
-      "using ImageIO, ImageShow"
+      "using ImageIO, ImageShow",
+      "function collatz_hailstone(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:8 =#\n    #= none:9 =#\n    out = Int64[]\n    #= none:10 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:11 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:12 =#\n    push!(out, n)\n    #= none:13 =#\n    steps = 0\n    #= none:14 =#\n    while n != 1 && steps < maxlen\n        #= none:15 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:16 =#\n        push!(out, n)\n        #= none:17 =#\n        steps += 1\n        #= none:18 =#\n        if n < 1\n            #= none:19 =#\n            break\n        end\n        #= none:21 =#\n    end\n    #= none:22 =#\n    return out\nend"
     ]
   },
   {
     "argtypes": [
-      "@NamedTuple{P::Int64, a::Int64, b::Int64}",
-      "Bool",
-      "Vector{String}",
-      "@NamedTuple{start_value::Int64, orbit::Int64}"
+      "Int64",
+      "Int64",
+      "Int64",
+      "Int64"
     ],
     "bonds": [
-      "collatz_parameters",
-      "do_generalize_collatz",
-      "generalize_collatz",
-      "graph_parameters"
+      "collatz_P",
+      "collatz_a",
+      "collatz_b",
+      "hailstone_start_value"
     ],
     "cells": [
       {
-        "cell_id": "af0c36ee-0534-4143-b59b-4ee041ef0f04",
+        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64})\n    var\"##cellval#475\" = if do_generalize_collatz\n            md\"!!! warning \\\"Divergence\\\"\n\tSome parameters will not behave as the traditional problem and will lead to some numbers diverging up to infinity. In that case, the calculations will stop at a stopping time of 1000. However, this still can still result in high latency so beware! .\n\"\n        else\n            md\"\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#475\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, hailstone_start_value::Int64)\n    st_x = Float64[]\n    st_y = Float64[]\n    let\n        #= none:8 =#\n        ub = Int64(stopping_ub)\n        #= none:9 =#\n        Pv = Int64(collatz_P)\n        #= none:10 =#\n        av = Int64(collatz_a)\n        #= none:11 =#\n        bv = Int64(collatz_b)\n        #= none:12 =#\n        n0 = Int64(1)\n        #= none:13 =#\n        while n0 <= ub\n            #= none:14 =#\n            push!(st_x, Float64(n0))\n            #= none:15 =#\n            push!(st_y, Float64(collatz_stopping_time(n0, Pv, av, bv, Int64(1000))))\n            #= none:16 =#\n            n0 += 1\n            #= none:17 =#\n        end\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#489\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#489\")\nend",
         "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported"
+          "ERR:UndefVarError: `stopping_ub` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
         "reasons": [],
-        "rettype": "Union{}",
+        "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)"
+            "2",
+            "3",
+            "1",
+            "15"
           ]
         ]
       },
       {
-        "cell_id": "1c3f1bea-f1ba-4d64-90ad-584391c01da5",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
-      {
-        "cell_id": "5f074850-b967-4de5-8ca3-b85a74052499",
+        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64})\n    generalize_collatz\n    stopping_times = Dict()\n    var\"##cellval#476\" = stopping_times\n    return (PlutoIslands._plain_body)(var\"##cellval#476\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, hailstone_start_value::Int64)\n    fig_conv = Figure(size = (700, 460))\n    ax_conv = Axis(fig_conv[1, 1]; title = \"Hailstone paths for 1 … \" * string(graph_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    top = Int64(graph_start_value)\n    n0 = Int64(1)\n    while n0 <= top\n        #= none:16 =#\n        seq = collatz_hailstone(n0, Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:22 =#\n        cx = Float64[]\n        #= none:23 =#\n        cy = Float64[]\n        #= none:24 =#\n        i = 1\n        #= none:25 =#\n        for v = seq\n            #= none:26 =#\n            push!(cx, Float64(i))\n            #= none:27 =#\n            push!(cy, Float64(v))\n            #= none:28 =#\n            i += 1\n            #= none:29 =#\n        end\n        #= none:30 =#\n        shade = Float64(n0 % 7) / 7.0\n        #= none:31 =#\n        lines!(ax_conv, cx, cy; color = (0.25 + 0.5shade, 0.45, 0.85 - 0.4shade, 0.55), linewidth = 1.5)\n        #= none:34 =#\n        n0 += 1\n        #= none:35 =#\n    end\n    var\"##cellval#490\" = fig_conv\n    return (PlutoIslands._html_body)(var\"##cellval#490\")\nend",
         "golden": [
-          "\"Dict{Any, Any}()\""
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
-        "mime": "text/plain",
+        "mime": "text/html",
         "reasons": [],
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)"
+            "2",
+            "3",
+            "1",
+            "15"
           ]
-        ]
-      },
-      {
-        "cell_id": "f21f1e3e-a3ab-458e-a101-ce824731f0b6",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
         ]
       },
       {
         "cell_id": "66fe673a-7679-4c55-bf59-146a8dd1241c",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64})\n    hailstone_seq = if \"Hailstone Sequence\" ∈ generalize_collatz\n            hailstone_sequence(hailstone_params.start_value; collatz_parameters..., verbose = false)\n        else\n            hailstone_sequence(hailstone_params.start_value; verbose = false)\n        end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_params.start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    hail_x = Float64[]\n    hail_y = Float64[]\n    for (i, v) = enumerate(hailstone_seq)\n        #= none:13 =#\n        push!(hail_x, Float64(i))\n        #= none:14 =#\n        push!(hail_y, Float64(v))\n        #= none:15 =#\n    end\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#477\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#477\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, hailstone_start_value::Int64)\n    hail_x = Float64[]\n    hail_y = Float64[]\n    let\n        #= none:5 =#\n        seq = collatz_hailstone(Int64(hailstone_start_value), Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:11 =#\n        i = 1\n        #= none:12 =#\n        for v = seq\n            #= none:13 =#\n            push!(hail_x, Float64(i))\n            #= none:14 =#\n            push!(hail_y, Float64(v))\n            #= none:15 =#\n            i += 1\n            #= none:16 =#\n        end\n    end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#491\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#491\")\nend",
         "golden": [
-          "ERR:UndefVarError: `hailstone_sequence` not defined in `Main.var\"##hv#502\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -1112,69 +1092,32 @@
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "6693800b-e2bc-46e4-b5f8-004184ef472b",
-        "eval_err": "syntax: type of \"record\" declared in inner scope",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64})\n    md\"!!! info \\\"Numerical Packages\\\"\n\t[Collatz](https://juliapackages.com/p/collatz): This package provide the methods to generate the hailstone sequence, the tree graph and stopping time for the collatz conjecture. \n\n\t[Graphs](https://www.juliapackages.com/p/graphs): Used to deal with creating and modifying graphs. \n\n\t[FixedPointNumbers](https://www.juliapackages.com/p/fixedpointnumbers): Package to deal with fixed point number, only used to handle colors.\n\"\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  key::Int64, previous::Collatz._CC.CC, depth::Int=0)\\n\\nTo handle the case where the search hits a cycle and previous is of type Collatz._CC.CC\\n\\n## Args \\n\\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Collatz._CC.CC`: The cycle value.\\n- `depth::Int`: The current depth of the search  \\n\\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, key::Int64, previous::Collatz._CC.CC, depth::Int = 0)\n            #= none:15 =#\n            #= none:18 =#\n            previous_index = findfirst((x->begin\n                            #= none:18 =#\n                            x == previous\n                        end), map((x->begin\n                                #= none:18 =#\n                                x[2]\n                            end), record))\n            #= none:21 =#\n            if isnothing(previous_index)\n                \"\"\n            else\n                add_edge!(g, previous, length(record) + 1)\n            end\n            #= none:24 =#\n            push!(record, (depth, key))\n            #= none:25 =#\n            return\n        end\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  tree::Dict, previous::Number=collect(keys(tree))[1], depth::Int=0)\\n\\t\\nThis function is used to explore the tree return by `tree_graph` from Collatz.jl and modify the graph g given as input. \\n\\n## Args \\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values. Each value is stored as (depth, value) in order to keep track of what depth the value was encountered\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Number`: The number passed by the previous call to the function \\n- `depth::Int`: The current depth of the search  \\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, tree::Dict, previous::Number = (collect(keys(tree)))[1], depth::Int = 0)\n            #= none:13 =#\n            #= none:16 =#\n            for key = keys(tree)\n                #= none:18 =#\n                add_vertex!(g)\n                #= none:21 =#\n                previous_index = findfirst((x->begin\n                                #= none:21 =#\n                                x == previous\n                            end), map((x->begin\n                                    #= none:21 =#\n                                    x[2]\n                                end), record))\n                #= none:24 =#\n                if isnothing(previous_index)\n                    \"\"\n                else\n                    add_edge!(g, previous_index, length(record) + 1)\n                end\n                #= none:27 =#\n                if key isa Number\n                    #= none:28 =#\n                    push!(record, (depth, key))\n                end\n                #= none:32 =#\n                descend_tree!(g, record, tree[key], key, depth + 1)\n                #= none:33 =#\n            end\n        end\n    #= none:1 =# Core.@doc \"\\tmake_collatz_graph(initial_value::Int, max_orbit_distance::Int; P=2, a=3, b=1)\\n\\nThis function returns a graph that represent the different branches that each number takes.\\n\\n## Args\\n\\n- `initial_value::Integer`: The starting value of the directed tree graph.\\n\\n- `max_orbit_distance::Integer`: Degree of seperation between the initial value and each value encountered. \\n\\n## Kwargs\\n\\n- ```P::Integer=2```: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n\\n- ```a::Integer=3```: Factor by which to multiply n.\\n\\n- ```b::Integer=1```: Value to add to the scaled value of n.\\n\\n\\n## See also\\n[`tree_graph`](@ref)\\n\" function make_collatz_graph(initial_value::Int, max_orbit_distance::Int; P = 2, a = 3, b = 1)\n            #= none:24 =#\n            #= none:25 =#\n            g = SimpleGraph()\n            #= none:26 =#\n            record::Array{Tuple{Number, Number}} = []\n            #= none:27 =#\n            tree = tree_graph(initial_value, max_orbit_distance; P, a, b)\n            #= none:28 =#\n            descend_tree!(g, record, tree)\n            #= none:29 =#\n            return (g, record)\n        end\n    (g, record) = if \"Graph\" ∈ generalize_collatz\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; collatz_parameters...)\n        else\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; )\n        end\n    graph_colors = [RGB(rescale((record[i])[1], 1, graph_parameters.orbit, 1, 0.3), 0.1, 0.3) for i = 1:nv(g)]\n    var\"##cellval#478\" = graph_colors\n    return (PlutoIslands._plain_body)(var\"##cellval#478\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "image/svg+xml",
-        "reasons": [
-          "unsupported output mime image/svg+xml in v0 (text/plain & md-text/html only)"
-        ]
-      },
-      {
-        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64})\n    generalize_collatz\n    stopping_times = Dict()\n    newValues = filter((x->begin\n                    #= none:3 =#\n                    !(x ∈ keys(stopping_times))\n                end), collect(range(1, stopping_parameters.ub, step = 1)))\n    for newValue = newValues\n        #= none:7 =#\n        push!(stopping_times, newValue => if \"Stopping Time\" ∈ generalize_collatz\n                    stopping_time(newValue; collatz_parameters..., total_stopping_time = true)\n                else\n                    stopping_time(newValue, total_stopping_time = true)\n                end)\n        #= none:10 =#\n    end\n    st_vals = collect(values(sort(filter((key->begin\n                                #= none:14 =#\n                                key[1] ∈ range(1, stopping_parameters.ub, step = 1)\n                            end), stopping_times))))\n    st_x = Float64[]\n    st_y = Float64[]\n    for (i, v) = enumerate(st_vals)\n        #= none:21 =#\n        push!(st_x, Float64(i))\n        #= none:22 =#\n        push!(st_y, Float64(v))\n        #= none:23 =#\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_parameters.ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#480\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#480\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `stopping_parameters` not defined in `Main.var\"##hv#502\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 1, orbit = 9)"
+            "2",
+            "3",
+            "1",
+            "15"
           ]
         ]
       },
       {
         "cell_id": "6d225dce-3362-4f5d-bba9-0b5312f6be5a",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#502\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64})\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    window_height = $(QuoteNode(700.0))\n    window_width = $(QuoteNode(500.0))\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#481\" = interactive_viz\n    return (PlutoIslands._plain_body)(var\"##cellval#481\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, hailstone_start_value::Int64)\n    viz_trajectories = Vector{Vector{Int64}}()\n    let\n        #= none:11 =#\n        Pv = Int64(collatz_P)\n        #= none:12 =#\n        av = Int64(collatz_a)\n        #= none:13 =#\n        bv = Int64(collatz_b)\n        #= none:14 =#\n        n0 = Int64(1)\n        #= none:15 =#\n        ntop = Int64(round(Int, num_traject))\n        #= none:16 =#\n        while n0 <= ntop\n            #= none:17 =#\n            push!(viz_trajectories, reverse(collatz_hailstone(n0, Pv, av, bv, Int64(1000))))\n            #= none:18 =#\n            n0 += 1\n            #= none:19 =#\n        end\n    end\n    interactive_viz = let\n            #= none:26 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:27 =#\n            ax = Axis(fig[1, 1])\n            #= none:28 =#\n            hidedecorations!(ax)\n            #= none:29 =#\n            hidespines!(ax)\n            #= none:31 =#\n            base_r = Float64(red(stroke_color))\n            #= none:32 =#\n            base_g = Float64(green(stroke_color))\n            #= none:33 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:35 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:36 =#\n                xs = Float64[]\n                #= none:37 =#\n                ys = Float64[]\n                #= none:38 =#\n                x = Float64(x_start)\n                #= none:39 =#\n                y = Float64(y_start)\n                #= none:40 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:41 =#\n                push!(xs, x)\n                #= none:42 =#\n                push!(ys, y)\n                #= none:43 =#\n                for v = seq\n                    #= none:44 =#\n                    if chris_style\n                        #= none:45 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:46 =# mod(v, 2) == 0\n                        #= none:47 =#\n                        θ += turn_scale\n                    else\n                        #= none:49 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:51 =#\n                    x += line_length * cosd(θ)\n                    #= none:52 =#\n                    y += line_length * sind(θ)\n                    #= none:53 =#\n                    push!(xs, x)\n                    #= none:54 =#\n                    push!(ys, y)\n                    #= none:55 =#\n                end\n                #= none:59 =#\n                col = if random_shade\n                        #= none:60 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:63 =# vary_shade\n                        #= none:64 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:65 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:69 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:71 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:72 =#\n            end\n            #= none:73 =#\n            fig\n        end\n    var\"##cellval#492\" = interactive_viz\n    return (PlutoIslands._html_body)(var\"##cellval#492\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#500\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
         "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "1b48b435-e959-477f-a8d2-3507da73fc28",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#502\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, graph_parameters::@NamedTuple{start_value::Int64, orbit::Int64})\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    window_height = $(QuoteNode(700.0))\n    window_width = $(QuoteNode(500.0))\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#482\" = #= none:1 =# @htl(\"$(PlutoUI.DownloadButton(\"<!doctype html><html><body>\" * html_snippet(interactive_viz) * \"</body></html>\", if filename == \"\"\n            \"MyCoolVisualization\"\n        else\n            filename\n        end * \".html\"))\\n\")\n    return (PlutoIslands._plain_body)(var\"##cellval#482\")\nend",
-        "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "2",
+            "3",
+            "1",
+            "15"
+          ]
+        ]
       }
     ],
     "group": 4,
@@ -1182,100 +1125,126 @@
     "group_reasons": [],
     "notebook": "CollatzConjecture.jl",
     "preamble": [
+      "function collatz_stopping_time(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:7 =#\n    #= none:8 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:9 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:10 =#\n    steps = 0\n    #= none:11 =#\n    while n != 1 && steps < maxlen\n        #= none:12 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:13 =#\n        steps += 1\n        #= none:14 =#\n        if n < 1\n            #= none:15 =#\n            break\n        end\n        #= none:17 =#\n    end\n    #= none:18 =#\n    return steps\nend",
       "using Collatz",
       "using Graphs",
       "using FixedPointNumbers",
       "using PlutoUI",
-      "import PlutoUI: combine",
       "using HypertextLiteral: @htl",
       "using Parameters",
       "using WasmMakie",
       "using Colors",
       "using Luxor",
       "using Karnak, NetworkLayout",
-      "using ImageIO, ImageShow"
+      "using ImageIO, ImageShow",
+      "function collatz_hailstone(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:8 =#\n    #= none:9 =#\n    out = Int64[]\n    #= none:10 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:11 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:12 =#\n    push!(out, n)\n    #= none:13 =#\n    steps = 0\n    #= none:14 =#\n    while n != 1 && steps < maxlen\n        #= none:15 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:16 =#\n        push!(out, n)\n        #= none:17 =#\n        steps += 1\n        #= none:18 =#\n        if n < 1\n            #= none:19 =#\n            break\n        end\n        #= none:21 =#\n    end\n    #= none:22 =#\n    return out\nend"
     ]
   },
   {
     "argtypes": [
-      "@NamedTuple{P::Int64, a::Int64, b::Int64}",
-      "Bool",
-      "Vector{String}",
-      "@NamedTuple{start_value::Int64}"
+      "Int64",
+      "Int64",
+      "Int64",
+      "Int64"
     ],
     "bonds": [
-      "collatz_parameters",
-      "do_generalize_collatz",
-      "generalize_collatz",
-      "hailstone_params"
+      "collatz_P",
+      "collatz_a",
+      "collatz_b",
+      "stopping_ub"
     ],
     "cells": [
       {
-        "cell_id": "af0c36ee-0534-4143-b59b-4ee041ef0f04",
+        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, hailstone_params::@NamedTuple{start_value::Int64})\n    var\"##cellval#483\" = if do_generalize_collatz\n            md\"!!! warning \\\"Divergence\\\"\n\tSome parameters will not behave as the traditional problem and will lead to some numbers diverging up to infinity. In that case, the calculations will stop at a stopping time of 1000. However, this still can still result in high latency so beware! .\n\"\n        else\n            md\"\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#483\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, stopping_ub::Int64)\n    st_x = Float64[]\n    st_y = Float64[]\n    let\n        #= none:8 =#\n        ub = Int64(stopping_ub)\n        #= none:9 =#\n        Pv = Int64(collatz_P)\n        #= none:10 =#\n        av = Int64(collatz_a)\n        #= none:11 =#\n        bv = Int64(collatz_b)\n        #= none:12 =#\n        n0 = Int64(1)\n        #= none:13 =#\n        while n0 <= ub\n            #= none:14 =#\n            push!(st_x, Float64(n0))\n            #= none:15 =#\n            push!(st_y, Float64(collatz_stopping_time(n0, Pv, av, bv, Int64(1000))))\n            #= none:16 =#\n            n0 += 1\n            #= none:17 =#\n        end\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#493\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#493\")\nend",
         "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported"
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
         "reasons": [],
-        "rettype": "Union{}",
+        "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 15,)"
+            "2",
+            "3",
+            "1",
+            "1000"
+          ],
+          [
+            "9",
+            "3",
+            "1",
+            "1000"
+          ],
+          [
+            "2",
+            "10",
+            "1",
+            "1000"
+          ],
+          [
+            "2",
+            "3",
+            "10",
+            "1000"
           ]
         ]
       },
       {
-        "cell_id": "1c3f1bea-f1ba-4d64-90ad-584391c01da5",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
-      {
-        "cell_id": "5f074850-b967-4de5-8ca3-b85a74052499",
+        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, hailstone_params::@NamedTuple{start_value::Int64})\n    generalize_collatz\n    stopping_times = Dict()\n    var\"##cellval#484\" = stopping_times\n    return (PlutoIslands._plain_body)(var\"##cellval#484\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, stopping_ub::Int64)\n    fig_conv = Figure(size = (700, 460))\n    ax_conv = Axis(fig_conv[1, 1]; title = \"Hailstone paths for 1 … \" * string(graph_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    top = Int64(graph_start_value)\n    n0 = Int64(1)\n    while n0 <= top\n        #= none:16 =#\n        seq = collatz_hailstone(n0, Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:22 =#\n        cx = Float64[]\n        #= none:23 =#\n        cy = Float64[]\n        #= none:24 =#\n        i = 1\n        #= none:25 =#\n        for v = seq\n            #= none:26 =#\n            push!(cx, Float64(i))\n            #= none:27 =#\n            push!(cy, Float64(v))\n            #= none:28 =#\n            i += 1\n            #= none:29 =#\n        end\n        #= none:30 =#\n        shade = Float64(n0 % 7) / 7.0\n        #= none:31 =#\n        lines!(ax_conv, cx, cy; color = (0.25 + 0.5shade, 0.45, 0.85 - 0.4shade, 0.55), linewidth = 1.5)\n        #= none:34 =#\n        n0 += 1\n        #= none:35 =#\n    end\n    var\"##cellval#494\" = fig_conv\n    return (PlutoIslands._html_body)(var\"##cellval#494\")\nend",
         "golden": [
-          "\"Dict{Any, Any}()\""
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
-        "mime": "text/plain",
+        "mime": "text/html",
         "reasons": [],
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 15,)"
+            "2",
+            "3",
+            "1",
+            "1000"
+          ],
+          [
+            "9",
+            "3",
+            "1",
+            "1000"
+          ],
+          [
+            "2",
+            "10",
+            "1",
+            "1000"
+          ],
+          [
+            "2",
+            "3",
+            "10",
+            "1000"
           ]
-        ]
-      },
-      {
-        "cell_id": "f21f1e3e-a3ab-458e-a101-ce824731f0b6",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
         ]
       },
       {
         "cell_id": "66fe673a-7679-4c55-bf59-146a8dd1241c",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, hailstone_params::@NamedTuple{start_value::Int64})\n    hailstone_seq = if \"Hailstone Sequence\" ∈ generalize_collatz\n            hailstone_sequence(hailstone_params.start_value; collatz_parameters..., verbose = false)\n        else\n            hailstone_sequence(hailstone_params.start_value; verbose = false)\n        end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_params.start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    hail_x = Float64[]\n    hail_y = Float64[]\n    for (i, v) = enumerate(hailstone_seq)\n        #= none:13 =#\n        push!(hail_x, Float64(i))\n        #= none:14 =#\n        push!(hail_y, Float64(v))\n        #= none:15 =#\n    end\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#485\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#485\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, stopping_ub::Int64)\n    hail_x = Float64[]\n    hail_y = Float64[]\n    let\n        #= none:5 =#\n        seq = collatz_hailstone(Int64(hailstone_start_value), Int64(collatz_P), Int64(collatz_a), Int64(collatz_b), Int64(1000))\n        #= none:11 =#\n        i = 1\n        #= none:12 =#\n        for v = seq\n            #= none:13 =#\n            push!(hail_x, Float64(i))\n            #= none:14 =#\n            push!(hail_y, Float64(v))\n            #= none:15 =#\n            i += 1\n            #= none:16 =#\n        end\n    end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#495\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#495\")\nend",
         "golden": [
-          "ERR:UndefVarError: `hailstone_sequence` not defined in `Main.var\"##hv#503\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `hailstone_start_value` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -1283,69 +1252,71 @@
         "rettype": "String",
         "samples": [
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 15,)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "6693800b-e2bc-46e4-b5f8-004184ef472b",
-        "eval_err": "syntax: type of \"record\" declared in inner scope",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, hailstone_params::@NamedTuple{start_value::Int64})\n    md\"!!! info \\\"Numerical Packages\\\"\n\t[Collatz](https://juliapackages.com/p/collatz): This package provide the methods to generate the hailstone sequence, the tree graph and stopping time for the collatz conjecture. \n\n\t[Graphs](https://www.juliapackages.com/p/graphs): Used to deal with creating and modifying graphs. \n\n\t[FixedPointNumbers](https://www.juliapackages.com/p/fixedpointnumbers): Package to deal with fixed point number, only used to handle colors.\n\"\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  key::Int64, previous::Collatz._CC.CC, depth::Int=0)\\n\\nTo handle the case where the search hits a cycle and previous is of type Collatz._CC.CC\\n\\n## Args \\n\\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Collatz._CC.CC`: The cycle value.\\n- `depth::Int`: The current depth of the search  \\n\\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, key::Int64, previous::Collatz._CC.CC, depth::Int = 0)\n            #= none:15 =#\n            #= none:18 =#\n            previous_index = findfirst((x->begin\n                            #= none:18 =#\n                            x == previous\n                        end), map((x->begin\n                                #= none:18 =#\n                                x[2]\n                            end), record))\n            #= none:21 =#\n            if isnothing(previous_index)\n                \"\"\n            else\n                add_edge!(g, previous, length(record) + 1)\n            end\n            #= none:24 =#\n            push!(record, (depth, key))\n            #= none:25 =#\n            return\n        end\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  tree::Dict, previous::Number=collect(keys(tree))[1], depth::Int=0)\\n\\t\\nThis function is used to explore the tree return by `tree_graph` from Collatz.jl and modify the graph g given as input. \\n\\n## Args \\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values. Each value is stored as (depth, value) in order to keep track of what depth the value was encountered\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Number`: The number passed by the previous call to the function \\n- `depth::Int`: The current depth of the search  \\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, tree::Dict, previous::Number = (collect(keys(tree)))[1], depth::Int = 0)\n            #= none:13 =#\n            #= none:16 =#\n            for key = keys(tree)\n                #= none:18 =#\n                add_vertex!(g)\n                #= none:21 =#\n                previous_index = findfirst((x->begin\n                                #= none:21 =#\n                                x == previous\n                            end), map((x->begin\n                                    #= none:21 =#\n                                    x[2]\n                                end), record))\n                #= none:24 =#\n                if isnothing(previous_index)\n                    \"\"\n                else\n                    add_edge!(g, previous_index, length(record) + 1)\n                end\n                #= none:27 =#\n                if key isa Number\n                    #= none:28 =#\n                    push!(record, (depth, key))\n                end\n                #= none:32 =#\n                descend_tree!(g, record, tree[key], key, depth + 1)\n                #= none:33 =#\n            end\n        end\n    #= none:1 =# Core.@doc \"\\tmake_collatz_graph(initial_value::Int, max_orbit_distance::Int; P=2, a=3, b=1)\\n\\nThis function returns a graph that represent the different branches that each number takes.\\n\\n## Args\\n\\n- `initial_value::Integer`: The starting value of the directed tree graph.\\n\\n- `max_orbit_distance::Integer`: Degree of seperation between the initial value and each value encountered. \\n\\n## Kwargs\\n\\n- ```P::Integer=2```: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n\\n- ```a::Integer=3```: Factor by which to multiply n.\\n\\n- ```b::Integer=1```: Value to add to the scaled value of n.\\n\\n\\n## See also\\n[`tree_graph`](@ref)\\n\" function make_collatz_graph(initial_value::Int, max_orbit_distance::Int; P = 2, a = 3, b = 1)\n            #= none:24 =#\n            #= none:25 =#\n            g = SimpleGraph()\n            #= none:26 =#\n            record::Array{Tuple{Number, Number}} = []\n            #= none:27 =#\n            tree = tree_graph(initial_value, max_orbit_distance; P, a, b)\n            #= none:28 =#\n            descend_tree!(g, record, tree)\n            #= none:29 =#\n            return (g, record)\n        end\n    (g, record) = if \"Graph\" ∈ generalize_collatz\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; collatz_parameters...)\n        else\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; )\n        end\n    graph_colors = [RGB(rescale((record[i])[1], 1, graph_parameters.orbit, 1, 0.3), 0.1, 0.3) for i = 1:nv(g)]\n    var\"##cellval#486\" = graph_colors\n    return (PlutoIslands._plain_body)(var\"##cellval#486\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "image/svg+xml",
-        "reasons": [
-          "unsupported output mime image/svg+xml in v0 (text/plain & md-text/html only)"
-        ]
-      },
-      {
-        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, hailstone_params::@NamedTuple{start_value::Int64})\n    generalize_collatz\n    stopping_times = Dict()\n    newValues = filter((x->begin\n                    #= none:3 =#\n                    !(x ∈ keys(stopping_times))\n                end), collect(range(1, stopping_parameters.ub, step = 1)))\n    for newValue = newValues\n        #= none:7 =#\n        push!(stopping_times, newValue => if \"Stopping Time\" ∈ generalize_collatz\n                    stopping_time(newValue; collatz_parameters..., total_stopping_time = true)\n                else\n                    stopping_time(newValue, total_stopping_time = true)\n                end)\n        #= none:10 =#\n    end\n    st_vals = collect(values(sort(filter((key->begin\n                                #= none:14 =#\n                                key[1] ∈ range(1, stopping_parameters.ub, step = 1)\n                            end), stopping_times))))\n    st_x = Float64[]\n    st_y = Float64[]\n    for (i, v) = enumerate(st_vals)\n        #= none:21 =#\n        push!(st_x, Float64(i))\n        #= none:22 =#\n        push!(st_y, Float64(v))\n        #= none:23 =#\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_parameters.ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#488\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#488\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `stopping_parameters` not defined in `Main.var\"##hv#503\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
+            "2",
+            "3",
+            "1",
+            "1000"
+          ],
           [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(start_value = 15,)"
+            "9",
+            "3",
+            "1",
+            "1000"
+          ],
+          [
+            "2",
+            "10",
+            "1",
+            "1000"
+          ],
+          [
+            "2",
+            "3",
+            "10",
+            "1000"
           ]
         ]
       },
       {
         "cell_id": "6d225dce-3362-4f5d-bba9-0b5312f6be5a",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#503\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
         "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, hailstone_params::@NamedTuple{start_value::Int64})\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    window_height = $(QuoteNode(700.0))\n    window_width = $(QuoteNode(500.0))\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#489\" = interactive_viz\n    return (PlutoIslands._plain_body)(var\"##cellval#489\")\nend",
+        "fn_src": "function (collatz_P::Int64, collatz_a::Int64, collatz_b::Int64, stopping_ub::Int64)\n    viz_trajectories = Vector{Vector{Int64}}()\n    let\n        #= none:11 =#\n        Pv = Int64(collatz_P)\n        #= none:12 =#\n        av = Int64(collatz_a)\n        #= none:13 =#\n        bv = Int64(collatz_b)\n        #= none:14 =#\n        n0 = Int64(1)\n        #= none:15 =#\n        ntop = Int64(round(Int, num_traject))\n        #= none:16 =#\n        while n0 <= ntop\n            #= none:17 =#\n            push!(viz_trajectories, reverse(collatz_hailstone(n0, Pv, av, bv, Int64(1000))))\n            #= none:18 =#\n            n0 += 1\n            #= none:19 =#\n        end\n    end\n    interactive_viz = let\n            #= none:26 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:27 =#\n            ax = Axis(fig[1, 1])\n            #= none:28 =#\n            hidedecorations!(ax)\n            #= none:29 =#\n            hidespines!(ax)\n            #= none:31 =#\n            base_r = Float64(red(stroke_color))\n            #= none:32 =#\n            base_g = Float64(green(stroke_color))\n            #= none:33 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:35 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:36 =#\n                xs = Float64[]\n                #= none:37 =#\n                ys = Float64[]\n                #= none:38 =#\n                x = Float64(x_start)\n                #= none:39 =#\n                y = Float64(y_start)\n                #= none:40 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:41 =#\n                push!(xs, x)\n                #= none:42 =#\n                push!(ys, y)\n                #= none:43 =#\n                for v = seq\n                    #= none:44 =#\n                    if chris_style\n                        #= none:45 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:46 =# mod(v, 2) == 0\n                        #= none:47 =#\n                        θ += turn_scale\n                    else\n                        #= none:49 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:51 =#\n                    x += line_length * cosd(θ)\n                    #= none:52 =#\n                    y += line_length * sind(θ)\n                    #= none:53 =#\n                    push!(xs, x)\n                    #= none:54 =#\n                    push!(ys, y)\n                    #= none:55 =#\n                end\n                #= none:59 =#\n                col = if random_shade\n                        #= none:60 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:63 =# vary_shade\n                        #= none:64 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:65 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:69 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:71 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:72 =#\n            end\n            #= none:73 =#\n            fig\n        end\n    var\"##cellval#496\" = interactive_viz\n    return (PlutoIslands._html_body)(var\"##cellval#496\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `num_traject` not defined in `Main.var\"##hv#501\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
         "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "1b48b435-e959-477f-a8d2-3507da73fc28",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#503\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, hailstone_params::@NamedTuple{start_value::Int64})\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    window_height = $(QuoteNode(700.0))\n    window_width = $(QuoteNode(500.0))\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#490\" = #= none:1 =# @htl(\"$(PlutoUI.DownloadButton(\"<!doctype html><html><body>\" * html_snippet(interactive_viz) * \"</body></html>\", if filename == \"\"\n            \"MyCoolVisualization\"\n        else\n            filename\n        end * \".html\"))\\n\")\n    return (PlutoIslands._plain_body)(var\"##cellval#490\")\nend",
-        "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "2",
+            "3",
+            "1",
+            "1000"
+          ],
+          [
+            "9",
+            "3",
+            "1",
+            "1000"
+          ],
+          [
+            "2",
+            "10",
+            "1",
+            "1000"
+          ],
+          [
+            "2",
+            "3",
+            "10",
+            "1000"
+          ]
+        ]
       }
     ],
     "group": 5,
@@ -1353,486 +1324,241 @@
     "group_reasons": [],
     "notebook": "CollatzConjecture.jl",
     "preamble": [
+      "function collatz_stopping_time(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:7 =#\n    #= none:8 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:9 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:10 =#\n    steps = 0\n    #= none:11 =#\n    while n != 1 && steps < maxlen\n        #= none:12 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:13 =#\n        steps += 1\n        #= none:14 =#\n        if n < 1\n            #= none:15 =#\n            break\n        end\n        #= none:17 =#\n    end\n    #= none:18 =#\n    return steps\nend",
       "using Collatz",
       "using Graphs",
       "using FixedPointNumbers",
       "using PlutoUI",
-      "import PlutoUI: combine",
       "using HypertextLiteral: @htl",
       "using Parameters",
       "using WasmMakie",
       "using Colors",
       "using Luxor",
       "using Karnak, NetworkLayout",
-      "using ImageIO, ImageShow"
+      "using ImageIO, ImageShow",
+      "function collatz_hailstone(n0::Int64, P::Int64, a::Int64, b::Int64, maxlen::Int64)\n    #= none:8 =#\n    #= none:9 =#\n    out = Int64[]\n    #= none:10 =#\n    n = if n0 < 1\n            Int64(1)\n        else\n            n0\n        end\n    #= none:11 =#\n    pp = if P < 2\n            Int64(2)\n        else\n            P\n        end\n    #= none:12 =#\n    push!(out, n)\n    #= none:13 =#\n    steps = 0\n    #= none:14 =#\n    while n != 1 && steps < maxlen\n        #= none:15 =#\n        n = if n % pp == 0\n                n ÷ pp\n            else\n                a * n + b\n            end\n        #= none:16 =#\n        push!(out, n)\n        #= none:17 =#\n        steps += 1\n        #= none:18 =#\n        if n < 1\n            #= none:19 =#\n            break\n        end\n        #= none:21 =#\n    end\n    #= none:22 =#\n    return out\nend"
     ]
   },
   {
     "argtypes": [
-      "@NamedTuple{P::Int64, a::Int64, b::Int64}",
-      "Bool",
-      "Vector{String}",
-      "@NamedTuple{ub::Int64}"
+      "String"
     ],
     "bonds": [
-      "collatz_parameters",
-      "do_generalize_collatz",
-      "generalize_collatz",
-      "stopping_parameters"
+      "filename"
     ],
-    "cells": [
-      {
-        "cell_id": "af0c36ee-0534-4143-b59b-4ee041ef0f04",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, stopping_parameters::@NamedTuple{ub::Int64})\n    var\"##cellval#491\" = if do_generalize_collatz\n            md\"!!! warning \\\"Divergence\\\"\n\tSome parameters will not behave as the traditional problem and will lead to some numbers diverging up to infinity. In that case, the calculations will stop at a stopping time of 1000. However, this still can still result in high latency so beware! .\n\"\n        else\n            md\"\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#491\")\nend",
-        "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported"
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(ub = 1000,)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "1c3f1bea-f1ba-4d64-90ad-584391c01da5",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
-      {
-        "cell_id": "5f074850-b967-4de5-8ca3-b85a74052499",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, stopping_parameters::@NamedTuple{ub::Int64})\n    generalize_collatz\n    stopping_times = Dict()\n    var\"##cellval#492\" = stopping_times\n    return (PlutoIslands._plain_body)(var\"##cellval#492\")\nend",
-        "golden": [
-          "\"Dict{Any, Any}()\""
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(ub = 1000,)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "f21f1e3e-a3ab-458e-a101-ce824731f0b6",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
-      {
-        "cell_id": "66fe673a-7679-4c55-bf59-146a8dd1241c",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, stopping_parameters::@NamedTuple{ub::Int64})\n    hailstone_seq = if \"Hailstone Sequence\" ∈ generalize_collatz\n            hailstone_sequence(hailstone_params.start_value; collatz_parameters..., verbose = false)\n        else\n            hailstone_sequence(hailstone_params.start_value; verbose = false)\n        end\n    fig_hail = Figure(size = (640, 420))\n    ax_hail = Axis(fig_hail[1, 1]; title = \"Hailstone sequence of: \" * string(hailstone_params.start_value), xlabel = \"Iterations\", ylabel = \"Value\")\n    hail_x = Float64[]\n    hail_y = Float64[]\n    for (i, v) = enumerate(hailstone_seq)\n        #= none:13 =#\n        push!(hail_x, Float64(i))\n        #= none:14 =#\n        push!(hail_y, Float64(v))\n        #= none:15 =#\n    end\n    lines!(ax_hail, hail_x, hail_y; color = (0.678, 0.847, 0.902, 1.0))\n    scatter!(ax_hail, hail_x, hail_y; markersize = 12.0, color = (0.678, 0.847, 0.902, 1.0))\n    var\"##cellval#493\" = fig_hail\n    return (PlutoIslands._html_body)(var\"##cellval#493\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `hailstone_sequence` not defined in `Main.var\"##hv#504\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(ub = 1000,)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "6693800b-e2bc-46e4-b5f8-004184ef472b",
-        "eval_err": "syntax: type of \"record\" declared in inner scope",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, stopping_parameters::@NamedTuple{ub::Int64})\n    md\"!!! info \\\"Numerical Packages\\\"\n\t[Collatz](https://juliapackages.com/p/collatz): This package provide the methods to generate the hailstone sequence, the tree graph and stopping time for the collatz conjecture. \n\n\t[Graphs](https://www.juliapackages.com/p/graphs): Used to deal with creating and modifying graphs. \n\n\t[FixedPointNumbers](https://www.juliapackages.com/p/fixedpointnumbers): Package to deal with fixed point number, only used to handle colors.\n\"\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  key::Int64, previous::Collatz._CC.CC, depth::Int=0)\\n\\nTo handle the case where the search hits a cycle and previous is of type Collatz._CC.CC\\n\\n## Args \\n\\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Collatz._CC.CC`: The cycle value.\\n- `depth::Int`: The current depth of the search  \\n\\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, key::Int64, previous::Collatz._CC.CC, depth::Int = 0)\n            #= none:15 =#\n            #= none:18 =#\n            previous_index = findfirst((x->begin\n                            #= none:18 =#\n                            x == previous\n                        end), map((x->begin\n                                #= none:18 =#\n                                x[2]\n                            end), record))\n            #= none:21 =#\n            if isnothing(previous_index)\n                \"\"\n            else\n                add_edge!(g, previous, length(record) + 1)\n            end\n            #= none:24 =#\n            push!(record, (depth, key))\n            #= none:25 =#\n            return\n        end\n    #= none:1 =# Core.@doc \"\\tdescend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number,Number}},  tree::Dict, previous::Number=collect(keys(tree))[1], depth::Int=0)\\n\\t\\nThis function is used to explore the tree return by `tree_graph` from Collatz.jl and modify the graph g given as input. \\n\\n## Args \\n- `g::SimpleGraph`: The graph to modify \\n- `record::Array{Tuple{Number,Number}}`: An array that keeps track of each of the encountered values. Each value is stored as (depth, value) in order to keep track of what depth the value was encountered\\n- `tree::Dict`: The tree graph returned by `tree_graph` \\n- `previous::Number`: The number passed by the previous call to the function \\n- `depth::Int`: The current depth of the search  \\n\" function descend_tree!(g::SimpleGraph{Int64}, record::Array{Tuple{Number, Number}}, tree::Dict, previous::Number = (collect(keys(tree)))[1], depth::Int = 0)\n            #= none:13 =#\n            #= none:16 =#\n            for key = keys(tree)\n                #= none:18 =#\n                add_vertex!(g)\n                #= none:21 =#\n                previous_index = findfirst((x->begin\n                                #= none:21 =#\n                                x == previous\n                            end), map((x->begin\n                                    #= none:21 =#\n                                    x[2]\n                                end), record))\n                #= none:24 =#\n                if isnothing(previous_index)\n                    \"\"\n                else\n                    add_edge!(g, previous_index, length(record) + 1)\n                end\n                #= none:27 =#\n                if key isa Number\n                    #= none:28 =#\n                    push!(record, (depth, key))\n                end\n                #= none:32 =#\n                descend_tree!(g, record, tree[key], key, depth + 1)\n                #= none:33 =#\n            end\n        end\n    #= none:1 =# Core.@doc \"\\tmake_collatz_graph(initial_value::Int, max_orbit_distance::Int; P=2, a=3, b=1)\\n\\nThis function returns a graph that represent the different branches that each number takes.\\n\\n## Args\\n\\n- `initial_value::Integer`: The starting value of the directed tree graph.\\n\\n- `max_orbit_distance::Integer`: Degree of seperation between the initial value and each value encountered. \\n\\n## Kwargs\\n\\n- ```P::Integer=2```: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n\\n- ```a::Integer=3```: Factor by which to multiply n.\\n\\n- ```b::Integer=1```: Value to add to the scaled value of n.\\n\\n\\n## See also\\n[`tree_graph`](@ref)\\n\" function make_collatz_graph(initial_value::Int, max_orbit_distance::Int; P = 2, a = 3, b = 1)\n            #= none:24 =#\n            #= none:25 =#\n            g = SimpleGraph()\n            #= none:26 =#\n            record::Array{Tuple{Number, Number}} = []\n            #= none:27 =#\n            tree = tree_graph(initial_value, max_orbit_distance; P, a, b)\n            #= none:28 =#\n            descend_tree!(g, record, tree)\n            #= none:29 =#\n            return (g, record)\n        end\n    (g, record) = if \"Graph\" ∈ generalize_collatz\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; collatz_parameters...)\n        else\n            make_collatz_graph(graph_parameters.start_value, graph_parameters.orbit; )\n        end\n    graph_colors = [RGB(rescale((record[i])[1], 1, graph_parameters.orbit, 1, 0.3), 0.1, 0.3) for i = 1:nv(g)]\n    var\"##cellval#494\" = graph_colors\n    return (PlutoIslands._plain_body)(var\"##cellval#494\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "3550fe19-261e-4069-9bf6-6417dcaac102",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "image/svg+xml",
-        "reasons": [
-          "unsupported output mime image/svg+xml in v0 (text/plain & md-text/html only)"
-        ]
-      },
-      {
-        "cell_id": "45ca6e2a-6a58-475e-9c02-4925e71625bd",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, stopping_parameters::@NamedTuple{ub::Int64})\n    generalize_collatz\n    stopping_times = Dict()\n    newValues = filter((x->begin\n                    #= none:3 =#\n                    !(x ∈ keys(stopping_times))\n                end), collect(range(1, stopping_parameters.ub, step = 1)))\n    for newValue = newValues\n        #= none:7 =#\n        push!(stopping_times, newValue => if \"Stopping Time\" ∈ generalize_collatz\n                    stopping_time(newValue; collatz_parameters..., total_stopping_time = true)\n                else\n                    stopping_time(newValue, total_stopping_time = true)\n                end)\n        #= none:10 =#\n    end\n    st_vals = collect(values(sort(filter((key->begin\n                                #= none:14 =#\n                                key[1] ∈ range(1, stopping_parameters.ub, step = 1)\n                            end), stopping_times))))\n    st_x = Float64[]\n    st_y = Float64[]\n    for (i, v) = enumerate(st_vals)\n        #= none:21 =#\n        push!(st_x, Float64(i))\n        #= none:22 =#\n        push!(st_y, Float64(v))\n        #= none:23 =#\n    end\n    fig_st = Figure(size = (640, 420))\n    ax_st = Axis(fig_st[1, 1]; title = \"Total stopping time of numbers up to \" * string(stopping_parameters.ub), xlabel = \"Starting point\", ylabel = \"Stopping time\")\n    scatter!(ax_st, st_x, st_y; markersize = 4.0)\n    var\"##cellval#496\" = fig_st\n    return (PlutoIslands._html_body)(var\"##cellval#496\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `stopping_time` not defined in `Main.var\"##hv#504\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "(P = 2, a = 3, b = 1)",
-            "false",
-            "[\"Interactive\"]",
-            "(ub = 1000,)"
-          ]
-        ]
-      },
-      {
-        "cell_id": "6d225dce-3362-4f5d-bba9-0b5312f6be5a",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#504\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, stopping_parameters::@NamedTuple{ub::Int64})\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    window_height = $(QuoteNode(700.0))\n    window_width = $(QuoteNode(500.0))\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#497\" = interactive_viz\n    return (PlutoIslands._plain_body)(var\"##cellval#497\")\nend",
-        "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "1b48b435-e959-477f-a8d2-3507da73fc28",
-        "eval_err": "LoadError: UndefVarError: `@unpack` not defined in `Main.var\"##hv#504\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (collatz_parameters::@NamedTuple{P::Int64, a::Int64, b::Int64}, do_generalize_collatz::Bool, generalize_collatz::Vector{String}, stopping_parameters::@NamedTuple{ub::Int64})\n    md\"!!! info \\\"Notebook Packages\\\"\n\t[PlutoUI](https://www.juliapackages.com/p/PlutoUI): Extension for Pluto to handle interactivity, provides the Sliders, Checkboxes and Color Picker. \n\n\t[HypertextLiteral](https://www.juliapackages.com/p/HypertextLiteral): Drawing library, specifically for graphs.\n\n\"\n    shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tshortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the shortcut formulation:\\ng(n) = (3n + 1) / 2 if odd and g(n) = n / 2 if even\\n\\n\" function shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(shortcut_collatz_cache, n)\n                #= none:12 =#\n                return shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:14 =#\n                sequence = [n, shortcut_collatz(n ÷ 2)...]\n                #= none:15 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:16 =#\n                return sequence\n            else\n                #= none:18 =#\n                sequence = [n, shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:19 =#\n                shortcut_collatz_cache[n] = sequence\n                #= none:20 =#\n                return sequence\n            end\n        end\n    window_height = $(QuoteNode(700.0))\n    window_width = $(QuoteNode(500.0))\n    ultra_shortcut_collatz_cache = Dict{Int, Vector{Int}}()\n    #= none:1 =# Core.@doc \"\\tultra_shortcut_collatz(n::Int)\\n\\nCalculate the collatz sequence of a number using the absolute shortcut formulation:\\ng(n) = (3n + 1) / 2^k  if odd where k is the highest power that divides 3n+1 and g(n) = n / 2 if even\\n\\n\" function ultra_shortcut_collatz(n::Int)\n            #= none:8 =#\n            #= none:9 =#\n            if n == 1\n                #= none:10 =#\n                return [1]\n            elseif #= none:11 =# haskey(ultra_shortcut_collatz_cache, n)\n                #= none:12 =#\n                return ultra_shortcut_collatz_cache[n]\n            elseif #= none:13 =# n % 2 == 0\n                #= none:15 =#\n                while n % 2 == 0\n                    #= none:16 =#\n                    n = n ÷ 2\n                    #= none:17 =#\n                end\n                #= none:19 =#\n                if n == 1\n                    #= none:19 =#\n                    return [1]\n                end\n                #= none:20 =#\n                sequence = [n, ultra_shortcut_collatz(3n + 1)...]\n                #= none:21 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:22 =#\n                return sequence\n            else\n                #= none:24 =#\n                sequence = [n, ultra_shortcut_collatz(Int((3n + 1) / 2))...]\n                #= none:25 =#\n                ultra_shortcut_collatz_cache[n] = sequence\n                #= none:26 =#\n                return sequence\n            end\n        end\n    #= none:1 =# Core.@doc \"\\treverse_hailstone_sequences(range::UnitRange{Int64}; P::Int=2, a::Int=3, b::Int=1)\\nThis function wraps the `hailstone_sequence()` method from Collatz.jl to calculate list of hailstone sequence given a UnitRange. \\n\\nIt return the reversed sequence where the endpoint is the first element of the result.\\n\\n## Args\\n\\n- `range::UnitRange{Int64}`: Unit Range in which to calculate the hailstone sequences.\\n\\n\\n## Kwargs\\n\\n- `P::Integer = 2`: Modulus used to devide n, iff n is equivalent to (0 mod P).\\n- `a::Integer = 3`: Factor by which to multiply n.\\n- `b::Integer = 1`: Value to add to the scaled value of n.\\n\\n## Examples\\n```jldoctest\\njulia> hailstone_sequences(2:5) \\n[[1, 2], [1, 2, 4, 8, 16, 5, 10, 3], [1, 2, 4], [1, 2, 4, 8, 16, 5]]\\n```\\n```jldoctest\\njulia> hailstone_sequences(1:5; P=4, a=1, b=3)\\n[[1], [2, 8, 5, 2], [3, 12, 9, 6, 3], [1, 4], [5, 2, 8, 5]]\\n```\\n\\n## See also\\n[`hailstone_sequence`](@ref), [`hailstone_sequences`](@ref)\\n\" function reverse_hailstone_sequences(range::UnitRange{Int64}; P::Int = 2, a::Int = 3, b::Int = 1)\n            #= none:31 =#\n            #= none:32 =#\n            return [reverse(hailstone_sequence(starting_number; P, a, b, verbose = false)) for starting_number = range]\n        end\n    #= none:2 =# @unpack (num_traject, turn_scale, line_length) = viz_parameters\n    #= none:3 =# @unpack (init_angle, x_start, y_start, stroke_width) = viz_specs_parameters\n    #= none:4 =# @unpack (stroke_color, background_color) = viz_colors_options\n    #= none:5 =# @unpack (random_shade, vary_shade, edmund_style, chris_style) = viz_extra_options\n    viz_trajectories = if chris_style\n            #= none:9 =#\n            [reverse(ultra_shortcut_collatz(n)) for n = 1:num_traject]\n        elseif #= none:10 =# edmund_style\n            #= none:11 =#\n            [reverse(shortcut_collatz(n)) for n = 1:num_traject]\n        else\n            #= none:13 =#\n            reverse_hailstone_sequences(1:num_traject; P = collatz_parameters.P, a = collatz_parameters.a, b = collatz_parameters.b)\n        end\n    interactive_viz = let\n            #= none:21 =#\n            fig = Figure(size = (Float64(window_width), Float64(window_height)))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            hidespines!(ax)\n            #= none:26 =#\n            base_r = Float64(red(stroke_color))\n            #= none:27 =#\n            base_g = Float64(green(stroke_color))\n            #= none:28 =#\n            base_b = Float64(blue(stroke_color))\n            #= none:30 =#\n            for (t_i, seq) = enumerate(viz_trajectories)\n                #= none:31 =#\n                xs = Float64[]\n                #= none:32 =#\n                ys = Float64[]\n                #= none:33 =#\n                x = Float64(x_start)\n                #= none:34 =#\n                y = Float64(y_start)\n                #= none:35 =#\n                θ = Float64(init_angle) + 180.0\n                #= none:36 =#\n                push!(xs, x)\n                #= none:37 =#\n                push!(ys, y)\n                #= none:38 =#\n                for v = seq\n                    #= none:39 =#\n                    if chris_style\n                        #= none:40 =#\n                        θ += if mod(v, 3) == 1\n                                turn_scale\n                            else\n                                -turn_scale\n                            end\n                    elseif #= none:41 =# mod(v, 2) == 0\n                        #= none:42 =#\n                        θ += turn_scale\n                    else\n                        #= none:44 =#\n                        θ -= if edmund_style\n                                turn_scale / 2\n                            else\n                                turn_scale\n                            end\n                    end\n                    #= none:46 =#\n                    x += line_length * cosd(θ)\n                    #= none:47 =#\n                    y += line_length * sind(θ)\n                    #= none:48 =#\n                    push!(xs, x)\n                    #= none:49 =#\n                    push!(ys, y)\n                    #= none:50 =#\n                end\n                #= none:54 =#\n                col = if random_shade\n                        #= none:55 =#\n                        (Float64(mod(t_i * 37, 97)) / 97.0, Float64(mod(t_i * 53, 89)) / 89.0, Float64(mod(t_i * 71, 83)) / 83.0, 0.6)\n                    elseif #= none:58 =# vary_shade\n                        #= none:59 =#\n                        shade = (Float64(mod(t_i, 7)) - 3.0) * 0.08\n                        #= none:60 =#\n                        (clamp(base_r + shade, 0.0, 1.0), clamp(base_g + shade, 0.0, 1.0), clamp(base_b + shade, 0.0, 1.0), 0.6)\n                    else\n                        #= none:64 =#\n                        (base_r, base_g, base_b, 0.6)\n                    end\n                #= none:66 =#\n                lines!(ax, xs, ys; color = col, linewidth = Float64(stroke_width))\n                #= none:67 =#\n            end\n            #= none:68 =#\n            fig\n        end\n    var\"##cellval#498\" = #= none:1 =# @htl(\"$(PlutoUI.DownloadButton(\"<!doctype html><html><body>\" * html_snippet(interactive_viz) * \"</body></html>\", if filename == \"\"\n            \"MyCoolVisualization\"\n        else\n            filename\n        end * \".html\"))\\n\")\n    return (PlutoIslands._plain_body)(var\"##cellval#498\")\nend",
-        "kind": "string",
-        "mime": "application/vnd.pluto.stacktrace+object",
-        "reasons": []
-      }
-    ],
+    "cells": [],
     "group": 6,
     "group_ok": true,
     "group_reasons": [],
     "notebook": "CollatzConjecture.jl",
-    "preamble": [
-      "using Collatz",
-      "using Graphs",
-      "using FixedPointNumbers",
-      "using PlutoUI",
-      "import PlutoUI: combine",
-      "using HypertextLiteral: @htl",
-      "using Parameters",
-      "using WasmMakie",
-      "using Colors",
-      "using Luxor",
-      "using Karnak, NetworkLayout",
-      "using ImageIO, ImageShow"
-    ]
-  },
-  {
-    "argtypes": [
-      "Int64"
-    ],
-    "bonds": [
-      "m"
-    ],
-    "cells": [
-      {
-        "cell_id": "6dc89964-7c30-11eb-0a41-8d97b210ed34",
-        "extract_ok": true,
-        "fn_src": "function (m::Int64,)\n    var\"##cellval#559\" = (f(x) = begin\n                #= none:1 =#\n                x ^ m - 2\n            end)\n    return (PlutoIslands._plain_body)(var\"##cellval#559\")\nend",
-        "golden": [
-          "\"f\"",
-          "\"f\"",
-          "\"f\""
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "1"
-          ],
-          [
-            "3"
-          ],
-          [
-            "6"
-          ]
-        ]
-      },
-      {
-        "cell_id": "d35e0cc8-7c30-11eb-28d3-17c9e221ea62",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [
-          "empty cell body"
-        ]
-      },
-      {
-        "cell_id": "db26375a-7c30-11eb-066e-ab9e8ded3356",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#577\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (m::Int64,)\n    #= none:1 =# @variables (z, η)\n    f(x) = begin\n            #= none:1 =#\n            x ^ m - 2\n        end\n    var\"##cellval#561\" = f′(z)\n    return (PlutoIslands._html_body)(var\"##cellval#561\")\nend",
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": []
-      },
-      {
-        "cell_id": "63dbf052-7c32-11eb-1062-5b3581d38f70",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#577\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (m::Int64,)\n    #= none:1 =# @variables (z, η)\n    f(x) = begin\n            #= none:1 =#\n            x ^ m - 2\n        end\n    var\"##cellval#562\" = f(z)\n    return (PlutoIslands._html_body)(var\"##cellval#562\")\nend",
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": []
-      },
-      {
-        "cell_id": "9371f930-7c30-11eb-1f77-c7f31b97ea26",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#577\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (m::Int64,)\n    #= none:1 =# @variables (z, η)\n    f(x) = begin\n            #= none:1 =#\n            x ^ m - 2\n        end\n    var\"##cellval#563\" = f(z + η)\n    return (PlutoIslands._html_body)(var\"##cellval#563\")\nend",
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": []
-      },
-      {
-        "cell_id": "ea741018-7c30-11eb-3912-a50475e6ec49",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#577\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (m::Int64,)\n    #= none:1 =# @variables (z, η)\n    f(x) = begin\n            #= none:1 =#\n            x ^ m - 2\n        end\n    var\"##cellval#564\" = f(z) + η * f′(z)\n    return (PlutoIslands._html_body)(var\"##cellval#564\")\nend",
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": []
-      },
-      {
-        "cell_id": "e18f2470-7c31-11eb-2b74-d59d00d20ba4",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#577\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (m::Int64,)\n    #= none:1 =# @variables (z, η)\n    f(x) = begin\n            #= none:1 =#\n            x ^ m - 2\n        end\n    var\"##cellval#565\" = expand(f(z + η)) - (f(z) + η * f′(z))\n    return (PlutoIslands._html_body)(var\"##cellval#565\")\nend",
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": []
-      },
-      {
-        "cell_id": "98158a38-7c30-11eb-0796-2335e97ec6d0",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#577\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (m::Int64,)\n    #= none:1 =# @variables (z, η)\n    f(x) = begin\n            #= none:1 =#\n            x ^ m - 2\n        end\n    var\"##cellval#566\" = expand(f(z + η))\n    return (PlutoIslands._html_body)(var\"##cellval#566\")\nend",
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": []
-      }
-    ],
-    "group": 1,
-    "group_ok": true,
-    "group_reasons": [],
-    "notebook": "newton.jl",
-    "preamble": [
-      "using Symbolics, ForwardDiff, WasmMakie, PlutoUI, LaTeXStrings",
-      "using ForwardDiff: jacobian",
-      "import Latexify",
-      "f′(x) = begin\n        #= none:1 =#\n        ForwardDiff.derivative(f, x)\n    end",
-      "expand(ex) = begin\n        #= none:1 =#\n        simplify(ex, polynorm = true)\n    end"
-    ]
+    "preamble": []
   },
   {
     "argtypes": [
       "Int64",
-      "Int64"
+      "Int64",
+      "Float64"
     ],
     "bonds": [
       "n",
+      "which",
       "x0"
     ],
     "cells": [
       {
-        "cell_id": "ec6c6328-7b9c-11eb-1c69-dba12ae522ad",
+        "cell_id": "2e2e5f0e-7c31-11eb-0da7-770b07ee6202",
         "extract_ok": true,
-        "fn_src": "function (n::Int64, x0::Int64)\n    var\"##cellval#567\" = let\n            #= none:2 =#\n            f(x) = begin\n                    #= none:2 =#\n                    (0.2 * x ^ 3 - 4x) + 1\n                end\n            #= none:4 =#\n            standard_Newton(f, n, -10:0.01:10, x0, -10, 70)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#567\")\nend",
+        "fn_src": "function (n::Int64, which::Int64, x0::Float64)\n    root_estimate = newton_root(which, x0, n)\n    var\"##cellval#519\" = root_estimate\n    return (PlutoIslands._plain_body)(var\"##cellval#519\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#578\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#578\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#578\"`\nSuggestion: check for spelling errors or missing imports."
+          "\"1.4142135623730951\"",
+          "\"1.4142135623730951\"",
+          "\"0.7390851332151607\"",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#525\".var\"#2#3\")(::Int64, ::Int64, ::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#525\".var\"#2#3\")(::Int64, ::Int64, !Matched::Float64)\n   @ Main.var\"##hv#525\" none:0\n"
         ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "1",
-            "6"
-          ],
-          [
-            "11",
-            "6"
-          ],
-          [
-            "1",
-            "21"
-          ]
-        ]
-      }
-    ],
-    "group": 2,
-    "group_ok": true,
-    "group_reasons": [],
-    "notebook": "newton.jl",
-    "preamble": [
-      "using Symbolics, ForwardDiff, WasmMakie, PlutoUI, LaTeXStrings",
-      "using ForwardDiff: jacobian",
-      "import Latexify",
-      "straight(x0, y0, x, m) = begin\n        #= none:1 =#\n        y0 + m * (x - x0)\n    end",
-      "function standard_Newton(f, n, x_range, x0, ymin = -10.0, ymax = 10.0)\n    #= none:1 =#\n    #= none:3 =#\n    x0 = Float64(x0)\n    #= none:5 =#\n    f′ = (x->begin\n                #= none:5 =#\n                ForwardDiff.derivative(f, x)\n            end)\n    #= none:7 =#\n    xs = Float64[]\n    #= none:8 =#\n    ys = Float64[]\n    #= none:11 =#\n    let t = Float64(first(x_range)), hi = Float64(last(x_range)), dt = Float64(step(x_range))\n        #= none:13 =#\n        while t <= hi + dt / 2\n            #= none:14 =#\n            push!(xs, t)\n            #= none:15 =#\n            push!(ys, Float64(f(t)))\n            #= none:16 =#\n            t += dt\n            #= none:17 =#\n        end\n    end\n    #= none:20 =#\n    fig = Figure(size = (400, 300))\n    #= none:21 =#\n    ax = Axis(fig[1, 1])\n    #= none:22 =#\n    ax.ymin = Float64(ymin)\n    #= none:23 =#\n    ax.ymax = Float64(ymax)\n    #= none:25 =#\n    lines!(ax, xs, ys; linewidth = 3)\n    #= none:26 =#\n    hlines!(ax, [0.0]; color = :magenta, linewidth = 3, linestyle = :dash)\n    #= none:27 =#\n    scatter!(ax, [Float64(x0)], [0.0]; color = :green)\n    #= none:29 =#\n    for i = 1:n\n        #= none:31 =#\n        lines!(ax, [Float64(x0), Float64(x0)], [0.0, Float64(f(x0))]; color = (0.5, 0.5, 0.5, 0.5))\n        #= none:33 =#\n        scatter!(ax, [Float64(x0)], [Float64(f(x0))]; color = :red)\n        #= none:34 =#\n        m = f′(x0)\n        #= none:36 =#\n        ts = Float64[]\n        #= none:37 =#\n        for x = xs\n            #= none:38 =#\n            push!(ts, Float64(straight(x0, f(x0), x, m)))\n            #= none:39 =#\n        end\n        #= none:40 =#\n        lines!(ax, xs, ts; color = (0.0, 0.0, 1.0, 0.5), linestyle = :dash, linewidth = 2)\n        #= none:43 =#\n        x1 = x0 - f(x0) / m\n        #= none:45 =#\n        scatter!(ax, [Float64(x1)], [0.0]; color = :green)\n        #= none:47 =#\n        x0 = x1\n        #= none:49 =#\n    end\n    #= none:51 =#\n    fig\nend"
-    ]
-  },
-  {
-    "argtypes": [
-      "Int64",
-      "Int64"
-    ],
-    "bonds": [
-      "n2",
-      "x02"
-    ],
-    "cells": [
-      {
-        "cell_id": "ecb40aea-7b9c-11eb-1476-e54faf32d91c",
-        "extract_ok": true,
-        "fn_src": "function (n2::Int64, x02::Int64)\n    var\"##cellval#568\" = let\n            #= none:2 =#\n            f(x) = begin\n                    #= none:2 =#\n                    x ^ 2 - 2\n                end\n            #= none:4 =#\n            standard_Newton(f, n2, -1:0.01:10, x02, -10, 70)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#568\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#579\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#579\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#579\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "1",
-            "6"
-          ],
-          [
-            "11",
-            "6"
-          ],
-          [
-            "1",
-            "21"
-          ]
-        ]
-      }
-    ],
-    "group": 3,
-    "group_ok": true,
-    "group_reasons": [],
-    "notebook": "newton.jl",
-    "preamble": [
-      "using Symbolics, ForwardDiff, WasmMakie, PlutoUI, LaTeXStrings",
-      "using ForwardDiff: jacobian",
-      "import Latexify",
-      "straight(x0, y0, x, m) = begin\n        #= none:1 =#\n        y0 + m * (x - x0)\n    end",
-      "function standard_Newton(f, n, x_range, x0, ymin = -10.0, ymax = 10.0)\n    #= none:1 =#\n    #= none:3 =#\n    x0 = Float64(x0)\n    #= none:5 =#\n    f′ = (x->begin\n                #= none:5 =#\n                ForwardDiff.derivative(f, x)\n            end)\n    #= none:7 =#\n    xs = Float64[]\n    #= none:8 =#\n    ys = Float64[]\n    #= none:11 =#\n    let t = Float64(first(x_range)), hi = Float64(last(x_range)), dt = Float64(step(x_range))\n        #= none:13 =#\n        while t <= hi + dt / 2\n            #= none:14 =#\n            push!(xs, t)\n            #= none:15 =#\n            push!(ys, Float64(f(t)))\n            #= none:16 =#\n            t += dt\n            #= none:17 =#\n        end\n    end\n    #= none:20 =#\n    fig = Figure(size = (400, 300))\n    #= none:21 =#\n    ax = Axis(fig[1, 1])\n    #= none:22 =#\n    ax.ymin = Float64(ymin)\n    #= none:23 =#\n    ax.ymax = Float64(ymax)\n    #= none:25 =#\n    lines!(ax, xs, ys; linewidth = 3)\n    #= none:26 =#\n    hlines!(ax, [0.0]; color = :magenta, linewidth = 3, linestyle = :dash)\n    #= none:27 =#\n    scatter!(ax, [Float64(x0)], [0.0]; color = :green)\n    #= none:29 =#\n    for i = 1:n\n        #= none:31 =#\n        lines!(ax, [Float64(x0), Float64(x0)], [0.0, Float64(f(x0))]; color = (0.5, 0.5, 0.5, 0.5))\n        #= none:33 =#\n        scatter!(ax, [Float64(x0)], [Float64(f(x0))]; color = :red)\n        #= none:34 =#\n        m = f′(x0)\n        #= none:36 =#\n        ts = Float64[]\n        #= none:37 =#\n        for x = xs\n            #= none:38 =#\n            push!(ts, Float64(straight(x0, f(x0), x, m)))\n            #= none:39 =#\n        end\n        #= none:40 =#\n        lines!(ax, xs, ts; color = (0.0, 0.0, 1.0, 0.5), linestyle = :dash, linewidth = 2)\n        #= none:43 =#\n        x1 = x0 - f(x0) / m\n        #= none:45 =#\n        scatter!(ax, [Float64(x1)], [0.0]; color = :green)\n        #= none:47 =#\n        x0 = x1\n        #= none:49 =#\n    end\n    #= none:51 =#\n    fig\nend"
-    ]
-  },
-  {
-    "argtypes": [
-      "Float64"
-    ],
-    "bonds": [
-      "p"
-    ],
-    "cells": [
-      {
-        "cell_id": "18ce2fac-7c2e-11eb-03d2-b3a674621662",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#580\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (p::Float64,)\n    #= none:1 =# @variables (a, b, δ, ϵ)\n    var\"##cellval#569\" = jacobian(T(p), [a, b]) * [δ, ϵ]\n    return var\"##cellval#569\"\nend",
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "3828b94c-7c2d-11eb-2e01-79038b0f5226",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#580\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (p::Float64,)\n    #= none:1 =# @variables (a, b, δ, ϵ)\n    image = expand.((T(p))([a + δ, b + ϵ]))\n    var\"##cellval#570\" = image\n    return var\"##cellval#570\"\nend",
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "ed605b90-7c3e-11eb-34e9-776a05a177dd",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#580\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (p::Float64,)\n    #= none:1 =# @variables (a, b, δ, ϵ)\n    image = expand.((T(p))([a + δ, b + ϵ]))\n    var\"##cellval#571\" = image - (T(p))([a, b])\n    return var\"##cellval#571\"\nend",
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": []
-      },
-      {
-        "cell_id": "09b97be8-7c2e-11eb-05fd-65bbd097afb8",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#580\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
-        "extract_ok": true,
-        "fn_src": "function (p::Float64,)\n    #= none:1 =# @variables (a, b, δ, ϵ)\n    var\"##cellval#572\" = jacobian(T(p), [a, b]) .|> Text\n    return (PlutoIslands._plain_body)(var\"##cellval#572\")\nend",
         "kind": "string",
         "mime": "text/plain",
-        "reasons": []
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "5",
+            "1",
+            "2.0"
+          ],
+          [
+            "13",
+            "1",
+            "2.0"
+          ],
+          [
+            "5",
+            "3",
+            "2.0"
+          ],
+          [
+            "5",
+            "1",
+            "61"
+          ]
+        ]
       },
       {
-        "cell_id": "35b5c5c6-7c3f-11eb-2723-4b406a809114",
-        "eval_err": "LoadError: UndefVarError: `@variables` not defined in `Main.var\"##hv#580\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:1",
+        "cell_id": "f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e8",
         "extract_ok": true,
-        "fn_src": "function (p::Float64,)\n    #= none:1 =# @variables (a, b, δ, ϵ)\n    image = expand.((T(p))([a + δ, b + ϵ]))\n    var\"##cellval#573\" = simplify.(expand.((image - (T(p))([a, b])) - jacobian(T(p), [a, b]) * [δ, ϵ]))\n    return var\"##cellval#573\"\nend",
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": []
-      }
-    ],
-    "group": 4,
-    "group_ok": true,
-    "group_reasons": [],
-    "notebook": "newton.jl",
-    "preamble": [
-      "using Symbolics, ForwardDiff, WasmMakie, PlutoUI, LaTeXStrings",
-      "using ForwardDiff: jacobian",
-      "import Latexify",
-      "T(α) = begin\n        #= none:1 =#\n        ((x, y),)->begin\n                #= none:1 =#\n                [x + α * y ^ 2, y + α * x ^ 2]\n            end\n    end",
-      "expand(ex) = begin\n        #= none:1 =#\n        simplify(ex, polynorm = true)\n    end"
-    ]
-  },
-  {
-    "argtypes": [
-      "Float64"
-    ],
-    "bonds": [
-      "α"
-    ],
-    "cells": [
-      {
-        "cell_id": "02b1b470-7c31-11eb-28f4-411956f73f12",
-        "extract_ok": true,
-        "fn_src": "function (α::Float64,)\n    var\"##cellval#574\" = (T(α))([0.3, 0.4])\n    return var\"##cellval#574\"\nend",
+        "fn_src": "function (n::Int64, which::Int64, x0::Float64)\n    root_estimate = newton_root(which, x0, n)\n    return (\"<div class=\\\"markdown\\\"><p><strong>Final estimate of the root:</strong> \" * string(root_estimate)) * \"</p>\\n</div>\"\nend",
         "golden": [
-          "[0.3, 0.4]",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#4#5\")(::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#4#5\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#4#5\")(::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#4#5\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#4#5\")(::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#4#5\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n"
+          "\"<div class=\\\"markdown\\\"><p><strong>Final estimate of the root:</strong> 1.4142135623730951</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p><strong>Final estimate of the root:</strong> 1.4142135623730951</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p><strong>Final estimate of the root:</strong> 0.7390851332151607</p>\\n</div>\"",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#525\".var\"#5#6\")(::Int64, ::Int64, ::Int64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#525\".var\"#5#6\")(::Int64, ::Int64, !Matched::Float64)\n   @ Main.var\"##hv#525\" none:0\n"
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "5",
+            "1",
+            "2.0"
+          ],
+          [
+            "13",
+            "1",
+            "2.0"
+          ],
+          [
+            "5",
+            "3",
+            "2.0"
+          ],
+          [
+            "5",
+            "1",
+            "61"
+          ]
+        ]
+      },
+      {
+        "cell_id": "9bfafcc0-7ba2-11eb-1b67-e3a3803ead08",
+        "extract_ok": true,
+        "fn_src": "function (n::Int64, which::Int64, x0::Float64)\n    res = residual(which, x0, n)\n    var\"##cellval#521\" = res\n    return (PlutoIslands._plain_body)(var\"##cellval#521\")\nend",
+        "golden": [
+          "\"4.440892098500626e-16\"",
+          "\"4.440892098500626e-16\"",
+          "\"0.0\"",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#525\".var\"#8#9\")(::Int64, ::Int64, ::Int64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#525\".var\"#8#9\")(::Int64, ::Int64, !Matched::Float64)\n   @ Main.var\"##hv#525\" none:0\n"
+        ],
+        "kind": "string",
+        "mime": "text/plain",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "5",
+            "1",
+            "2.0"
+          ],
+          [
+            "13",
+            "1",
+            "2.0"
+          ],
+          [
+            "5",
+            "3",
+            "2.0"
+          ],
+          [
+            "5",
+            "1",
+            "61"
+          ]
+        ]
+      },
+      {
+        "cell_id": "f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e9",
+        "extract_ok": true,
+        "fn_src": "function (n::Int64, which::Int64, x0::Float64)\n    res = residual(which, x0, n)\n    return (\"<div class=\\\"markdown\\\"><p><strong>Residual |f&#40;x&#41;| at that estimate:</strong> \" * string(res)) * \"</p>\\n<p>&#40;this shrinks toward 0 as you raise the iteration count <code>n</code>&#41;</p>\\n</div>\"\nend",
+        "golden": [
+          "\"<div class=\\\"markdown\\\"><p><strong>Residual |f&#40;x&#41;| at that estimate:</strong> 4.440892098500626e-16</p>\\n<p>&#40;this shrinks toward 0 as you raise the iteration count <code>n</code>&#41;</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p><strong>Residual |f&#40;x&#41;| at that estimate:</strong> 4.440892098500626e-16</p>\\n<p>&#40;this shrinks toward 0 as you raise the iteration count <code>n</code>&#41;</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p><strong>Residual |f&#40;x&#41;| at that estimate:</strong> 0.0</p>\\n<p>&#40;this shrinks toward 0 as you raise the iteration count <code>n</code>&#41;</p>\\n</div>\"",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#525\".var\"#11#12\")(::Int64, ::Int64, ::Int64)\nThe function `#11` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#525\".var\"#11#12\")(::Int64, ::Int64, !Matched::Float64)\n   @ Main.var\"##hv#525\" none:0\n"
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "5",
+            "1",
+            "2.0"
+          ],
+          [
+            "13",
+            "1",
+            "2.0"
+          ],
+          [
+            "5",
+            "3",
+            "2.0"
+          ],
+          [
+            "5",
+            "1",
+            "61"
+          ]
+        ]
+      },
+      {
+        "cell_id": "f25af026-7b9c-11eb-1f11-77a8b06b2d71",
+        "extract_ok": true,
+        "fn_src": "function (n::Int64, which::Int64, x0::Float64)\n    var\"##cellval#523\" = let\n            #= none:4 =#\n            xs = Float64[]\n            #= none:5 =#\n            ys = Float64[]\n            #= none:6 =#\n            lo = -3.0\n            #= none:7 =#\n            hi = 3.0\n            #= none:8 =#\n            steps = 240\n            #= none:9 =#\n            for k = 0:steps\n                #= none:10 =#\n                t = lo + ((hi - lo) * k) / steps\n                #= none:11 =#\n                push!(xs, t)\n                #= none:12 =#\n                push!(ys, f(t, which))\n                #= none:13 =#\n            end\n            #= none:16 =#\n            seq = newton_sequence(which, x0, n)\n            #= none:17 =#\n            zx = Float64[]\n            #= none:18 =#\n            zy = Float64[]\n            #= none:19 =#\n            for v = seq\n                #= none:20 =#\n                push!(zx, v)\n                #= none:21 =#\n                push!(zy, 0.0)\n                #= none:22 =#\n            end\n            #= none:24 =#\n            fig = Figure(size = (480, 320))\n            #= none:25 =#\n            ax = Axis(fig[1, 1]; title = \"Newton's method\", xlabel = \"x\", ylabel = \"f(x)\")\n            #= none:26 =#\n            lines!(ax, xs, ys; linewidth = 3.0)\n            #= none:27 =#\n            hlines!(ax, [0.0]; color = :magenta, linewidth = 2.0, linestyle = :dash)\n            #= none:28 =#\n            scatter!(ax, zx, zy; color = :green, markersize = 10.0)\n            #= none:29 =#\n            fig\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#523\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#525\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#525\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#525\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#525\".var\"#14#15\")(::Int64, ::Int64, ::Int64)\nThe function `#14` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#525\".var\"#14#15\")(::Int64, ::Int64, !Matched::Float64)\n   @ Main.var\"##hv#525\" none:0\n"
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "5",
+            "1",
+            "2.0"
+          ],
+          [
+            "13",
+            "1",
+            "2.0"
+          ],
+          [
+            "5",
+            "3",
+            "2.0"
+          ],
+          [
+            "5",
+            "1",
+            "61"
+          ]
+        ]
+      },
+      {
+        "cell_id": "2fb40dc6-7c2f-11eb-2469-8deb4db59b5c",
+        "extract_ok": true,
+        "fn_src": "function (n::Int64, which::Int64, x0::Float64)\n    iterates = newton_sequence(which, x0, n)\n    var\"##cellval#524\" = iterates\n    return var\"##cellval#524\"\nend",
+        "golden": [
+          "[2.0, 1.5, 1.4166666666666667, 1.4142156862745099, 1.4142135623746899, 1.4142135623730951]",
+          "[2.0, 1.5, 1.4166666666666667, 1.4142156862745099, 1.4142135623746899, 1.4142135623730951, 1.414213562373095, 1.4142135623730951, 1.414213562373095, 1.4142135623730951, 1.414213562373095, 1.4142135623730951, 1.414213562373095, 1.4142135623730951]",
+          "[2.0, 0.7345361688544632, 0.7390897242053693, 0.7390851332198145, 0.7390851332151607, 0.7390851332151607]",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#525\".var\"#17#18\")(::Int64, ::Int64, ::Int64)\nThe function `#17` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#525\".var\"#17#18\")(::Int64, ::Int64, !Matched::Float64)\n   @ Main.var\"##hv#525\" none:0\n"
         ],
         "kind": "tree",
         "mime": "application/vnd.pluto.tree+object",
@@ -1840,89 +1566,39 @@
         "rettype": "Vector{Float64}",
         "samples": [
           [
-            "0.0"
+            "5",
+            "1",
+            "2.0"
           ],
           [
-            "1"
+            "13",
+            "1",
+            "2.0"
           ],
           [
-            "51"
+            "5",
+            "3",
+            "2.0"
           ],
           [
-            "101"
-          ]
-        ]
-      },
-      {
-        "cell_id": "07a754da-7c31-11eb-0394-4bef4d79fc30",
-        "extract_ok": true,
-        "fn_src": "function (α::Float64,)\n    #= none:1 =# Core.@doc \"Find ``x`` such that ``T(x) = 0``\" function newton2D(T, x0, n = 10)\n            #= none:2 =#\n            #= none:4 =#\n            x = x0\n            #= none:6 =#\n            for i = 1:n\n                #= none:7 =#\n                x = newton2D_step(T, x)\n                #= none:8 =#\n            end\n            #= none:10 =#\n            return x\n        end\n    #= none:1 =# Core.@doc \"Looks for ``x`` such that ``f(x) = y``, i.e. ``f(x) - y = 0``\" function inverse(f, y, x0 = [0, 0])\n            #= none:2 =#\n            #= none:3 =#\n            return newton2D((x->begin\n                            #= none:3 =#\n                            f(x) - y\n                        end), x0)\n        end\n    var\"##cellval#575\" = (inverse(T(α)))([0.3, 0.4])\n    return var\"##cellval#575\"\nend",
-        "golden": [
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#inverse#11\")(::Main.var\"##hv#581\".var\"#T##0#T##1\"{Float64})\nThe function `inverse` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#inverse#11\")(::Any, !Matched::Any, !Matched::Any)\n   @ Main.var\"##hv#581\" none:2\n  (::Main.var\"##hv#581\".var\"#inverse#11\")(::Any, !Matched::Any)\n   @ Main.var\"##hv#581\" none:2\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#8#9\")(::Int64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#8#9\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#8#9\")(::Int64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#8#9\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#8#9\")(::Int64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#8#9\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n"
-        ],
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "0.0"
-          ],
-          [
-            "1"
-          ],
-          [
-            "51"
-          ],
-          [
-            "101"
-          ]
-        ]
-      },
-      {
-        "cell_id": "5faa2784-7c31-11eb-34f1-3f8224dbdbde",
-        "extract_ok": true,
-        "fn_src": "function (α::Float64,)\n    #= none:1 =# Core.@doc \"Find ``x`` such that ``T(x) = 0``\" function newton2D(T, x0, n = 10)\n            #= none:2 =#\n            #= none:4 =#\n            x = x0\n            #= none:6 =#\n            for i = 1:n\n                #= none:7 =#\n                x = newton2D_step(T, x)\n                #= none:8 =#\n            end\n            #= none:10 =#\n            return x\n        end\n    #= none:1 =# Core.@doc \"Looks for ``x`` such that ``f(x) = y``, i.e. ``f(x) - y = 0``\" function inverse(f, y, x0 = [0, 0])\n            #= none:2 =#\n            #= none:3 =#\n            return newton2D((x->begin\n                            #= none:3 =#\n                            f(x) - y\n                        end), x0)\n        end\n    var\"##cellval#576\" = (T(α) ∘ inverse(T(α)))([0.3, 0.4])\n    return var\"##cellval#576\"\nend",
-        "golden": [
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#inverse#19\")(::Main.var\"##hv#581\".var\"#T##0#T##1\"{Float64})\nThe function `inverse` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#inverse#19\")(::Any, !Matched::Any, !Matched::Any)\n   @ Main.var\"##hv#581\" none:2\n  (::Main.var\"##hv#581\".var\"#inverse#19\")(::Any, !Matched::Any)\n   @ Main.var\"##hv#581\" none:2\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#16#17\")(::Int64)\nThe function `#16` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#16#17\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#16#17\")(::Int64)\nThe function `#16` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#16#17\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#581\".var\"#16#17\")(::Int64)\nThe function `#16` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#581\".var\"#16#17\")(!Matched::Float64)\n   @ Main.var\"##hv#581\" none:0\n"
-        ],
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "0.0"
-          ],
-          [
-            "1"
-          ],
-          [
-            "51"
-          ],
-          [
-            "101"
+            "5",
+            "1",
+            "61"
           ]
         ]
       }
     ],
-    "group": 5,
+    "group": 1,
     "group_ok": true,
     "group_reasons": [],
     "notebook": "newton.jl",
     "preamble": [
-      "T(α) = begin\n        #= none:1 =#\n        ((x, y),)->begin\n                #= none:1 =#\n                [x + α * y ^ 2, y + α * x ^ 2]\n            end\n    end",
-      "using Symbolics, ForwardDiff, WasmMakie, PlutoUI, LaTeXStrings",
-      "using ForwardDiff: jacobian",
-      "import Latexify",
-      "inverse(f) = begin\n        #= none:1 =#\n        y->begin\n                #= none:1 =#\n                inverse(f, y)\n            end\n    end",
-      "function newton2D_step(T, x)\n    #= none:1 =#\n    #= none:3 =#\n    J = ForwardDiff.jacobian(T, x)\n    #= none:5 =#\n    δ = J \\ T(x)\n    #= none:7 =#\n    return x - δ\nend"
+      "function fprime(x::Float64, which::Int64)\n    #= none:2 =#\n    #= none:3 =#\n    if which == 1\n        #= none:4 =#\n        return 2.0x\n    elseif #= none:5 =# which == 2\n        #= none:6 =#\n        return 3.0 * x * x - 1.0\n    else\n        #= none:8 =#\n        return -(sin(x)) - 1.0\n    end\nend",
+      "function f(x::Float64, which::Int64)\n    #= none:2 =#\n    #= none:3 =#\n    if which == 1\n        #= none:4 =#\n        return x * x - 2.0\n    elseif #= none:5 =# which == 2\n        #= none:6 =#\n        return x * x * x - x\n    else\n        #= none:8 =#\n        return cos(x) - x\n    end\nend",
+      "function newton_sequence(which::Int64, x0::Float64, n::Int64)\n    #= none:2 =#\n    #= none:3 =#\n    xs = Vector{Float64}(undef, n + 1)\n    #= none:4 =#\n    x = x0\n    #= none:5 =#\n    xs[1] = x\n    #= none:6 =#\n    for i = 1:n\n        #= none:7 =#\n        d = fprime(x, which)\n        #= none:9 =#\n        if d == 0.0\n            #= none:10 =#\n            xs[i + 1] = x\n        else\n            #= none:12 =#\n            x = x - f(x, which) / d\n            #= none:13 =#\n            xs[i + 1] = x\n        end\n        #= none:15 =#\n    end\n    #= none:16 =#\n    return xs\nend",
+      "function newton_root(which::Int64, x0::Float64, n::Int64)\n    #= none:2 =#\n    #= none:3 =#\n    xs = newton_sequence(which, x0, n)\n    #= none:4 =#\n    return xs[end]\nend",
+      "using PlutoUI, WasmMakie",
+      "function residual(which::Int64, x0::Float64, n::Int64)\n    #= none:2 =#\n    #= none:3 =#\n    x = newton_root(which, x0, n)\n    #= none:4 =#\n    return abs(f(x, which))\nend"
     ]
   },
   {
@@ -1985,7 +1661,7 @@
       {
         "cell_id": "c1d728e8-4833-4be8-bb7e-7f564b844b84",
         "extract_ok": true,
-        "fn_src": "function (check_me::Bool,)\n    var\"##cellval#767\" = check_me\n    return (PlutoIslands._plain_body)(var\"##cellval#767\")\nend",
+        "fn_src": "function (check_me::Bool,)\n    var\"##cellval#711\" = check_me\n    return (PlutoIslands._plain_body)(var\"##cellval#711\")\nend",
         "golden": [
           "\"false\"",
           "\"true\""
@@ -2025,7 +1701,7 @@
       {
         "cell_id": "7a14e496-c765-11ea-20a1-6fb960009251",
         "extract_ok": true,
-        "fn_src": "function (clicked::Int64,)\n    var\"##cellval#768\" = clicked\n    return (PlutoIslands._plain_body)(var\"##cellval#768\")\nend",
+        "fn_src": "function (clicked::Int64,)\n    var\"##cellval#712\" = clicked\n    return (PlutoIslands._plain_body)(var\"##cellval#712\")\nend",
         "golden": [
           "\"0\""
         ],
@@ -2061,7 +1737,7 @@
       {
         "cell_id": "00f9f608-85bd-4932-b585-39f74dcf53b4",
         "extract_ok": true,
-        "fn_src": "function (distance::Int64,)\n    var\"##cellval#769\" = distance\n    return (PlutoIslands._plain_body)(var\"##cellval#769\")\nend",
+        "fn_src": "function (distance::Int64,)\n    var\"##cellval#713\" = distance\n    return (PlutoIslands._plain_body)(var\"##cellval#713\")\nend",
         "golden": [
           "\"1\"",
           "\"50\"",
@@ -2105,12 +1781,12 @@
       {
         "cell_id": "9128d2c1-364c-4446-baaa-6d0593edda47",
         "extract_ok": true,
-        "fn_src": "function (favourite_function::typeof(sin),)\n    var\"##cellval#770\" = favourite_function(2)\n    return (PlutoIslands._plain_body)(var\"##cellval#770\")\nend",
+        "fn_src": "function (favourite_function::typeof(sin),)\n    var\"##cellval#714\" = favourite_function(2)\n    return (PlutoIslands._plain_body)(var\"##cellval#714\")\nend",
         "golden": [
           "\"0.9092974268256817\"",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#799\".var\"#2#3\")(::String)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#799\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#799\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#799\".var\"#2#3\")(::String)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#799\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#799\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#799\".var\"#2#3\")(::String)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#799\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#799\" none:0\n"
+          "ERR:MethodError: no method matching (::Main.var\"##hv#743\".var\"#2#3\")(::String)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#743\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#743\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#743\".var\"#2#3\")(::String)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#743\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#743\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#743\".var\"#2#3\")(::String)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#743\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#743\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -2153,7 +1829,7 @@
       {
         "cell_id": "dcda9ad2-c763-11ea-3ec6-093b823ba66d",
         "extract_ok": true,
-        "fn_src": "function (fruit::String,)\n    var\"##cellval#771\" = fruit\n    return (PlutoIslands._plain_body)(var\"##cellval#771\")\nend",
+        "fn_src": "function (fruit::String,)\n    var\"##cellval#715\" = fruit\n    return (PlutoIslands._plain_body)(var\"##cellval#715\")\nend",
         "golden": [
           "\"\\\"apple\\\"\"",
           "\"\\\"puiselect-1\\\"\"",
@@ -2197,7 +1873,7 @@
       {
         "cell_id": "2c7811cb-d9ea-470c-8cb7-2b3803489f3f",
         "extract_ok": true,
-        "fn_src": "function (fruit_basket::Vector{String},)\n    var\"##cellval#772\" = fruit_basket\n    return var\"##cellval#772\"\nend",
+        "fn_src": "function (fruit_basket::Vector{String},)\n    var\"##cellval#716\" = fruit_basket\n    return var\"##cellval#716\"\nend",
         "golden": [
           "String[]",
           "[\"1\", \"2\", \"3\"]",
@@ -2241,7 +1917,7 @@
       {
         "cell_id": "bb356b12-c765-11ea-2c36-697f4314bb93",
         "extract_ok": true,
-        "fn_src": "function (go::Int64,)\n    var\"##cellval#773\" = let\n            #= none:2 =#\n            go\n            #= none:4 =#\n            md\"I am $(rand(1:15)) years old!\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#773\")\nend",
+        "fn_src": "function (go::Int64,)\n    var\"##cellval#717\" = let\n            #= none:2 =#\n            go\n            #= none:4 =#\n            md\"I am $(rand(1:15)) years old!\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#717\")\nend",
         "golden": [
           "ERR:text/html rendering of Markdown.MD unsupported"
         ],
@@ -2275,17 +1951,17 @@
     ],
     "cells": [
       {
-        "cell_id": "adcf4e68-c761-11ea-00bb-c3b15c6dedc0",
+        "cell_id": "5d420570-c764-11ea-396b-cf0db01d34aa",
         "extract_ok": true,
-        "fn_src": "function (having_fun::Bool,)\n    var\"##cellval#774\" = having_fun\n    return (PlutoIslands._plain_body)(var\"##cellval#774\")\nend",
+        "fn_src": "function (having_fun::Bool,)\n    var\"##cellval#718\" = if having_fun\n            md\"🎈🎈\"\n        else\n            md\"☕\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#718\")\nend",
         "golden": [
-          "\"true\"",
-          "\"false\""
+          "ERR:text/html rendering of Markdown.MD unsupported",
+          "ERR:text/html rendering of Markdown.MD unsupported"
         ],
         "kind": "string",
-        "mime": "text/plain",
+        "mime": "text/html",
         "reasons": [],
-        "rettype": "String",
+        "rettype": "Union{}",
         "samples": [
           [
             "true"
@@ -2296,17 +1972,17 @@
         ]
       },
       {
-        "cell_id": "5d420570-c764-11ea-396b-cf0db01d34aa",
+        "cell_id": "adcf4e68-c761-11ea-00bb-c3b15c6dedc0",
         "extract_ok": true,
-        "fn_src": "function (having_fun::Bool,)\n    var\"##cellval#775\" = if having_fun\n            md\"🎈🎈\"\n        else\n            md\"☕\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#775\")\nend",
+        "fn_src": "function (having_fun::Bool,)\n    var\"##cellval#719\" = having_fun\n    return (PlutoIslands._plain_body)(var\"##cellval#719\")\nend",
         "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported"
+          "\"true\"",
+          "\"false\""
         ],
         "kind": "string",
-        "mime": "text/html",
+        "mime": "text/plain",
         "reasons": [],
-        "rettype": "Union{}",
+        "rettype": "String",
         "samples": [
           [
             "true"
@@ -2338,7 +2014,7 @@
       {
         "cell_id": "44591b34-cc50-11ea-2005-2f7075e6f2db",
         "extract_ok": true,
-        "fn_src": "function (important_document::Nothing,)\n    var\"##cellval#776\" = important_document\n    return (PlutoIslands._plain_body)(var\"##cellval#776\")\nend",
+        "fn_src": "function (important_document::Nothing,)\n    var\"##cellval#720\" = important_document\n    return (PlutoIslands._plain_body)(var\"##cellval#720\")\nend",
         "golden": [
           "\"nothing\""
         ],
@@ -2390,7 +2066,7 @@
       {
         "cell_id": "3dcd7002-c765-11ea-323d-a1fb49409011",
         "extract_ok": true,
-        "fn_src": "function (poem::String,)\n    var\"##cellval#777\" = split(poem, \"\\n\")\n    return var\"##cellval#777\"\nend",
+        "fn_src": "function (poem::String,)\n    var\"##cellval#721\" = split(poem, \"\\n\")\n    return var\"##cellval#721\"\nend",
         "golden": [
           "SubString{String}[\"Je opent en sluit je armen,\", \"Maar houdt niets vast.\", \"Het is net zwemmen.\"]"
         ],
@@ -2407,9 +2083,9 @@
       {
         "cell_id": "fc12280c-c768-11ea-3ebc-ebcd6b3459c1",
         "extract_ok": true,
-        "fn_src": "function (poem::String,)\n    var\"##cellval#778\" = DownloadButton(poem, \"poem.txt\")\n    return (PlutoIslands._html_body)(var\"##cellval#778\")\nend",
+        "fn_src": "function (poem::String,)\n    var\"##cellval#722\" = DownloadButton(poem, \"poem.txt\")\n    return (PlutoIslands._html_body)(var\"##cellval#722\")\nend",
         "golden": [
-          "ERR:UndefVarError: `DownloadButton` not defined in `Main.var\"##hv#806\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `DownloadButton` not defined in `Main.var\"##hv#750\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -2443,7 +2119,7 @@
       {
         "cell_id": "e4c262d6-c761-11ea-36b2-055419bfc981",
         "extract_ok": true,
-        "fn_src": "function (s::String,)\n    var\"##cellval#779\" = s\n    return (PlutoIslands._plain_body)(var\"##cellval#779\")\nend",
+        "fn_src": "function (s::String,)\n    var\"##cellval#723\" = s\n    return (PlutoIslands._plain_body)(var\"##cellval#723\")\nend",
         "golden": [
           "\"\\\"\\\"\""
         ],
@@ -2479,7 +2155,7 @@
       {
         "cell_id": "f985c8de-c761-11ea-126c-1fd79d547b79",
         "extract_ok": true,
-        "fn_src": "function (sentence::String,)\n    var\"##cellval#780\" = sentence\n    return (PlutoIslands._plain_body)(var\"##cellval#780\")\nend",
+        "fn_src": "function (sentence::String,)\n    var\"##cellval#724\" = sentence\n    return (PlutoIslands._plain_body)(var\"##cellval#724\")\nend",
         "golden": [
           "\"\\\"te dansen omdat men leeft\\\"\""
         ],
@@ -2515,7 +2191,7 @@
       {
         "cell_id": "f9052ed8-84cc-4cca-abb2-9363aafc6040",
         "extract_ok": true,
-        "fn_src": "function (speeds::@NamedTuple{North::Int64, East::Int64, South::Int64, West::Int64},)\n    var\"##cellval#781\" = speeds.North\n    return (PlutoIslands._plain_body)(var\"##cellval#781\")\nend",
+        "fn_src": "function (speeds::@NamedTuple{North::Int64, East::Int64, South::Int64, West::Int64},)\n    var\"##cellval#725\" = speeds.North\n    return (PlutoIslands._plain_body)(var\"##cellval#725\")\nend",
         "golden": [
           "\"1\""
         ],
@@ -2532,7 +2208,7 @@
       {
         "cell_id": "a4eac824-ba87-473a-b39a-783c4de3f933",
         "extract_ok": true,
-        "fn_src": "function (speeds::@NamedTuple{North::Int64, East::Int64, South::Int64, West::Int64},)\n    var\"##cellval#782\" = speeds\n    return var\"##cellval#782\"\nend",
+        "fn_src": "function (speeds::@NamedTuple{North::Int64, East::Int64, South::Int64, West::Int64},)\n    var\"##cellval#726\" = speeds\n    return var\"##cellval#726\"\nend",
         "golden": [
           "(North = 1, East = 1, South = 1, West = 1)"
         ],
@@ -2568,7 +2244,7 @@
       {
         "cell_id": "49e7cd06-c760-11ea-3f5d-2741d94278a6",
         "extract_ok": true,
-        "fn_src": "function (t::Int64,)\n    var\"##cellval#783\" = t\n    return (PlutoIslands._plain_body)(var\"##cellval#783\")\nend",
+        "fn_src": "function (t::Int64,)\n    var\"##cellval#727\" = t\n    return (PlutoIslands._plain_body)(var\"##cellval#727\")\nend",
         "golden": [
           "\"1\""
         ],
@@ -2604,7 +2280,7 @@
       {
         "cell_id": "5be148cc-c760-11ea-0819-a7bb403d27ff",
         "extract_ok": true,
-        "fn_src": "function (t_slow::Int64,)\n    var\"##cellval#784\" = t_slow\n    return (PlutoIslands._plain_body)(var\"##cellval#784\")\nend",
+        "fn_src": "function (t_slow::Int64,)\n    var\"##cellval#728\" = t_slow\n    return (PlutoIslands._plain_body)(var\"##cellval#728\")\nend",
         "golden": [
           "\"1\""
         ],
@@ -2640,7 +2316,7 @@
       {
         "cell_id": "33df82f5-2223-4f77-8bff-b6665040070b",
         "extract_ok": true,
-        "fn_src": "function (test1::Int64,)\n    var\"##cellval#785\" = test1\n    return (PlutoIslands._plain_body)(var\"##cellval#785\")\nend",
+        "fn_src": "function (test1::Int64,)\n    var\"##cellval#729\" = test1\n    return (PlutoIslands._plain_body)(var\"##cellval#729\")\nend",
         "golden": [
           "\"1\"",
           "\"10\"",
@@ -2684,7 +2360,7 @@
       {
         "cell_id": "21347c66-ad0f-46db-a7dd-d9ef7a22c61b",
         "extract_ok": true,
-        "fn_src": "function (test2::Int64,)\n    var\"##cellval#786\" = test2\n    return (PlutoIslands._plain_body)(var\"##cellval#786\")\nend",
+        "fn_src": "function (test2::Int64,)\n    var\"##cellval#730\" = test2\n    return (PlutoIslands._plain_body)(var\"##cellval#730\")\nend",
         "golden": [
           "\"1\"",
           "\"10\"",
@@ -2728,7 +2404,7 @@
       {
         "cell_id": "705662e2-c763-11ea-2f6d-cdaffc1fc73a",
         "extract_ok": true,
-        "fn_src": "function (vegetable::String,)\n    var\"##cellval#787\" = vegetable\n    return (PlutoIslands._plain_body)(var\"##cellval#787\")\nend",
+        "fn_src": "function (vegetable::String,)\n    var\"##cellval#731\" = vegetable\n    return (PlutoIslands._plain_body)(var\"##cellval#731\")\nend",
         "golden": [
           "\"\\\"potato\\\"\"",
           "\"\\\"puiselect-1\\\"\"",
@@ -2772,7 +2448,7 @@
       {
         "cell_id": "a20e30f2-f0fe-11ea-0ca7-c5195c9eb24a",
         "extract_ok": true,
-        "fn_src": "function (vegetable_basket::Vector{String},)\n    var\"##cellval#788\" = vegetable_basket\n    return var\"##cellval#788\"\nend",
+        "fn_src": "function (vegetable_basket::Vector{String},)\n    var\"##cellval#732\" = vegetable_basket\n    return var\"##cellval#732\"\nend",
         "golden": [
           "String[]",
           "[\"1\", \"2\", \"3\"]",
@@ -2816,12 +2492,12 @@
       {
         "cell_id": "b7788c4c-feb6-45cd-87ca-ae28c5ba3d07",
         "extract_ok": true,
-        "fn_src": "function (which_function::typeof(sin),)\n    var\"##cellval#789\" = which_function(π)\n    return (PlutoIslands._plain_body)(var\"##cellval#789\")\nend",
+        "fn_src": "function (which_function::typeof(sin),)\n    var\"##cellval#733\" = which_function(π)\n    return (PlutoIslands._plain_body)(var\"##cellval#733\")\nend",
         "golden": [
           "\"0.0\"",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#816\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#816\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#816\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#816\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#816\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#816\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#816\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#816\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#816\" none:0\n"
+          "ERR:MethodError: no method matching (::Main.var\"##hv#760\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#760\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#760\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#760\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#760\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#760\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#760\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#760\".var\"#2#3\")(!Matched::typeof(sin))\n   @ Main.var\"##hv#760\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -2864,16 +2540,16 @@
     ],
     "cells": [
       {
-        "cell_id": "3c68b25c-c761-11ea-226a-4f46579a6732",
+        "cell_id": "a4488984-c760-11ea-2930-871f6b400ef5",
         "extract_ok": true,
-        "fn_src": "function (x::Int64, x_different::Int64)\n    dog_url = $(QuoteNode(\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Welsh_Springer_Spaniel.jpg/500px-Welsh_Springer_Spaniel.jpg\"))\n    var\"##cellval#790\" = Resource(dog_url, :width => x * x_different)\n    return (PlutoIslands._html_body)(var\"##cellval#790\")\nend",
+        "fn_src": "function (x::Int64, x_different::Int64)\n    var\"##cellval#734\" = x\n    return (PlutoIslands._plain_body)(var\"##cellval#734\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Resource` not defined in `Main.var\"##hv#817\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Resource` not defined in `Main.var\"##hv#817\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Resource` not defined in `Main.var\"##hv#817\"`\nSuggestion: check for spelling errors or missing imports."
+          "\"5\"",
+          "\"11\"",
+          "\"5\""
         ],
         "kind": "string",
-        "mime": "text/html",
+        "mime": "text/plain",
         "reasons": [],
         "rettype": "String",
         "samples": [
@@ -2892,16 +2568,16 @@
         ]
       },
       {
-        "cell_id": "a4488984-c760-11ea-2930-871f6b400ef5",
+        "cell_id": "3c68b25c-c761-11ea-226a-4f46579a6732",
         "extract_ok": true,
-        "fn_src": "function (x::Int64, x_different::Int64)\n    var\"##cellval#791\" = x\n    return (PlutoIslands._plain_body)(var\"##cellval#791\")\nend",
+        "fn_src": "function (x::Int64, x_different::Int64)\n    dog_url = $(QuoteNode(\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Welsh_Springer_Spaniel.jpg/500px-Welsh_Springer_Spaniel.jpg\"))\n    var\"##cellval#735\" = Resource(dog_url, :width => x * x_different)\n    return (PlutoIslands._html_body)(var\"##cellval#735\")\nend",
         "golden": [
-          "\"5\"",
-          "\"11\"",
-          "\"5\""
+          "ERR:UndefVarError: `Resource` not defined in `Main.var\"##hv#761\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Resource` not defined in `Main.var\"##hv#761\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Resource` not defined in `Main.var\"##hv#761\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
-        "mime": "text/plain",
+        "mime": "text/html",
         "reasons": [],
         "rettype": "String",
         "samples": [
@@ -2941,7 +2617,7 @@
       {
         "cell_id": "78ecdf26-26a1-45e3-a44d-e65594a24ada",
         "extract_ok": true,
-        "fn_src": "function (x_very_different::Float64,)\n    var\"##cellval#792\" = x_very_different\n    return (PlutoIslands._plain_body)(var\"##cellval#792\")\nend",
+        "fn_src": "function (x_very_different::Float64,)\n    var\"##cellval#736\" = x_very_different\n    return (PlutoIslands._plain_body)(var\"##cellval#736\")\nend",
         "golden": [
           "\"NaN\""
         ],
@@ -2977,12 +2653,12 @@
       {
         "cell_id": "dfe10b6c-c760-11ea-2f77-79cc4cfa8dc4",
         "extract_ok": true,
-        "fn_src": "function (y::Float64,)\n    var\"##cellval#793\" = y\n    return (PlutoIslands._plain_body)(var\"##cellval#793\")\nend",
+        "fn_src": "function (y::Float64,)\n    var\"##cellval#737\" = y\n    return (PlutoIslands._plain_body)(var\"##cellval#737\")\nend",
         "golden": [
           "\"25.0\"",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#819\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#819\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#819\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#819\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#819\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#819\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#819\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#819\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#819\" none:0\n"
+          "ERR:MethodError: no method matching (::Main.var\"##hv#763\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#763\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#763\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#763\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#763\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#763\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#763\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#763\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#763\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -3025,7 +2701,7 @@
       {
         "cell_id": "b787ead6-c761-11ea-3b17-41c0a5434f9b",
         "extract_ok": true,
-        "fn_src": "function (z::Bool,)\n    var\"##cellval#794\" = z\n    return (PlutoIslands._plain_body)(var\"##cellval#794\")\nend",
+        "fn_src": "function (z::Bool,)\n    var\"##cellval#738\" = z\n    return (PlutoIslands._plain_body)(var\"##cellval#738\")\nend",
         "golden": [
           "\"false\"",
           "\"true\""
@@ -3063,26 +2739,9 @@
     ],
     "cells": [
       {
-        "cell_id": "9155d298-7758-4715-913f-9624c22450bb",
-        "extract_ok": true,
-        "fn_src": "function (c::ComplexF64,)\n    var\"##cellval#875\" = c\n    return (PlutoIslands._plain_body)(var\"##cellval#875\")\nend",
-        "golden": [
-          "\"0.9 + 0.4im\""
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "0.9 + 0.4im"
-          ]
-        ]
-      },
-      {
         "cell_id": "78da1442-19df-464f-8099-407b50d99303",
         "extract_ok": true,
-        "fn_src": "function (c::ComplexF64,)\n    new_initial_value = $(QuoteNode(1.0))\n    new_sequence = create_sequence_with_c(Fc, c, new_initial_value, 15)\n    var\"##cellval#876\" = new_sequence\n    return var\"##cellval#876\"\nend",
+        "fn_src": "function (c::ComplexF64,)\n    new_initial_value = $(QuoteNode(1.0))\n    new_sequence = create_sequence_with_c(Fc, c, new_initial_value, 15)\n    var\"##cellval#821\" = new_sequence\n    return var\"##cellval#821\"\nend",
         "golden": [
           "ComplexF64[1.0 + 0.0im, 1.9 + 0.4im, 4.35 + 1.92im, 16.136099999999995 + 17.103999999999996im, -31.27309279 + 552.3837087999997im, -304148.85541499086 - 34549.093961973456im, 9.131288635755573e10 + 2.10161347687184e10im, 7.896365294330952e21 + 3.838087851622118e21im, 4.762166650474506e43 + 6.061388741628427e43im, -1.406220227024827e87 + 5.773068664188906e87im, -3.1350866474546124e175 - 1.6236411855171277e175im, NaN + Inf*im, NaN + NaN*im, NaN + NaN*im, NaN + NaN*im]"
         ],
@@ -3099,9 +2758,26 @@
       {
         "cell_id": "4693d328-0907-4d62-b8e4-dcccff803b59",
         "extract_ok": true,
-        "fn_src": "function (c::ComplexF64,)\n    new_initial_value = $(QuoteNode(1.0))\n    new_sequence = create_sequence_with_c(Fc, c, new_initial_value, 15)\n    var\"##cellval#877\" = last(new_sequence)\n    return (PlutoIslands._plain_body)(var\"##cellval#877\")\nend",
+        "fn_src": "function (c::ComplexF64,)\n    new_initial_value = $(QuoteNode(1.0))\n    new_sequence = create_sequence_with_c(Fc, c, new_initial_value, 15)\n    var\"##cellval#822\" = last(new_sequence)\n    return (PlutoIslands._plain_body)(var\"##cellval#822\")\nend",
         "golden": [
           "\"NaN + NaN*im\""
+        ],
+        "kind": "string",
+        "mime": "text/plain",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "0.9 + 0.4im"
+          ]
+        ]
+      },
+      {
+        "cell_id": "9155d298-7758-4715-913f-9624c22450bb",
+        "extract_ok": true,
+        "fn_src": "function (c::ComplexF64,)\n    var\"##cellval#823\" = c\n    return (PlutoIslands._plain_body)(var\"##cellval#823\")\nend",
+        "golden": [
+          "\"0.9 + 0.4im\""
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -3119,49 +2795,30 @@
     "group_reasons": [],
     "notebook": "fractals.jl",
     "preamble": [
-      "using PlutoUI, PlutoTeachingTools, PlutoImageCoordinatePicker, WasmMakie",
-      "using ImageShow, ImageIO, Colors",
+      "function create_sequence_with_c(F, C, initial_value, max_n)\n    #= none:1 =#\n    #= none:3 =#\n    function z_i(last_z, i)\n        #= none:3 =#\n        #= none:4 =#\n        F(last_z, C)\n    end\n    #= none:8 =#\n    series = accumulate(z_i, 2:max_n, init = initial_value)\n    #= none:11 =#\n    return [initial_value, series...]\nend",
       "Fc(z, c) = begin\n        #= none:1 =#\n        z ^ 2 + c\n    end",
-      "function create_sequence_with_c(F, C, initial_value, max_n)\n    #= none:1 =#\n    #= none:3 =#\n    function z_i(last_z, i)\n        #= none:3 =#\n        #= none:4 =#\n        F(last_z, C)\n    end\n    #= none:8 =#\n    series = accumulate(z_i, 2:max_n, init = initial_value)\n    #= none:11 =#\n    return [initial_value, series...]\nend"
+      "using PlutoUI, PlutoTeachingTools, PlutoImageCoordinatePicker, WasmMakie",
+      "using ImageShow, ImageIO, Colors"
     ]
   },
   {
     "argtypes": [
-      "ComplexF64",
       "String",
       "String"
     ],
     "bonds": [
-      "c_for_fractal",
       "color1",
       "color2"
     ],
     "cells": [
       {
-        "cell_id": "8899561d-42e7-4397-a649-8800461c6649",
-        "extract_ok": true,
-        "fn_src": "function (c_for_fractal::ComplexF64, color1::String, color2::String)\n    img_size = $(QuoteNode(300))\n    var\"##cellval#878\" = let\n            #= none:4 =#\n            coords = Float64[]\n            #= none:5 =#\n            for k = 0:img_size\n                #= none:6 =#\n                push!(coords, -1.5 + (3.0k) / img_size)\n                #= none:7 =#\n            end\n            #= none:9 =#\n            fractal = julia_fractal(80, coords, coords, c_for_fractal, Complex)\n            #= none:11 =#\n            c1 = (Float64(red(color1)), Float64(green(color1)), Float64(blue(color1)), 1.0)\n            #= none:12 =#\n            c2 = (Float64(red(color2)), Float64(green(color2)), Float64(blue(color2)), 1.0)\n            #= none:15 =#\n            pixels = Vector{NTuple{4, Float64}}(undef, img_size * img_size)\n            #= none:16 =#\n            for j = 1:img_size, i = 1:img_size\n                #= none:17 =#\n                v = fractal[j + (i - 1) * (img_size + 1)]\n                #= none:18 =#\n                pixels[i + (j - 1) * img_size] = if v == 1.0f0\n                        c1\n                    else\n                        c2\n                    end\n                #= none:19 =#\n            end\n            #= none:21 =#\n            fig = Figure(size = (340, 340))\n            #= none:22 =#\n            ax = Axis(fig[1, 1])\n            #= none:23 =#\n            hidedecorations!(ax)\n            #= none:24 =#\n            image!(ax, (-1.5, 1.5), (-1.5, 1.5), pixels, img_size, img_size; interpolate = false)\n            #= none:25 =#\n            fig\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#878\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `img_size` not defined in `Main.var\"##hv#890\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "-0.0400000000000001 + 0.72im",
-            "\"#f5c894\"",
-            "\"#445233\""
-          ]
-        ]
-      },
-      {
         "cell_id": "3dc2f13d-0238-444d-b440-5e7e2df0618f",
         "extract_ok": true,
-        "fn_src": "function (c_for_fractal::ComplexF64, color1::String, color2::String)\n    return (((\"<div class=\\\"markdown\\\"><blockquote>\\n<h4>Recipe: Julia Set picture</h4>\\n<ol>\\n<li><p>Choose a complex number <span class=\\\"tex\\\">\\$c\\$</span> <strong>&#40;on the left&#41;</strong>.</p>\\n</li>\\n<li><p>We define our favorite sequence <span class=\\\"tex\\\">\\$z_&#123;n&#43;1&#125; &#61; z_n^2 &#43; c\\$</span></p>\\n</li>\\n<li><p>Now, we&#39;re going over <strong>all</strong> the imaginary numbers in a square around <span class=\\\"tex\\\">\\$0\\$</span>, and for each:</p>\\n</li>\\n</ol>\\n<ul>\\n<li><p>Use the number as the initial value to compute a sequence.</p>\\n</li>\\n<li><p>If the sequence <strong>converges</strong>, we color the point in \" * string(color1)) * \". </p>\\n</li>\\n<li><p>If the sequence <strong>diverges</strong>, we color the point in \") * string(color2)) * \".</p>\\n</li>\\n</ul>\\n</blockquote>\\n</div>\"\nend",
+        "fn_src": "function (color1::String, color2::String)\n    return (((\"<div class=\\\"markdown\\\"><blockquote>\\n<h4>Recipe: Julia Set picture</h4>\\n<ol>\\n<li><p>Choose a complex number <span class=\\\"tex\\\">\\$c\\$</span> <strong>&#40;on the left&#41;</strong>.</p>\\n</li>\\n<li><p>We define our favorite sequence <span class=\\\"tex\\\">\\$z_&#123;n&#43;1&#125; &#61; z_n^2 &#43; c\\$</span></p>\\n</li>\\n<li><p>Now, we&#39;re going over <strong>all</strong> the imaginary numbers in a square around <span class=\\\"tex\\\">\\$0\\$</span>, and for each:</p>\\n</li>\\n</ol>\\n<ul>\\n<li><p>Use the number as the initial value to compute a sequence.</p>\\n</li>\\n<li><p>If the sequence <strong>converges</strong>, we color the point in \" * string(color1)) * \". </p>\\n</li>\\n<li><p>If the sequence <strong>diverges</strong>, we color the point in \") * string(color2)) * \".</p>\\n</li>\\n</ul>\\n</blockquote>\\n</div>\"\nend",
         "golden": [
-          "\"<div class=\\\"markdown\\\"><blockquote>\\n<h4>Recipe: Julia Set picture</h4>\\n<ol>\\n<li><p>Choose a complex number <span class=\\\"tex\\\">\\$c\\$</span> <strong>&#40;on the left&#41;</strong>.</p>\\n</li>\\n<li><p>We define our favorite sequence <span class=\\\"tex\\\">\\$z_&#123;n&#43;1&#125; &#61; z_n^2 &#43; c\\$</span></p>\\n</li>\\n<li><p>Now, we&#39;re going over <strong>all</strong> the imaginary numbers in a square around <span class=\\\"tex\\\">\\$0\\$</span>, and for each:</p>\\n</li>\\n</ol>\\n<ul>\\n<li><p>Use the number as the initial value to compute a sequence.</p>\\n</li>\\n<li><p>If the sequence <strong>converges</strong>, we color the point in #f5c894. </p>\\n</li>\\n<li><p>If the sequence <strong>diverges</strong>, we color the point in #445233.</p>\\n</li>\\n</ul>\\n</blockquote>\\n</div>\""
+          "\"<div class=\\\"markdown\\\"><blockquote>\\n<h4>Recipe: Julia Set picture</h4>\\n<ol>\\n<li><p>Choose a complex number <span class=\\\"tex\\\">\\$c\\$</span> <strong>&#40;on the left&#41;</strong>.</p>\\n</li>\\n<li><p>We define our favorite sequence <span class=\\\"tex\\\">\\$z_&#123;n&#43;1&#125; &#61; z_n^2 &#43; c\\$</span></p>\\n</li>\\n<li><p>Now, we&#39;re going over <strong>all</strong> the imaginary numbers in a square around <span class=\\\"tex\\\">\\$0\\$</span>, and for each:</p>\\n</li>\\n</ol>\\n<ul>\\n<li><p>Use the number as the initial value to compute a sequence.</p>\\n</li>\\n<li><p>If the sequence <strong>converges</strong>, we color the point in #f5c894. </p>\\n</li>\\n<li><p>If the sequence <strong>diverges</strong>, we color the point in #445233.</p>\\n</li>\\n</ul>\\n</blockquote>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><blockquote>\\n<h4>Recipe: Julia Set picture</h4>\\n<ol>\\n<li><p>Choose a complex number <span class=\\\"tex\\\">\\$c\\$</span> <strong>&#40;on the left&#41;</strong>.</p>\\n</li>\\n<li><p>We define our favorite sequence <span class=\\\"tex\\\">\\$z_&#123;n&#43;1&#125; &#61; z_n^2 &#43; c\\$</span></p>\\n</li>\\n<li><p>Now, we&#39;re going over <strong>all</strong> the imaginary numbers in a square around <span class=\\\"tex\\\">\\$0\\$</span>, and for each:</p>\\n</li>\\n</ol>\\n<ul>\\n<li><p>Use the number as the initial value to compute a sequence.</p>\\n</li>\\n<li><p>If the sequence <strong>converges</strong>, we color the point in #ffffff. </p>\\n</li>\\n<li><p>If the sequence <strong>diverges</strong>, we color the point in #445233.</p>\\n</li>\\n</ul>\\n</blockquote>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><blockquote>\\n<h4>Recipe: Julia Set picture</h4>\\n<ol>\\n<li><p>Choose a complex number <span class=\\\"tex\\\">\\$c\\$</span> <strong>&#40;on the left&#41;</strong>.</p>\\n</li>\\n<li><p>We define our favorite sequence <span class=\\\"tex\\\">\\$z_&#123;n&#43;1&#125; &#61; z_n^2 &#43; c\\$</span></p>\\n</li>\\n<li><p>Now, we&#39;re going over <strong>all</strong> the imaginary numbers in a square around <span class=\\\"tex\\\">\\$0\\$</span>, and for each:</p>\\n</li>\\n</ol>\\n<ul>\\n<li><p>Use the number as the initial value to compute a sequence.</p>\\n</li>\\n<li><p>If the sequence <strong>converges</strong>, we color the point in #f5c894. </p>\\n</li>\\n<li><p>If the sequence <strong>diverges</strong>, we color the point in #ffffff.</p>\\n</li>\\n</ul>\\n</blockquote>\\n</div>\""
         ],
         "kind": "string",
         "mime": "text/html",
@@ -3169,9 +2826,16 @@
         "rettype": "String",
         "samples": [
           [
-            "-0.0400000000000001 + 0.72im",
             "\"#f5c894\"",
             "\"#445233\""
+          ],
+          [
+            "\"#ffffff\"",
+            "\"#445233\""
+          ],
+          [
+            "\"#f5c894\"",
+            "\"#ffffff\""
           ]
         ]
       }
@@ -3181,10 +2845,6 @@
     "group_reasons": [],
     "notebook": "fractals.jl",
     "preamble": [
-      "function scale_tuple(tuple, new_min, new_max)\n    #= none:1 =#\n    #= none:2 =#\n    return (Int(round(((tuple[1] + 1.5) / 3) * (new_max - new_min) + new_min)), Int(round(((tuple[2] + 1.5) / 3) * (new_max - new_min) + new_min)))\nend",
-      "f(z, c) = begin\n        #= none:2 =#\n        z * z + c\n    end",
-      "function is_stable(iterations, z, c)\n    #= none:6 =#\n    #= none:7 =#\n    for _ = 1:iterations\n        #= none:9 =#\n        if abs(z) > 5\n            #= none:10 =#\n            return 0\n        end\n        #= none:12 =#\n        z = f(z, c)\n        #= none:13 =#\n    end\n    #= none:14 =#\n    1\nend",
-      "function julia_fractal(depth, X, Y, c, f)\n    #= none:21 =#\n    #= none:22 =#\n    img = fill(0.0f0, (img_size + 1) * (img_size + 1))\n    #= none:23 =#\n    for x = X\n        #= none:24 =#\n        for y = Y\n            #= none:25 =#\n            z = f(x, y)\n            #= none:26 =#\n            (x_scaled, y_scaled) = scale_tuple((x, y), 0, img_size)\n            #= none:27 =#\n            img[y_scaled + 1 + x_scaled * (img_size + 1)] = is_stable(depth, z, c)\n            #= none:28 =#\n        end\n        #= none:29 =#\n    end\n    #= none:30 =#\n    img\nend",
       "using PlutoUI, PlutoTeachingTools, PlutoImageCoordinatePicker, WasmMakie",
       "using ImageShow, ImageIO, Colors"
     ]
@@ -3204,12 +2864,49 @@
       {
         "cell_id": "ae6b02ce-180e-487b-9a25-2be9c6092293",
         "extract_ok": true,
-        "fn_src": "function (initial_value::Int64, initial_value_with_c::Int64, max_n::Int64)\n    C = $(QuoteNode(-1))\n    C_sequence = create_sequence_with_c(Fc, C, initial_value_with_c, max_n)\n    var\"##cellval#880\" = C_sequence\n    return var\"##cellval#880\"\nend",
+        "fn_src": "function (initial_value::Int64, initial_value_with_c::Int64, max_n::Int64)\n    C = $(QuoteNode(-1))\n    C_sequence = create_sequence_with_c(Fc, C, initial_value_with_c, max_n)\n    var\"##cellval#825\" = C_sequence\n    return var\"##cellval#825\"\nend",
         "golden": [
           "[1]",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#891\".var\"#2#3\")(::BigInt, ::Int64, ::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#891\".var\"#2#3\")(!Matched::Int64, ::Int64, ::Int64)\n   @ Main.var\"##hv#891\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#891\".var\"#2#3\")(::Int64, ::BigInt, ::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#891\".var\"#2#3\")(::Int64, !Matched::Int64, ::Int64)\n   @ Main.var\"##hv#891\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#838\".var\"#2#3\")(::BigInt, ::Int64, ::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#838\".var\"#2#3\")(!Matched::Int64, ::Int64, ::Int64)\n   @ Main.var\"##hv#838\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#838\".var\"#2#3\")(::Int64, ::BigInt, ::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#838\".var\"#2#3\")(::Int64, !Matched::Int64, ::Int64)\n   @ Main.var\"##hv#838\" none:0\n",
           "[1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0]"
+        ],
+        "kind": "tree",
+        "mime": "application/vnd.pluto.tree+object",
+        "reasons": [],
+        "rettype": "Vector{Int64}",
+        "samples": [
+          [
+            "-10",
+            "1",
+            "1"
+          ],
+          [
+            "21",
+            "1",
+            "1"
+          ],
+          [
+            "-10",
+            "21",
+            "1"
+          ],
+          [
+            "-10",
+            "1",
+            "20"
+          ]
+        ]
+      },
+      {
+        "cell_id": "ee4df211-020e-43d4-a41d-513fbd6f31b7",
+        "extract_ok": true,
+        "fn_src": "function (initial_value::Int64, initial_value_with_c::Int64, max_n::Int64)\n    sequence = create_sequence(F, initial_value, max_n)\n    var\"##cellval#826\" = sequence\n    return var\"##cellval#826\"\nend",
+        "golden": [
+          "[-10]",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#838\".var\"#5#6\")(::BigInt, ::Int64, ::Int64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#838\".var\"#5#6\")(!Matched::Int64, ::Int64, ::Int64)\n   @ Main.var\"##hv#838\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#838\".var\"#5#6\")(::Int64, ::BigInt, ::Int64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#838\".var\"#5#6\")(::Int64, !Matched::Int64, ::Int64)\n   @ Main.var\"##hv#838\" none:0\n",
+          "[-10, 101, 10202, 104080805, 10832813969448026, -5257659521197158491, 8128048319517835354, 5447623955824582565, 450075922934751322, -6610599726280630363, 5290282140997804122, -2994486988833054811, -2306455147916795814, -1810588387028787291, -3614232991933636518, -1743865572590641243, 949347015816142938, 5646647375586107301, 2985183730106916954, 5539408661823332261]"
         ],
         "kind": "tree",
         "mime": "application/vnd.pluto.tree+object",
@@ -3241,54 +2938,17 @@
       {
         "cell_id": "221742a5-146e-4d7d-8d50-0f7bd5a30cb5",
         "extract_ok": true,
-        "fn_src": "function (initial_value::Int64, initial_value_with_c::Int64, max_n::Int64)\n    var\"##cellval#881\" = if initial_value_with_c == 1\n            #= none:3 =#\n            md\"!!! correct \\\"Answer\\\"\n\n\tIn this case, the series **doesn't** go to infinity but moves back and forth between 0 and -1, and so it doesn't *diverge*. It oscillates. \n\n\tPS: The same thing happens if initial\\_value\\_with\\_c = 0\"\n        else\n            #= none:10 =#\n            md\"\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#881\")\nend",
+        "fn_src": "function (initial_value::Int64, initial_value_with_c::Int64, max_n::Int64)\n    var\"##cellval#827\" = if initial_value_with_c == 1\n            #= none:3 =#\n            md\"!!! correct \\\"Answer\\\"\n\n\tIn this case, the series **doesn't** go to infinity but moves back and forth between 0 and -1, and so it doesn't *diverge*. It oscillates. \n\n\tPS: The same thing happens if initial\\_value\\_with\\_c = 0\"\n        else\n            #= none:10 =#\n            md\"\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#827\")\nend",
         "golden": [
           "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#891\".var\"#5#6\")(::BigInt, ::Int64, ::Int64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#891\".var\"#5#6\")(!Matched::Int64, ::Int64, ::Int64)\n   @ Main.var\"##hv#891\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#891\".var\"#5#6\")(::Int64, ::BigInt, ::Int64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#891\".var\"#5#6\")(::Int64, !Matched::Int64, ::Int64)\n   @ Main.var\"##hv#891\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#838\".var\"#8#9\")(::BigInt, ::Int64, ::Int64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#838\".var\"#8#9\")(!Matched::Int64, ::Int64, ::Int64)\n   @ Main.var\"##hv#838\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#838\".var\"#8#9\")(::Int64, ::BigInt, ::Int64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#838\".var\"#8#9\")(::Int64, !Matched::Int64, ::Int64)\n   @ Main.var\"##hv#838\" none:0\n",
           "ERR:text/html rendering of Markdown.MD unsupported"
         ],
         "kind": "string",
         "mime": "text/html",
         "reasons": [],
         "rettype": "Union{}",
-        "samples": [
-          [
-            "-10",
-            "1",
-            "1"
-          ],
-          [
-            "21",
-            "1",
-            "1"
-          ],
-          [
-            "-10",
-            "21",
-            "1"
-          ],
-          [
-            "-10",
-            "1",
-            "20"
-          ]
-        ]
-      },
-      {
-        "cell_id": "ee4df211-020e-43d4-a41d-513fbd6f31b7",
-        "extract_ok": true,
-        "fn_src": "function (initial_value::Int64, initial_value_with_c::Int64, max_n::Int64)\n    sequence = create_sequence(F, initial_value, max_n)\n    var\"##cellval#882\" = sequence\n    return var\"##cellval#882\"\nend",
-        "golden": [
-          "[-10]",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#891\".var\"#8#9\")(::BigInt, ::Int64, ::Int64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#891\".var\"#8#9\")(!Matched::Int64, ::Int64, ::Int64)\n   @ Main.var\"##hv#891\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#891\".var\"#8#9\")(::Int64, ::BigInt, ::Int64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#891\".var\"#8#9\")(::Int64, !Matched::Int64, ::Int64)\n   @ Main.var\"##hv#891\" none:0\n",
-          "[-10, 101, 10202, 104080805, 10832813969448026, -5257659521197158491, 8128048319517835354, 5447623955824582565, 450075922934751322, -6610599726280630363, 5290282140997804122, -2994486988833054811, -2306455147916795814, -1810588387028787291, -3614232991933636518, -1743865572590641243, 949347015816142938, 5646647375586107301, 2985183730106916954, 5539408661823332261]"
-        ],
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": [],
-        "rettype": "Vector{Int64}",
         "samples": [
           [
             "-10",
@@ -3318,12 +2978,150 @@
     "group_reasons": [],
     "notebook": "fractals.jl",
     "preamble": [
-      "Fc(z, c) = begin\n        #= none:1 =#\n        z ^ 2 + c\n    end",
       "function create_sequence_with_c(F, C, initial_value, max_n)\n    #= none:1 =#\n    #= none:3 =#\n    function z_i(last_z, i)\n        #= none:3 =#\n        #= none:4 =#\n        F(last_z, C)\n    end\n    #= none:8 =#\n    series = accumulate(z_i, 2:max_n, init = initial_value)\n    #= none:11 =#\n    return [initial_value, series...]\nend",
+      "Fc(z, c) = begin\n        #= none:1 =#\n        z ^ 2 + c\n    end",
       "using PlutoUI, PlutoTeachingTools, PlutoImageCoordinatePicker, WasmMakie",
       "using ImageShow, ImageIO, Colors",
-      "F(z) = begin\n        #= none:1 =#\n        z ^ 2 + 1\n    end",
-      "function create_sequence(F, initial_value, max_n)\n    #= none:1 =#\n    #= none:3 =#\n    function z_i(last_z, i)\n        #= none:3 =#\n        #= none:4 =#\n        F(last_z)\n    end\n    #= none:8 =#\n    series = accumulate(z_i, 2:max_n, init = initial_value)\n    #= none:11 =#\n    return [initial_value, series...]\nend"
+      "function create_sequence(F, initial_value, max_n)\n    #= none:1 =#\n    #= none:3 =#\n    function z_i(last_z, i)\n        #= none:3 =#\n        #= none:4 =#\n        F(last_z)\n    end\n    #= none:8 =#\n    series = accumulate(z_i, 2:max_n, init = initial_value)\n    #= none:11 =#\n    return [initial_value, series...]\nend",
+      "F(z) = begin\n        #= none:1 =#\n        z ^ 2 + 1\n    end"
+    ]
+  },
+  {
+    "argtypes": [
+      "Float64",
+      "Float64",
+      "Int64",
+      "Int64"
+    ],
+    "bonds": [
+      "julia_cx",
+      "julia_cy",
+      "julia_iter",
+      "julia_zoom"
+    ],
+    "cells": [
+      {
+        "cell_id": "8899561d-42e7-4397-a649-8800461c6649",
+        "extract_ok": true,
+        "fn_src": "function (julia_cx::Float64, julia_cy::Float64, julia_iter::Int64, julia_zoom::Int64)\n    var\"##cellval#828\" = let\n            #= none:5 =#\n            n = 140\n            #= none:6 =#\n            half = 1.6 / Float64(julia_zoom)\n            #= none:7 =#\n            pix = julia_field(Int64(n), Int64(julia_iter), Float64(julia_cx), Float64(julia_cy), 0.0, 0.0, half)\n            #= none:10 =#\n            fractal_figure(pix, Int64(n))\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#828\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#839\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#839\".var\"#3#4\")(::Int64, ::Float64, ::Int64, ::Int64)\nThe function `#3` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#839\".var\"#3#4\")(!Matched::Float64, ::Float64, ::Int64, ::Int64)\n   @ Main.var\"##hv#839\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#839\".var\"#3#4\")(::Float64, ::Int64, ::Int64, ::Int64)\nThe function `#3` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#839\".var\"#3#4\")(::Float64, !Matched::Float64, ::Int64, ::Int64)\n   @ Main.var\"##hv#839\" none:0\n",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#839\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "-0.04",
+            "0.72",
+            "60",
+            "1"
+          ],
+          [
+            "101",
+            "0.72",
+            "60",
+            "1"
+          ],
+          [
+            "-0.04",
+            "101",
+            "60",
+            "1"
+          ],
+          [
+            "-0.04",
+            "0.72",
+            "23",
+            "1"
+          ]
+        ]
+      }
+    ],
+    "group": 4,
+    "group_ok": true,
+    "group_reasons": [],
+    "notebook": "fractals.jl",
+    "preamble": [
+      "function escape_color(escaped::Bool, t::Float64)\n    #= none:4 =#\n    #= none:5 =#\n    if !escaped\n        #= none:6 =#\n        return (0.0, 0.0, 0.0, 1.0)\n    end\n    #= none:8 =#\n    r = 0.5 + 0.5 * sin(3.0 + 6.2831853t)\n    #= none:9 =#\n    g = 0.5 + 0.5 * sin(1.0 + 6.2831853t)\n    #= none:10 =#\n    b = 0.5 + 0.5 * sin(5.0 + 6.2831853t)\n    #= none:11 =#\n    return (r, g, b, 1.0)\nend",
+      "function julia_field(n::Int64, max_iter::Int64, cx::Float64, cy::Float64, ctr_x::Float64, ctr_y::Float64, half::Float64)\n    #= none:10 =#\n    #= none:12 =#\n    nn = if n < 2\n            Int64(2)\n        else\n            if n > 200\n                Int64(200)\n            else\n                n\n            end\n        end\n    #= none:13 =#\n    mi = if max_iter < 1\n            Int64(1)\n        else\n            max_iter\n        end\n    #= none:14 =#\n    h = if half <= 0.0\n            1.0e-6\n        else\n            half\n        end\n    #= none:15 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nn * nn)\n    #= none:16 =#\n    lo_x = ctr_x - h\n    #= none:17 =#\n    lo_y = ctr_y - h\n    #= none:18 =#\n    step = (2.0h) / Float64(nn - 1)\n    #= none:19 =#\n    for j = 1:nn\n        #= none:20 =#\n        zy0 = lo_y + step * Float64(j - 1)\n        #= none:21 =#\n        for i = 1:nn\n            #= none:22 =#\n            zx = lo_x + step * Float64(i - 1)\n            #= none:23 =#\n            zy = zy0\n            #= none:24 =#\n            it = Int64(0)\n            #= none:25 =#\n            escaped = false\n            #= none:26 =#\n            while it < mi\n                #= none:27 =#\n                zx2 = zx * zx\n                #= none:28 =#\n                zy2 = zy * zy\n                #= none:29 =#\n                if zx2 + zy2 > 4.0\n                    #= none:30 =#\n                    escaped = true\n                    #= none:31 =#\n                    break\n                end\n                #= none:33 =#\n                new_zx = (zx2 - zy2) + cx\n                #= none:34 =#\n                zy = 2.0 * zx * zy + cy\n                #= none:35 =#\n                zx = new_zx\n                #= none:36 =#\n                it += 1\n                #= none:37 =#\n            end\n            #= none:38 =#\n            t = Float64(it) / Float64(mi)\n            #= none:39 =#\n            pix[i + (j - 1) * nn] = escape_color(escaped, t)\n            #= none:40 =#\n        end\n        #= none:41 =#\n    end\n    #= none:42 =#\n    return pix\nend",
+      "function mandel_field(n::Int64, max_iter::Int64, ctr_x::Float64, ctr_y::Float64, half::Float64)\n    #= none:47 =#\n    #= none:49 =#\n    nn = if n < 2\n            Int64(2)\n        else\n            if n > 200\n                Int64(200)\n            else\n                n\n            end\n        end\n    #= none:50 =#\n    mi = if max_iter < 1\n            Int64(1)\n        else\n            max_iter\n        end\n    #= none:51 =#\n    h = if half <= 0.0\n            1.0e-6\n        else\n            half\n        end\n    #= none:52 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nn * nn)\n    #= none:53 =#\n    lo_x = ctr_x - h\n    #= none:54 =#\n    lo_y = ctr_y - h\n    #= none:55 =#\n    step = (2.0h) / Float64(nn - 1)\n    #= none:56 =#\n    for j = 1:nn\n        #= none:57 =#\n        cy = lo_y + step * Float64(j - 1)\n        #= none:58 =#\n        for i = 1:nn\n            #= none:59 =#\n            cx = lo_x + step * Float64(i - 1)\n            #= none:60 =#\n            zx = 0.0\n            #= none:61 =#\n            zy = 0.0\n            #= none:62 =#\n            it = Int64(0)\n            #= none:63 =#\n            escaped = false\n            #= none:64 =#\n            while it < mi\n                #= none:65 =#\n                zx2 = zx * zx\n                #= none:66 =#\n                zy2 = zy * zy\n                #= none:67 =#\n                if zx2 + zy2 > 4.0\n                    #= none:68 =#\n                    escaped = true\n                    #= none:69 =#\n                    break\n                end\n                #= none:71 =#\n                new_zx = (zx2 - zy2) + cx\n                #= none:72 =#\n                zy = 2.0 * zx * zy + cy\n                #= none:73 =#\n                zx = new_zx\n                #= none:74 =#\n                it += 1\n                #= none:75 =#\n            end\n            #= none:76 =#\n            t = Float64(it) / Float64(mi)\n            #= none:77 =#\n            pix[i + (j - 1) * nn] = escape_color(escaped, t)\n            #= none:78 =#\n        end\n        #= none:79 =#\n    end\n    #= none:80 =#\n    return pix\nend",
+      "function fractal_figure(pix::Vector{NTuple{4, Float64}}, nn::Int64; px::Int = 340)\n    #= none:86 =#\n    #= none:87 =#\n    fig = Figure(size = (px, px))\n    #= none:88 =#\n    ax = Axis(fig[1, 1])\n    #= none:89 =#\n    hidedecorations!(ax)\n    #= none:90 =#\n    hidespines!(ax)\n    #= none:91 =#\n    image!(ax, (0.0, Float64(nn)), (0.0, Float64(nn)), pix, nn, nn; interpolate = false)\n    #= none:93 =#\n    fig\nend",
+      "using PlutoUI, PlutoTeachingTools, PlutoImageCoordinatePicker, WasmMakie",
+      "using ImageShow, ImageIO, Colors"
+    ]
+  },
+  {
+    "argtypes": [
+      "Float64",
+      "Float64",
+      "Int64",
+      "Int64"
+    ],
+    "bonds": [
+      "mb_cx",
+      "mb_cy",
+      "mb_iter",
+      "mb_zoom"
+    ],
+    "cells": [
+      {
+        "cell_id": "d3b2c4e5-9066-4c2f-b14a-3e2c7f8a5d93",
+        "extract_ok": true,
+        "fn_src": "function (mb_cx::Float64, mb_cy::Float64, mb_iter::Int64, mb_zoom::Int64)\n    var\"##cellval#829\" = let\n            #= none:4 =#\n            n = 140\n            #= none:5 =#\n            half = 1.6 / Float64(mb_zoom)\n            #= none:6 =#\n            pix = mandel_field(Int64(n), Int64(mb_iter), Float64(mb_cx), Float64(mb_cy), half)\n            #= none:8 =#\n            fractal_figure(pix, Int64(n))\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#829\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#840\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#840\".var\"#3#4\")(::Int64, ::Float64, ::Int64, ::Int64)\nThe function `#3` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#840\".var\"#3#4\")(!Matched::Float64, ::Float64, ::Int64, ::Int64)\n   @ Main.var\"##hv#840\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#840\".var\"#3#4\")(::Float64, ::Int64, ::Int64, ::Int64)\nThe function `#3` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#840\".var\"#3#4\")(::Float64, !Matched::Float64, ::Int64, ::Int64)\n   @ Main.var\"##hv#840\" none:0\n",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#840\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "-0.5",
+            "-0.01",
+            "60",
+            "1"
+          ],
+          [
+            "151",
+            "-0.01",
+            "60",
+            "1"
+          ],
+          [
+            "-0.5",
+            "126",
+            "60",
+            "1"
+          ],
+          [
+            "-0.5",
+            "-0.01",
+            "23",
+            "1"
+          ]
+        ]
+      }
+    ],
+    "group": 5,
+    "group_ok": true,
+    "group_reasons": [],
+    "notebook": "fractals.jl",
+    "preamble": [
+      "function escape_color(escaped::Bool, t::Float64)\n    #= none:4 =#\n    #= none:5 =#\n    if !escaped\n        #= none:6 =#\n        return (0.0, 0.0, 0.0, 1.0)\n    end\n    #= none:8 =#\n    r = 0.5 + 0.5 * sin(3.0 + 6.2831853t)\n    #= none:9 =#\n    g = 0.5 + 0.5 * sin(1.0 + 6.2831853t)\n    #= none:10 =#\n    b = 0.5 + 0.5 * sin(5.0 + 6.2831853t)\n    #= none:11 =#\n    return (r, g, b, 1.0)\nend",
+      "function julia_field(n::Int64, max_iter::Int64, cx::Float64, cy::Float64, ctr_x::Float64, ctr_y::Float64, half::Float64)\n    #= none:10 =#\n    #= none:12 =#\n    nn = if n < 2\n            Int64(2)\n        else\n            if n > 200\n                Int64(200)\n            else\n                n\n            end\n        end\n    #= none:13 =#\n    mi = if max_iter < 1\n            Int64(1)\n        else\n            max_iter\n        end\n    #= none:14 =#\n    h = if half <= 0.0\n            1.0e-6\n        else\n            half\n        end\n    #= none:15 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nn * nn)\n    #= none:16 =#\n    lo_x = ctr_x - h\n    #= none:17 =#\n    lo_y = ctr_y - h\n    #= none:18 =#\n    step = (2.0h) / Float64(nn - 1)\n    #= none:19 =#\n    for j = 1:nn\n        #= none:20 =#\n        zy0 = lo_y + step * Float64(j - 1)\n        #= none:21 =#\n        for i = 1:nn\n            #= none:22 =#\n            zx = lo_x + step * Float64(i - 1)\n            #= none:23 =#\n            zy = zy0\n            #= none:24 =#\n            it = Int64(0)\n            #= none:25 =#\n            escaped = false\n            #= none:26 =#\n            while it < mi\n                #= none:27 =#\n                zx2 = zx * zx\n                #= none:28 =#\n                zy2 = zy * zy\n                #= none:29 =#\n                if zx2 + zy2 > 4.0\n                    #= none:30 =#\n                    escaped = true\n                    #= none:31 =#\n                    break\n                end\n                #= none:33 =#\n                new_zx = (zx2 - zy2) + cx\n                #= none:34 =#\n                zy = 2.0 * zx * zy + cy\n                #= none:35 =#\n                zx = new_zx\n                #= none:36 =#\n                it += 1\n                #= none:37 =#\n            end\n            #= none:38 =#\n            t = Float64(it) / Float64(mi)\n            #= none:39 =#\n            pix[i + (j - 1) * nn] = escape_color(escaped, t)\n            #= none:40 =#\n        end\n        #= none:41 =#\n    end\n    #= none:42 =#\n    return pix\nend",
+      "function mandel_field(n::Int64, max_iter::Int64, ctr_x::Float64, ctr_y::Float64, half::Float64)\n    #= none:47 =#\n    #= none:49 =#\n    nn = if n < 2\n            Int64(2)\n        else\n            if n > 200\n                Int64(200)\n            else\n                n\n            end\n        end\n    #= none:50 =#\n    mi = if max_iter < 1\n            Int64(1)\n        else\n            max_iter\n        end\n    #= none:51 =#\n    h = if half <= 0.0\n            1.0e-6\n        else\n            half\n        end\n    #= none:52 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nn * nn)\n    #= none:53 =#\n    lo_x = ctr_x - h\n    #= none:54 =#\n    lo_y = ctr_y - h\n    #= none:55 =#\n    step = (2.0h) / Float64(nn - 1)\n    #= none:56 =#\n    for j = 1:nn\n        #= none:57 =#\n        cy = lo_y + step * Float64(j - 1)\n        #= none:58 =#\n        for i = 1:nn\n            #= none:59 =#\n            cx = lo_x + step * Float64(i - 1)\n            #= none:60 =#\n            zx = 0.0\n            #= none:61 =#\n            zy = 0.0\n            #= none:62 =#\n            it = Int64(0)\n            #= none:63 =#\n            escaped = false\n            #= none:64 =#\n            while it < mi\n                #= none:65 =#\n                zx2 = zx * zx\n                #= none:66 =#\n                zy2 = zy * zy\n                #= none:67 =#\n                if zx2 + zy2 > 4.0\n                    #= none:68 =#\n                    escaped = true\n                    #= none:69 =#\n                    break\n                end\n                #= none:71 =#\n                new_zx = (zx2 - zy2) + cx\n                #= none:72 =#\n                zy = 2.0 * zx * zy + cy\n                #= none:73 =#\n                zx = new_zx\n                #= none:74 =#\n                it += 1\n                #= none:75 =#\n            end\n            #= none:76 =#\n            t = Float64(it) / Float64(mi)\n            #= none:77 =#\n            pix[i + (j - 1) * nn] = escape_color(escaped, t)\n            #= none:78 =#\n        end\n        #= none:79 =#\n    end\n    #= none:80 =#\n    return pix\nend",
+      "function fractal_figure(pix::Vector{NTuple{4, Float64}}, nn::Int64; px::Int = 340)\n    #= none:86 =#\n    #= none:87 =#\n    fig = Figure(size = (px, px))\n    #= none:88 =#\n    ax = Axis(fig[1, 1])\n    #= none:89 =#\n    hidedecorations!(ax)\n    #= none:90 =#\n    hidespines!(ax)\n    #= none:91 =#\n    image!(ax, (0.0, Float64(nn)), (0.0, Float64(nn)), pix, nn, nn; interpolate = false)\n    #= none:93 =#\n    fig\nend",
+      "using PlutoUI, PlutoTeachingTools, PlutoImageCoordinatePicker, WasmMakie",
+      "using ImageShow, ImageIO, Colors"
     ]
   },
   {
@@ -3337,13 +3135,13 @@
     ],
     "cells": [
       {
-        "cell_id": "2e7f10f3-eb4d-40e0-ae48-c0b4563b99c4",
+        "cell_id": "4135244d-fb5a-4e8d-ad4b-c4046781b70c",
         "extract_ok": true,
-        "fn_src": "function (n::Int64, z0::Int64)\n    z1 = z0 ^ 2 + 1\n    var\"##cellval#883\" = z1\n    return (PlutoIslands._plain_body)(var\"##cellval#883\")\nend",
+        "fn_src": "function (n::Int64, z0::Int64)\n    zₙ = Fⁿ(z0, n)\n    var\"##cellval#830\" = zₙ\n    return (PlutoIslands._plain_body)(var\"##cellval#830\")\nend",
         "golden": [
-          "\"2\"",
-          "\"2\"",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#892\".var\"#2#3\")(::Int64, ::BigInt)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#892\".var\"#2#3\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#892\" none:0\n"
+          "\"458330\"",
+          "\"7126870523349933989\"",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#841\".var\"#2#3\")(::Int64, ::BigInt)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#841\".var\"#2#3\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#841\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -3365,13 +3163,13 @@
         ]
       },
       {
-        "cell_id": "4135244d-fb5a-4e8d-ad4b-c4046781b70c",
+        "cell_id": "2e7f10f3-eb4d-40e0-ae48-c0b4563b99c4",
         "extract_ok": true,
-        "fn_src": "function (n::Int64, z0::Int64)\n    zₙ = Fⁿ(z0, n)\n    var\"##cellval#884\" = zₙ\n    return (PlutoIslands._plain_body)(var\"##cellval#884\")\nend",
+        "fn_src": "function (n::Int64, z0::Int64)\n    z1 = z0 ^ 2 + 1\n    var\"##cellval#831\" = z1\n    return (PlutoIslands._plain_body)(var\"##cellval#831\")\nend",
         "golden": [
-          "\"458330\"",
-          "\"7126870523349933989\"",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#892\".var\"#5#6\")(::Int64, ::BigInt)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#892\".var\"#5#6\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#892\" none:0\n"
+          "\"2\"",
+          "\"2\"",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#841\".var\"#5#6\")(::Int64, ::BigInt)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#841\".var\"#5#6\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#841\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -3395,11 +3193,11 @@
       {
         "cell_id": "cf1f1d8a-c462-47b1-9e17-ea88357570aa",
         "extract_ok": true,
-        "fn_src": "function (n::Int64, z0::Int64)\n    z1 = z0 ^ 2 + 1\n    z2 = z1 ^ 2 + 1\n    var\"##cellval#885\" = z2\n    return (PlutoIslands._plain_body)(var\"##cellval#885\")\nend",
+        "fn_src": "function (n::Int64, z0::Int64)\n    z1 = z0 ^ 2 + 1\n    z2 = z1 ^ 2 + 1\n    var\"##cellval#832\" = z2\n    return (PlutoIslands._plain_body)(var\"##cellval#832\")\nend",
         "golden": [
           "\"5\"",
           "\"5\"",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#892\".var\"#8#9\")(::Int64, ::BigInt)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#892\".var\"#8#9\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#892\" none:0\n"
+          "ERR:MethodError: no method matching (::Main.var\"##hv#841\".var\"#8#9\")(::Int64, ::BigInt)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#841\".var\"#8#9\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#841\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -3423,11 +3221,11 @@
       {
         "cell_id": "b2a95d75-a254-4918-96d2-7ec5c2a60d8a",
         "extract_ok": true,
-        "fn_src": "function (n::Int64, z0::Int64)\n    z1 = z0 ^ 2 + 1\n    z2 = z1 ^ 2 + 1\n    z3 = z2 ^ 2 + 1\n    var\"##cellval#886\" = z3\n    return (PlutoIslands._plain_body)(var\"##cellval#886\")\nend",
+        "fn_src": "function (n::Int64, z0::Int64)\n    z1 = z0 ^ 2 + 1\n    z2 = z1 ^ 2 + 1\n    z3 = z2 ^ 2 + 1\n    var\"##cellval#833\" = z3\n    return (PlutoIslands._plain_body)(var\"##cellval#833\")\nend",
         "golden": [
           "\"26\"",
           "\"26\"",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#892\".var\"#11#12\")(::Int64, ::BigInt)\nThe function `#11` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#892\".var\"#11#12\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#892\" none:0\n"
+          "ERR:MethodError: no method matching (::Main.var\"##hv#841\".var\"#11#12\")(::Int64, ::BigInt)\nThe function `#11` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#841\".var\"#11#12\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#841\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -3451,11 +3249,11 @@
       {
         "cell_id": "d81173b4-8847-4c17-9a30-5e20c6f313dd",
         "extract_ok": true,
-        "fn_src": "function (n::Int64, z0::Int64)\n    z1 = z0 ^ 2 + 1\n    z2 = z1 ^ 2 + 1\n    z3 = z2 ^ 2 + 1\n    z4 = z3 ^ 2 + 1\n    var\"##cellval#887\" = z4\n    return (PlutoIslands._plain_body)(var\"##cellval#887\")\nend",
+        "fn_src": "function (n::Int64, z0::Int64)\n    z1 = z0 ^ 2 + 1\n    z2 = z1 ^ 2 + 1\n    z3 = z2 ^ 2 + 1\n    z4 = z3 ^ 2 + 1\n    var\"##cellval#834\" = z4\n    return (PlutoIslands._plain_body)(var\"##cellval#834\")\nend",
         "golden": [
           "\"677\"",
           "\"677\"",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#892\".var\"#14#15\")(::Int64, ::BigInt)\nThe function `#14` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#892\".var\"#14#15\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#892\" none:0\n"
+          "ERR:MethodError: no method matching (::Main.var\"##hv#841\".var\"#14#15\")(::Int64, ::BigInt)\nThe function `#14` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#841\".var\"#14#15\")(::Int64, !Matched::Int64)\n   @ Main.var\"##hv#841\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -3477,15 +3275,15 @@
         ]
       }
     ],
-    "group": 4,
+    "group": 6,
     "group_ok": true,
     "group_reasons": [],
     "notebook": "fractals.jl",
     "preamble": [
-      "using PlutoUI, PlutoTeachingTools, PlutoImageCoordinatePicker, WasmMakie",
-      "using ImageShow, ImageIO, Colors",
       "F(z) = begin\n        #= none:1 =#\n        z ^ 2 + 1\n    end",
-      "Fⁿ(x, n) = begin\n        #= none:1 =#\n        ((∘)(fill(F, n)...))(x)\n    end"
+      "Fⁿ(x, n) = begin\n        #= none:1 =#\n        ((∘)(fill(F, n)...))(x)\n    end",
+      "using PlutoUI, PlutoTeachingTools, PlutoImageCoordinatePicker, WasmMakie",
+      "using ImageShow, ImageIO, Colors"
     ]
   },
   {
@@ -3499,7 +3297,7 @@
       {
         "cell_id": "57819281-a466-4f6c-af96-ffe512594270",
         "extract_ok": true,
-        "fn_src": "function (show_answer::Bool,)\n    var\"##cellval#888\" = if show_answer\n            #= none:3 =#\n            md\"!!! correct \\\"Answer!\\\"\n\n\tIf you guessed that the code calculates the $n^{th}$ number in the sequence then you guessed correctly! 🎉\"\n        else\n            #= none:9 =#\n            md\"!!! hint \\\"Did you guess what the code does?\\\" \n\n\t**Tip:** Move both the $n$ **and** the $z_0$ sliders around if you need help!\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#888\")\nend",
+        "fn_src": "function (show_answer::Bool,)\n    var\"##cellval#835\" = if show_answer\n            #= none:3 =#\n            md\"!!! correct \\\"Answer!\\\"\n\n\tIf you guessed that the code calculates the $n^{th}$ number in the sequence then you guessed correctly! 🎉\"\n        else\n            #= none:9 =#\n            md\"!!! hint \\\"Did you guess what the code does?\\\" \n\n\t**Tip:** Move both the $n$ **and** the $z_0$ sliders around if you need help!\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#835\")\nend",
         "golden": [
           "ERR:text/html rendering of Markdown.MD unsupported",
           "ERR:text/html rendering of Markdown.MD unsupported"
@@ -3518,7 +3316,7 @@
         ]
       }
     ],
-    "group": 5,
+    "group": 7,
     "group_ok": true,
     "group_reasons": [],
     "notebook": "fractals.jl",
@@ -3558,9 +3356,228 @@
     ],
     "cells": [
       {
+        "cell_id": "9fab3bbb-5c7f-4464-97c9-847f52754845",
+        "extract_ok": true,
+        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    var\"##cellval#887\" = treatment_in\n    return (PlutoIslands._plain_body)(var\"##cellval#887\")\nend",
+        "golden": [
+          "\"[1, 2, 3, 4, 0, 0, 0, 0]\"",
+          "\"[6, 2, 3, 4, 0, 0, 0, 0]\"",
+          "\"[1, 6, 3, 4, 0, 0, 0, 0]\"",
+          "\"[1, 2, 6, 4, 0, 0, 0, 0]\""
+        ],
+        "kind": "string",
+        "mime": "text/plain",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "1",
+            "2",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "6",
+            "2",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "1",
+            "6",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "1",
+            "2",
+            "6",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ]
+        ]
+      },
+      {
+        "cell_id": "0dd8235c-c09b-49ae-b02a-4bbb285970a6",
+        "extract_ok": true,
+        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    happyX = findlast((>)(0), treatment_in)\n    var\"##cellval#888\" = happyX\n    return (PlutoIslands._plain_body)(var\"##cellval#888\")\nend",
+        "golden": [
+          "\"4\"",
+          "\"4\"",
+          "\"4\"",
+          "\"4\""
+        ],
+        "kind": "string",
+        "mime": "text/plain",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "1",
+            "2",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "6",
+            "2",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "1",
+            "6",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "1",
+            "2",
+            "6",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ]
+        ]
+      },
+      {
+        "cell_id": "9274ed36-a28e-42f3-879f-167d5afa6fc7",
+        "extract_ok": true,
+        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    var\"##cellval#889\" = treatment\n    return var\"##cellval#889\"\nend",
+        "golden": [
+          "[\"💊\", \"💊💊\", \"💊💊💊\", \"💊💊💊💊\", \"\", \"\", \"\", \"\"]",
+          "[\"💊💊💊💊💊💊\", \"💊💊\", \"💊💊💊\", \"💊💊💊💊\", \"\", \"\", \"\", \"\"]",
+          "[\"💊\", \"💊💊💊💊💊💊\", \"💊💊💊\", \"💊💊💊💊\", \"\", \"\", \"\", \"\"]",
+          "[\"💊\", \"💊💊\", \"💊💊💊💊💊💊\", \"💊💊💊💊\", \"\", \"\", \"\", \"\"]"
+        ],
+        "kind": "tree",
+        "mime": "application/vnd.pluto.tree+object",
+        "reasons": [],
+        "rettype": "Vector{String}",
+        "samples": [
+          [
+            "1",
+            "2",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "6",
+            "2",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "1",
+            "6",
+            "3",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ],
+          [
+            "1",
+            "2",
+            "6",
+            "4",
+            "0",
+            "0",
+            "0",
+            "0",
+            "false",
+            "1",
+            "5",
+            "true"
+          ]
+        ]
+      },
+      {
         "cell_id": "380ba7f0-76e6-47ec-98e2-e6c6a3b7f2d5",
         "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    var\"##cellval#934\" = patients\n    return var\"##cellval#934\"\nend",
+        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    var\"##cellval#890\" = patients\n    return var\"##cellval#890\"\nend",
         "golden": [
           "[\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\"]",
           "[\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\"]",
@@ -3633,7 +3650,7 @@
       {
         "cell_id": "a60029d5-ae8d-4704-bef1-076949712c37",
         "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    patients_flipped = append!([\"\" for i = 1:8 - length(patients)], reverse(patients))\n    var\"##cellval#935\" = patients_flipped\n    return var\"##cellval#935\"\nend",
+        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    patients_flipped = append!([\"\" for i = 1:8 - length(patients)], reverse(patients))\n    var\"##cellval#891\" = patients_flipped\n    return var\"##cellval#891\"\nend",
         "golden": [
           "[\"\", \"\", \"\", \"👵🧝🧑👴\", \"👧👴👴👩🧝🧚👩🧓\", \"👩🧔🏼🧝🧚\", \"👴🧑\", \"👵\"]",
           "[\"\", \"\", \"\", \"👵🧝🧑👴\", \"👧👴👴👩🧝🧚👩🧓\", \"👩🧔🏼🧝🧚\", \"👴🧑\", \"👵\"]",
@@ -3704,306 +3721,14 @@
         ]
       },
       {
-        "cell_id": "9fab3bbb-5c7f-4464-97c9-847f52754845",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    var\"##cellval#936\" = treatment_in\n    return (PlutoIslands._plain_body)(var\"##cellval#936\")\nend",
-        "golden": [
-          "\"[1, 2, 3, 4, 0, 0, 0, 0]\"",
-          "\"[6, 2, 3, 4, 0, 0, 0, 0]\"",
-          "\"[1, 6, 3, 4, 0, 0, 0, 0]\"",
-          "\"[1, 2, 6, 4, 0, 0, 0, 0]\""
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "1",
-            "2",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "6",
-            "2",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "1",
-            "6",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "1",
-            "2",
-            "6",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ]
-        ]
-      },
-      {
-        "cell_id": "9274ed36-a28e-42f3-879f-167d5afa6fc7",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    var\"##cellval#937\" = treatment\n    return var\"##cellval#937\"\nend",
-        "golden": [
-          "[\"💊\", \"💊💊\", \"💊💊💊\", \"💊💊💊💊\", \"\", \"\", \"\", \"\"]",
-          "[\"💊💊💊💊💊💊\", \"💊💊\", \"💊💊💊\", \"💊💊💊💊\", \"\", \"\", \"\", \"\"]",
-          "[\"💊\", \"💊💊💊💊💊💊\", \"💊💊💊\", \"💊💊💊💊\", \"\", \"\", \"\", \"\"]",
-          "[\"💊\", \"💊💊\", \"💊💊💊💊💊💊\", \"💊💊💊💊\", \"\", \"\", \"\", \"\"]"
-        ],
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": [],
-        "rettype": "Vector{String}",
-        "samples": [
-          [
-            "1",
-            "2",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "6",
-            "2",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "1",
-            "6",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "1",
-            "2",
-            "6",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ]
-        ]
-      },
-      {
-        "cell_id": "f0d08486-0086-48da-baeb-169f3812d0ea",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    var\"##cellval#938\" = let\n            #= none:2 =#\n            t = treatment\n            #= none:3 =#\n            p = patients\n            #= none:4 =#\n            md\"Now as a doctor, you want to be ready for this scenario, at each day you want to know, how many pills you will need for your patients:\n\n- On day 1: you would give $((t[1]))  to $((p[1])) \n- On day 2: you would give $((t[2]))  to $((p[1]))  , and $((t[1]))  to $((p[2]))  each\n- On day 3: you would give  $((t[3]))  to $(length(p[1])) , and $((t[2])) pills to $((p[2])) , and $((t[1]))  to $((p[3]))  each ... etc \n\nNotice how we are multiplying and adding each day? We are close to performing a convolution already!\n\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#938\")\nend",
-        "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported"
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "1",
-            "2",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "6",
-            "2",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "1",
-            "6",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "1",
-            "2",
-            "6",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ]
-        ]
-      },
-      {
         "cell_id": "472b52d8-e787-4a93-83d8-c53e977a143c",
         "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    patients_flipped = append!([\"\" for i = 1:8 - length(patients)], reverse(patients))\n    numbers_patients = [length(s) for s = patients_flipped]\n    y2_patients = append!([0 for i = 1:9], numbers_patients, [0 for i = 1:16 - length(patients_flipped)])\n    numbers_pills = [length(s) for s = treatment]\n    y1_pills = append!([0 for i = 1:9], numbers_pills, [0 for i = 1:16 - length(numbers_pills)])\n    if k_conv < 9\n        #= none:11 =#\n        idx = 9 - k_conv\n    else\n        #= none:11 =#\n        idx = 34 - k_conv\n    end\n    y2_patients_draw = y2_patients[[idx + 1:end; 1:idx]]\n    var\"##cellval#939\" = y2_patients_draw\n    return (PlutoIslands._plain_body)(var\"##cellval#939\")\nend",
+        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    patients_flipped = append!([\"\" for i = 1:8 - length(patients)], reverse(patients))\n    numbers_patients = [length(s) for s = patients_flipped]\n    y2_patients = append!([0 for i = 1:9], numbers_patients, [0 for i = 1:16 - length(patients_flipped)])\n    numbers_pills = [length(s) for s = treatment]\n    y1_pills = append!([0 for i = 1:9], numbers_pills, [0 for i = 1:16 - length(numbers_pills)])\n    var\"##cellval#892\" = y1_pills\n    return (PlutoIslands._plain_body)(var\"##cellval#892\")\nend",
         "golden": [
-          "\"[0, 0, 0, 0, 4, 8, 5, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\"",
-          "\"[0, 0, 0, 0, 4, 8, 5, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\"",
-          "\"[0, 0, 0, 0, 4, 8, 5, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\"",
-          "\"[0, 0, 0, 0, 4, 8, 5, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\""
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "1",
-            "2",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "6",
-            "2",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "1",
-            "6",
-            "3",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ],
-          [
-            "1",
-            "2",
-            "6",
-            "4",
-            "0",
-            "0",
-            "0",
-            "0",
-            "false",
-            "1",
-            "5",
-            "true"
-          ]
-        ]
-      },
-      {
-        "cell_id": "ceb05a23-93b8-4423-a5f9-f6e3d961d0c6",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    color_grey = (0.5, 0.5, 0.5, 1.0)\n    colors = [_rgba(ColorSchemes.viridis[i]) for i = 1:40:256]\n    col_length = length(colors)\n    color_blue = _rgba(ColorSchemes.viridis[116])\n    patients_flipped = append!([\"\" for i = 1:8 - length(patients)], reverse(patients))\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    numbers_patients = [length(s) for s = patients_flipped]\n    y2_patients = append!([0 for i = 1:9], numbers_patients, [0 for i = 1:16 - length(patients_flipped)])\n    numbers_pills = [length(s) for s = treatment]\n    y1_pills = append!([0 for i = 1:9], numbers_pills, [0 for i = 1:16 - length(numbers_pills)])\n    if k_conv < 9\n        #= none:11 =#\n        idx = 9 - k_conv\n    else\n        #= none:11 =#\n        idx = 34 - k_conv\n    end\n    y2_patients_draw = y2_patients[[idx + 1:end; 1:idx]]\n    f = Figure(size = (650, 700))\n    ax1 = Axis(f[1, 1]; ylabel = \"New patients\")\n    ax2 = Axis(f[2, 1]; ylabel = \"New pills required\")\n    ax3 = Axis(f[3, 1]; ylabel = \"Stockpile required\", xlabel = \"Day\")\n    x = Float64[]\n    for k = -nb:2nb\n        #= none:18 =#\n        push!(x, Float64(k))\n        #= none:19 =#\n    end\n    x_conv = Float64[]\n    for k = -nb:5nb\n        #= none:22 =#\n        push!(x_conv, (Float64(k) - nb * 1.5) + 4)\n        #= none:23 =#\n    end\n    l = length(x)\n    k = (k_conv - nb) + 1\n    grey_marker = 16.0\n    color_marker = 7.0\n    y1 = y1_pills\n    y2 = y2_patients\n    y2_draw = y2_patients_draw\n    y12_draw = y1 .* y2_draw\n    y12 = y1 .* y2\n    y3 = simple_conv(y1, reverse(y2))\n    vlines!(ax1, [Float64(k_conv - 1)]; color = color_blue)\n    vlines!(ax2, [Float64(k_conv - 1)]; color = color_blue)\n    vlines!(ax3, [Float64((k - 2) + nb / 2 + 4)]; color = color_blue)\n    max_ax1 = maximum([maximum(y1), maximum(y2)]) + 2\n    max_ax2 = maximum(y1) * maximum(y2) + 2\n    if stairs\n        #= none:54 =#\n        stairs!(ax1, x, y1; color = colors[6], step = :center)\n        #= none:55 =#\n        stairs!(ax1, x, y2_draw; color = colors[4], step = :center)\n        #= none:56 =#\n        stairs!(ax2, x, y12_draw; color = colors[7], step = :center)\n        #= none:57 =#\n        stairs!(ax3, x_conv, y3; color = colors[1], step = :center)\n    end\n    draw_grey_points(x, y2_draw, ax1, l, :patient, grey_marker, [color_grey], true)\n    draw_grey_points(x, y1, ax1, l, :pill, color_marker, colors)\n    draw_all(l, k + nb, k_conv + 2nb, x, x_conv, y1, y2, y2_draw, y12_draw, y3, ax1, ax2, ax3, grey_marker, color_marker, true)\n    draw_grey_points(x, y1, ax1, l, :pillghost, grey_marker, [color_grey])\n    draw_grey_points(x_conv, y3, ax3, 4nb - 1, :pillghost, grey_marker, [color_grey])\n    ax1.xmin = -4.0\n    ax1.xmax = 12.0\n    ax2.xmin = -4.0\n    ax2.xmax = 12.0\n    ax3.xmin = -4.0\n    ax3.xmax = 12.0\n    ax1.ymin = -1.0\n    ax1.ymax = Float64(max_ax1)\n    ax2.ymin = -0.2 * Float64(max_ax2)\n    ax2.ymax = Float64(max_ax2)\n    ax3.ymin = -1.0\n    var\"##cellval#940\" = (ax3.ymax = Float64(maximum(y3) + 7))\n    return (PlutoIslands._plain_body)(var\"##cellval#940\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `ColorSchemes` not defined in `Main.var\"##hv#943\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `ColorSchemes` not defined in `Main.var\"##hv#943\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `ColorSchemes` not defined in `Main.var\"##hv#943\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `ColorSchemes` not defined in `Main.var\"##hv#943\"`\nSuggestion: check for spelling errors or missing imports."
+          "\"[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\"",
+          "\"[0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\"",
+          "\"[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 6, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\"",
+          "\"[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\""
         ],
         "kind": "string",
         "mime": "text/plain",
@@ -4071,12 +3796,12 @@
       {
         "cell_id": "6b243243-8f26-4f2d-8727-564f0701b302",
         "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    color_grey = (0.5, 0.5, 0.5, 1.0)\n    colors = [_rgba(ColorSchemes.viridis[i]) for i = 1:40:256]\n    col_length = length(colors)\n    color_blue = _rgba(ColorSchemes.viridis[116])\n    patients_flipped = append!([\"\" for i = 1:8 - length(patients)], reverse(patients))\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    numbers_patients = [length(s) for s = patients_flipped]\n    y2_patients = append!([0 for i = 1:9], numbers_patients, [0 for i = 1:16 - length(patients_flipped)])\n    numbers_pills = [length(s) for s = treatment]\n    y1_pills = append!([0 for i = 1:9], numbers_pills, [0 for i = 1:16 - length(numbers_pills)])\n    if k_conv < 9\n        #= none:11 =#\n        idx = 9 - k_conv\n    else\n        #= none:11 =#\n        idx = 34 - k_conv\n    end\n    y2_patients_draw = y2_patients[[idx + 1:end; 1:idx]]\n    f = Figure(size = (650, 700))\n    ax1 = Axis(f[1, 1]; ylabel = \"New patients\")\n    ax2 = Axis(f[2, 1]; ylabel = \"New pills required\")\n    ax3 = Axis(f[3, 1]; ylabel = \"Stockpile required\", xlabel = \"Day\")\n    x = Float64[]\n    for k = -nb:2nb\n        #= none:18 =#\n        push!(x, Float64(k))\n        #= none:19 =#\n    end\n    x_conv = Float64[]\n    for k = -nb:5nb\n        #= none:22 =#\n        push!(x_conv, (Float64(k) - nb * 1.5) + 4)\n        #= none:23 =#\n    end\n    l = length(x)\n    k = (k_conv - nb) + 1\n    grey_marker = 16.0\n    color_marker = 7.0\n    y1 = y1_pills\n    y2 = y2_patients\n    y2_draw = y2_patients_draw\n    y12_draw = y1 .* y2_draw\n    y12 = y1 .* y2\n    y3 = simple_conv(y1, reverse(y2))\n    vlines!(ax1, [Float64(k_conv - 1)]; color = color_blue)\n    vlines!(ax2, [Float64(k_conv - 1)]; color = color_blue)\n    vlines!(ax3, [Float64((k - 2) + nb / 2 + 4)]; color = color_blue)\n    max_ax1 = maximum([maximum(y1), maximum(y2)]) + 2\n    max_ax2 = maximum(y1) * maximum(y2) + 2\n    if stairs\n        #= none:54 =#\n        stairs!(ax1, x, y1; color = colors[6], step = :center)\n        #= none:55 =#\n        stairs!(ax1, x, y2_draw; color = colors[4], step = :center)\n        #= none:56 =#\n        stairs!(ax2, x, y12_draw; color = colors[7], step = :center)\n        #= none:57 =#\n        stairs!(ax3, x_conv, y3; color = colors[1], step = :center)\n    end\n    draw_grey_points(x, y2_draw, ax1, l, :patient, grey_marker, [color_grey], true)\n    draw_grey_points(x, y1, ax1, l, :pill, color_marker, colors)\n    draw_all(l, k + nb, k_conv + 2nb, x, x_conv, y1, y2, y2_draw, y12_draw, y3, ax1, ax2, ax3, grey_marker, color_marker, true)\n    draw_grey_points(x, y1, ax1, l, :pillghost, grey_marker, [color_grey])\n    draw_grey_points(x_conv, y3, ax3, 4nb - 1, :pillghost, grey_marker, [color_grey])\n    ax1.xmin = -4.0\n    ax1.xmax = 12.0\n    ax2.xmin = -4.0\n    ax2.xmax = 12.0\n    ax3.xmin = -4.0\n    ax3.xmax = 12.0\n    ax1.ymin = -1.0\n    ax1.ymax = Float64(max_ax1)\n    ax2.ymin = -0.2 * Float64(max_ax2)\n    ax2.ymax = Float64(max_ax2)\n    ax3.ymin = -1.0\n    ax3.ymax = Float64(maximum(y3) + 7)\n    var\"##cellval#941\" = f\n    return (PlutoIslands._html_body)(var\"##cellval#941\")\nend",
+        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    patients_flipped = append!([\"\" for i = 1:8 - length(patients)], reverse(patients))\n    numbers_patients = [length(s) for s = patients_flipped]\n    y2_patients = append!([0 for i = 1:9], numbers_patients, [0 for i = 1:16 - length(patients_flipped)])\n    numbers_pills = [length(s) for s = treatment]\n    y1_pills = append!([0 for i = 1:9], numbers_pills, [0 for i = 1:16 - length(numbers_pills)])\n    col_conv = (0.85, 0.65, 0.13, 1.0)\n    col_today = (0.85, 0.2, 0.2, 1.0)\n    y3 = simple_conv(y1_pills, reverse(y2_patients))\n    n3 = length(y3)\n    xs3 = Float64[]\n    ys3 = Float64[]\n    for i = 1:n3\n        #= none:20 =#\n        push!(xs3, Float64(i))\n        #= none:21 =#\n        push!(ys3, Float64(y3[i]))\n        #= none:22 =#\n    end\n    day = k_conv\n    if day < 1\n        #= none:28 =#\n        day = 1\n    elseif #= none:29 =# day > n3\n        #= none:30 =#\n        day = n3\n    end\n    day_x = Float64(day)\n    day_y = Float64(y3[day])\n    f = Figure(size = (640, 380))\n    ax = Axis(f[1, 1]; ylabel = \"stockpile\", xlabel = \"day\")\n    lines!(ax, xs3, ys3; color = col_conv, linewidth = 3.0)\n    scatter!(ax, [day_x], [day_y]; color = col_today, markersize = 12.0)\n    var\"##cellval#893\" = f\n    return (PlutoIslands._html_body)(var\"##cellval#893\")\nend",
         "golden": [
-          "ERR:UndefVarError: `ColorSchemes` not defined in `Main.var\"##hv#943\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `ColorSchemes` not defined in `Main.var\"##hv#943\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `ColorSchemes` not defined in `Main.var\"##hv#943\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `ColorSchemes` not defined in `Main.var\"##hv#943\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#895\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#895\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#895\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#895\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -4142,19 +3867,19 @@
         ]
       },
       {
-        "cell_id": "0dd8235c-c09b-49ae-b02a-4bbb285970a6",
+        "cell_id": "f0d08486-0086-48da-baeb-169f3812d0ea",
         "extract_ok": true,
-        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    happyX = findlast(treatment_in .> 0)\n    var\"##cellval#942\" = happyX\n    return (PlutoIslands._plain_body)(var\"##cellval#942\")\nend",
+        "fn_src": "function (a1_s::Int64, a2_s::Int64, a3_s::Int64, a4_s::Int64, a5_s::Int64, a6_s::Int64, a7_s::Int64, a8_s::Int64, exponential::Bool, k_conv::Int64, len::Int64, stairs::Bool)\n    treatment_in = [a1_s, a2_s, a3_s, a4_s, a5_s, a6_s, a7_s, a8_s]\n    treatment = vec([repeat('💊', i) for i = treatment_in])\n    patients = if exponential\n            (collect([\"👵\", \"🧑👴\", \"🧑🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴🧑🧝🧝🧚🧓🧚🧓🧚🧑🧝🧝🧝\", \"👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑\", \"🧚🧚🧚🧚🧚🧚🧚🧚🧚🧓🧚🧓🧚🧑🧝🧝👧👴👴👩🧝🧚👩🧓👧👴👴👩🧝🧚👩🧓👵🧝🧑👴🧑👵🧝🧑👴🧑🧓🧚👩🧝🧚👩👩🧝🧚👩👴👴👩🧝🧚🧓🧚🧓👴👵🧑🧑🧑\", \"\"]))[1:len]\n        else\n            (collect([\"👵\", \"👴🧑\", \"👩🧔🏼🧝🧚\", \"👧👴👴👩🧝🧚👩🧓\", \"👵🧝🧑👴\", \"🧓🧚\", \"🧚\", \"\"]))[1:len]\n        end\n    var\"##cellval#894\" = let\n            #= none:2 =#\n            t = treatment\n            #= none:3 =#\n            p = patients\n            #= none:4 =#\n            md\"Now as a doctor, you want to be ready for this scenario, at each day you want to know, how many pills you will need for your patients:\n\n- On day 1: you would give $((t[1]))  to $((p[1])) \n- On day 2: you would give $((t[2]))  to $((p[1]))  , and $((t[1]))  to $((p[2]))  each\n- On day 3: you would give  $((t[3]))  to $(length(p[1])) , and $((t[2])) pills to $((p[2])) , and $((t[1]))  to $((p[3]))  each ... etc \n\nNotice how we are multiplying and adding each day? We are close to performing a convolution already!\n\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#894\")\nend",
         "golden": [
-          "\"4\"",
-          "\"4\"",
-          "\"4\"",
-          "\"4\""
+          "ERR:text/html rendering of Markdown.MD unsupported",
+          "ERR:text/html rendering of Markdown.MD unsupported",
+          "ERR:text/html rendering of Markdown.MD unsupported",
+          "ERR:text/html rendering of Markdown.MD unsupported"
         ],
         "kind": "string",
-        "mime": "text/plain",
+        "mime": "text/html",
         "reasons": [],
-        "rettype": "String",
+        "rettype": "Union{}",
         "samples": [
           [
             "1",
@@ -4224,119 +3949,26 @@
       "using PlutoUI",
       "using PlutoUI.ExperimentalLayout: grid, vbox, hbox, Div",
       "using HypertextLiteral",
-      "function draw_point(x, count, ax::Axis, style::Symbol, size_marker, color::NTuple{4, Float64}, offset::Int, masked = false)\n    #= none:3 =#\n    #= none:4 =#\n    for y = 1:count[1]\n        #= none:5 =#\n        if style == :patient\n            #= none:6 =#\n            scatter!(ax, [Float64(x) + 0.1], [Float64(y + offset)]; markersize = Float64(size_marker), marker = :circle, color = (1.0, 1.0, 1.0, 1.0))\n            #= none:9 =#\n            scatter!(ax, [Float64(x) + 0.1], [Float64(y + offset)]; markersize = 0.62 * Float64(size_marker), marker = :circle, color = color)\n        elseif #= none:11 =# style == :pillghost\n            #= none:12 =#\n            scatter!(ax, [Float64(x) - 0.2], [Float64(y + offset)]; markersize = Float64(size_marker), marker = :circle, color = (0.5, 0.5, 0.5, 0.2))\n        else\n            #= none:16 =#\n            scatter!(ax, [Float64(x) - 0.2], [Float64(y + offset)]; markersize = Float64(size_marker), marker = :circle, color = color)\n        end\n        #= none:19 =#\n    end\nend",
-      "function simple_conv(a, b)\n    #= none:3 =#\n    #= none:4 =#\n    n = length(a)\n    #= none:5 =#\n    m = length(b)\n    #= none:6 =#\n    out = fill(0.0, (n + m) - 1)\n    #= none:7 =#\n    for i = 1:n\n        #= none:8 =#\n        for j = 1:m\n            #= none:9 =#\n            out[(i + j) - 1] += Float64(a[i]) * Float64(b[j])\n            #= none:10 =#\n        end\n        #= none:11 =#\n    end\n    #= none:12 =#\n    out\nend",
-      "_rgba(c) = begin\n        #= none:2 =#\n        (Float64(red(c)), Float64(green(c)), Float64(blue(c)), 1.0)\n    end",
-      "function draw_all(l, k, k_conv, x, x_conv, y1, y2, y2_draw, y12, y3, ax1, ax2, ax3, grey_marker, color_marker, masked = false)\n    #= none:1 =#\n    #= none:2 =#\n    offset = 0\n    #= none:3 =#\n    for index = k:k + nb\n        #= none:4 =#\n        scatter!(ax3, [Float64(x_conv[k_conv])], [Float64(y3[k_conv])]; color = colors[1])\n        #= none:6 =#\n        if index < 1 || index > l\n            #= none:7 =#\n            continue\n        end\n        #= none:10 =#\n        color = colors[mod(index, col_length) + 1]\n        #= none:13 =#\n        draw_point(x[index], y12[index], ax2, :pill, color_marker, color, 0)\n        #= none:14 =#\n        draw_point(x_conv[k_conv], y12[index], ax3, :pill, color_marker, color, offset)\n        #= none:16 =#\n        draw_point(x[index], y12[index], ax2, :pillghost, grey_marker, color, 0)\n        #= none:18 =#\n        if y1[index] != 0 && y2_draw[index] != 0\n            #= none:19 =#\n            draw_point(x[index], y2_draw[index], ax1, :patient, grey_marker, color, 0, masked)\n        end\n        #= none:22 =#\n        offset += y12[index]\n        #= none:23 =#\n    end\nend",
-      "function draw_grey_points(x, y, ax, len, style, size_marker, colors, masked = false)\n    #= none:1 =#\n    #= none:3 =#\n    for j = 1:len\n        #= none:4 =#\n        color = colors[mod(j, length(colors)) + 1]\n        #= none:5 =#\n        draw_point(x[j], y[j], ax, style, size_marker, color, 0, masked)\n        #= none:7 =#\n    end\nend"
+      "function simple_conv(a, b)\n    #= none:3 =#\n    #= none:4 =#\n    n = length(a)\n    #= none:5 =#\n    m = length(b)\n    #= none:6 =#\n    out = fill(0.0, (n + m) - 1)\n    #= none:7 =#\n    for i = 1:n\n        #= none:8 =#\n        for j = 1:m\n            #= none:9 =#\n            out[(i + j) - 1] += Float64(a[i]) * Float64(b[j])\n            #= none:10 =#\n        end\n        #= none:11 =#\n    end\n    #= none:12 =#\n    out\nend"
     ]
   },
   {
     "argtypes": [
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Matrix{Float64}",
-      "String"
+      "Int64"
     ],
     "bonds": [
-      "a1_s",
-      "a2_s",
-      "a3_s",
-      "b1_s",
-      "b2_s",
-      "b3_s",
-      "c1_s",
-      "c2_s",
-      "c3_s",
-      "test_filter_selected",
-      "test_img_selected"
+      "blur_radius"
     ],
     "cells": [
       {
-        "cell_id": "ef0bea69-6dfd-4526-a96e-6607771660fe",
+        "cell_id": "88933746-6028-11eb-32de-13eb6ff43e29",
         "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#962\" = test_img\n    return (PlutoIslands._plain_body)(var\"##cellval#962\")\nend",
+        "fn_src": "function (blur_radius::Int64,)\n    var\"##cellval#918\" = let\n            #= none:2 =#\n            (nr, nc) = (72, 72)\n            #= none:3 =#\n            base = scene(nr, nc)\n            #= none:4 =#\n            rad = Int(blur_radius)\n            #= none:5 =#\n            out = Vector{Float64}(undef, nr * nc)\n            #= none:6 =#\n            for i = 1:nr, j = 1:nc\n                #= none:7 =#\n                acc = 0.0\n                #= none:8 =#\n                cnt = 0\n                #= none:9 =#\n                for di = -rad:rad, dj = -rad:rad\n                    #= none:10 =#\n                    ii = i + di\n                    #= none:11 =#\n                    jj = j + dj\n                    #= none:12 =#\n                    if ii >= 1 && (ii <= nr && (jj >= 1 && jj <= nc))\n                        #= none:13 =#\n                        acc += pixel_at(base, nr, nc, ii, jj)\n                        #= none:14 =#\n                        cnt += 1\n                    end\n                    #= none:16 =#\n                end\n                #= none:17 =#\n                out[j + (nr - i) * nc] = acc / cnt\n                #= none:18 =#\n            end\n            #= none:19 =#\n            gray_figure(out, nr, nc)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#918\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "8ae0248f-6eba-4941-85f4-b21be3c7e725",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    box_filter = [0.111 0.111 0.111; 0.111 0.111 0.111; 0.111 0.111 0.111]\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#963\" = gray_figure(demonstrate_filter(test_img, box_filter); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#963\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#923\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#923\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#923\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#923\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -4344,411 +3976,16 @@
         "rettype": "String",
         "samples": [
           [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
+            "2"
           ],
           [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
+            "1"
           ],
           [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
+            "4"
           ],
           [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "6ff88cb3-7cca-4091-b914-10c4bdc0d9d2",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#964\" = gray_figure(test_img)\n    return (PlutoIslands._html_body)(var\"##cellval#964\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "6c31cbb0-01ed-40cf-b400-3ed6b7c79ecc",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    var\"##cellval#965\" = kernel_figure(test_filter_selected)\n    return (PlutoIslands._html_body)(var\"##cellval#965\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "4b560bf2-00d9-4440-9589-834cd9177f66",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#966\" = gray_figure(demonstrate_filter(test_img, test_filter_selected); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#966\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "9edf2fce-715a-46fc-bc5f-d58e08de789b",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
-      {
-        "cell_id": "9d42dd93-98b4-40db-9d3f-8917d6f72354",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#967\" = gray_figure(demonstrate_filter(test_img, filter); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#967\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#982\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "5737939b-0bb9-4ddf-8948-6356e60d79f3",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    var\"##cellval#968\" = if filter == [0.0 -1.0 0.0; -1.0 5.011872336272722 -1.0; 0.0 -1.0 0.0]\n            #= none:2 =#\n            correct(md\"**Great!** That was a tough question but you figured it out! \n\nNow you know how filters in image processing work.\")\n        else\n            #= none:6 =#\n            hint(md\"The Sharpening filter is applying the edge detection filter on top of the original filter\")\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#968\")\nend",
-        "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported"
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
+            "7"
           ]
         ]
       }
@@ -4758,117 +3995,28 @@
     "group_reasons": [],
     "notebook": "convolution_2d.jl",
     "preamble": [
-      "using Images, TestImages, PlutoUI, WasmMakie",
-      "using WasmMakie: Axis",
-      "function convolve(img, filter)\n    #= none:1 =#\n    #= none:4 =#\n    (img_row, img_col) = size(img)\n    #= none:5 =#\n    (filter_row, filter_col) = size(filter)\n    #= none:8 =#\n    filtered = zeros((img_row - filter_row) + 1, (img_col - filter_col) + 1)\n    #= none:9 =#\n    (filtered_row, filtered_col) = size(filtered)\n    #= none:12 =#\n    for i = 1:filtered_row\n        #= none:13 =#\n        for j = 1:filtered_col\n            #= none:14 =#\n            filtered[i, j] = sum(img[i:(i + filter_row) - 1, j:(j + filter_col) - 1] .* filter)\n            #= none:15 =#\n        end\n        #= none:16 =#\n    end\n    #= none:18 =#\n    return filtered\nend",
-      "function demonstrate_filter(image, filter)\n    #= none:2 =#\n    #= none:3 =#\n    (height, width) = size(image)\n    #= none:4 =#\n    filtered_img = Gray.(convolve(image, filter))\n    #= none:5 =#\n    padded_img = image[2:height - 1, 2:width - 1]\n    #= none:6 =#\n    [padded_img filtered_img]\nend",
-      "function gray_figure(m; px = 240, colorrange = (0.0, 1.0))\n    #= none:4 =#\n    #= none:5 =#\n    ms = m[1:max(1, ceil(Int, size(m, 1) / 200)):end, 1:max(1, ceil(Int, size(m, 2) / 200)):end]\n    #= none:7 =#\n    (nr, nc) = size(ms)\n    #= none:8 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:9 =#\n    for i = 1:nr, j = 1:nc\n        #= none:10 =#\n        vals[j + (nr - i) * nc] = Float64(gray(ms[i, j]))\n        #= none:11 =#\n    end\n    #= none:12 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:13 =#\n    ax = Axis(fig[1, 1])\n    #= none:14 =#\n    hidedecorations!(ax)\n    #= none:15 =#\n    hidespines!(ax)\n    #= none:16 =#\n    heatmap!(ax, 1:nc, 1:nr, vals, nc, nr; colorrange = colorrange)\n    #= none:18 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "function rgb_figure(m; px = 240)\n    #= none:21 =#\n    #= none:22 =#\n    ms = m[1:max(1, ceil(Int, size(m, 1) / 200)):end, 1:max(1, ceil(Int, size(m, 2) / 200)):end]\n    #= none:24 =#\n    (nr, nc) = size(ms)\n    #= none:25 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:26 =#\n    for i = 1:nr, j = 1:nc\n        #= none:27 =#\n        v = ms[i, j]\n        #= none:28 =#\n        pix[j + (nr - i) * nc] = (Float64(red(v)), Float64(green(v)), Float64(blue(v)), 1.0)\n        #= none:30 =#\n    end\n    #= none:31 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:32 =#\n    ax = Axis(fig[1, 1])\n    #= none:33 =#\n    hidedecorations!(ax)\n    #= none:34 =#\n    hidespines!(ax)\n    #= none:35 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:37 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "function kernel_figure(k; px = 180)\n    #= none:40 =#\n    #= none:41 =#\n    kf = Float64.(k)\n    #= none:42 =#\n    (lo, hi) = extrema(kf)\n    #= none:43 =#\n    hi = if hi == lo\n            lo + 1.0\n        else\n            hi\n        end\n    #= none:44 =#\n    gray_figure(kf; px = px, colorrange = (lo, hi))\nend",
-      "correct(text = md\"Great! You got the right answer! Let's move on to the next section.\") = begin\n        #= none:1 =#\n        Markdown.MD(Markdown.Admonition(\"correct\", \"Got it!\", [text]))\n    end",
-      "hint(text) = begin\n        #= none:1 =#\n        Markdown.MD(Markdown.Admonition(\"hint\", \"Hint\", [text]))\n    end"
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:9 =#\n    #= none:10 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:11 =#\n    for k = 1:nr * nc\n        #= none:12 =#\n        v = vals[k]\n        #= none:13 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:14 =#\n    end\n    #= none:15 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:16 =#\n    ax = Axis(fig[1, 1])\n    #= none:17 =#\n    hidedecorations!(ax)\n    #= none:18 =#\n    hidespines!(ax)\n    #= none:19 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:21 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:24 =#\n    #= none:26 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:27 =#\n    ax = Axis(fig[1, 1])\n    #= none:28 =#\n    hidedecorations!(ax)\n    #= none:29 =#\n    hidespines!(ax)\n    #= none:30 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:32 =#\n    fig\nend",
+      "function scene(nr::Int, nc::Int)\n    #= none:3 =#\n    #= none:4 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:5 =#\n    ci = (nr + 1) / 2\n    #= none:6 =#\n    cj = (nc + 1) / 2\n    #= none:7 =#\n    for i = 1:nr, j = 1:nc\n        #= none:8 =#\n        di = i - ci\n        #= none:9 =#\n        dj = j - cj\n        #= none:10 =#\n        dist = sqrt(di * di + dj * dj)\n        #= none:11 =#\n        rings = 0.5 + 0.5 * cos(dist * 0.8)\n        #= none:12 =#\n        grad = (i + j) / (nr + nc)\n        #= none:13 =#\n        v = 0.55rings + 0.45grad\n        #= none:15 =#\n        if i >= 12 && (i <= 24 && (j >= 12 && j <= 24))\n            #= none:16 =#\n            v = 0.95\n        end\n        #= none:18 =#\n        if i >= 44 && (i <= 60 && (j >= 46 && j <= 62))\n            #= none:19 =#\n            v = 0.1\n        end\n        #= none:21 =#\n        v < 0.0 && (v = 0.0)\n        #= none:22 =#\n        v > 1.0 && (v = 1.0)\n        #= none:23 =#\n        vals[j + (nr - i) * nc] = v\n        #= none:24 =#\n    end\n    #= none:25 =#\n    return vals\nend",
+      "function pixel_at(vals::Vector{Float64}, nr::Int, nc::Int, i::Int, j::Int)\n    #= none:2 =#\n    #= none:3 =#\n    ii = i\n    #= none:4 =#\n    jj = j\n    #= none:5 =#\n    ii < 1 && (ii = 1)\n    #= none:6 =#\n    ii > nr && (ii = nr)\n    #= none:7 =#\n    jj < 1 && (jj = 1)\n    #= none:8 =#\n    jj > nc && (jj = nc)\n    #= none:9 =#\n    return vals[jj + (nr - ii) * nc]\nend",
+      "using PlutoUI, WasmMakie"
     ]
   },
   {
     "argtypes": [
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "Float64",
-      "String"
+      "Bool"
     ],
     "bonds": [
-      "a1_s",
-      "a2_s",
-      "a3_s",
-      "b1_s",
-      "b2_s",
-      "b3_s",
-      "c1_s",
-      "c2_s",
-      "c3_s",
-      "test_img_selected"
+      "color_blur"
     ],
     "cells": [
       {
-        "cell_id": "ef0bea69-6dfd-4526-a96e-6607771660fe",
+        "cell_id": "d1174f21-5c74-4934-acdf-716671cfc2db",
         "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#969\" = test_img\n    return (PlutoIslands._plain_body)(var\"##cellval#969\")\nend",
+        "fn_src": "function (color_blur::Bool,)\n    var\"##cellval#919\" = let\n            #= none:2 =#\n            (nr, nc) = (72, 72)\n            #= none:3 =#\n            ci = (nr + 1) / 2\n            #= none:3 =#\n            cj = (nc + 1) / 2\n            #= none:5 =#\n            rr = Vector{Float64}(undef, nr * nc)\n            #= none:6 =#\n            gg = Vector{Float64}(undef, nr * nc)\n            #= none:7 =#\n            bb = Vector{Float64}(undef, nr * nc)\n            #= none:8 =#\n            for i = 1:nr, j = 1:nc\n                #= none:9 =#\n                di = i - ci\n                #= none:9 =#\n                dj = j - cj\n                #= none:10 =#\n                dist = sqrt(di * di + dj * dj)\n                #= none:11 =#\n                idx = j + (nr - i) * nc\n                #= none:12 =#\n                rr[idx] = (j - 1) / (nc - 1)\n                #= none:13 =#\n                gg[idx] = (i - 1) / (nr - 1)\n                #= none:14 =#\n                bb[idx] = 0.5 + 0.5 * cos(dist * 0.6)\n                #= none:15 =#\n            end\n            #= none:16 =#\n            if color_blur\n                #= none:17 =#\n                k = make_kernel(2, 1.0)\n                #= none:18 =#\n                rr = convolve(rr, nr, nc, k)\n                #= none:19 =#\n                gg = convolve(gg, nr, nc, k)\n                #= none:20 =#\n                bb = convolve(bb, nr, nc, k)\n            end\n            #= none:22 =#\n            pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n            #= none:23 =#\n            for k2 = 1:nr * nc\n                #= none:24 =#\n                pix[k2] = (rr[k2], gg[k2], bb[k2], 1.0)\n                #= none:25 =#\n            end\n            #= none:26 =#\n            rgb_figure(pix, nr, nc)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#919\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "8ae0248f-6eba-4941-85f4-b21be3c7e725",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_img_selected::String)\n    box_filter = [0.111 0.111 0.111; 0.111 0.111 0.111; 0.111 0.111 0.111]\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#970\" = gray_figure(demonstrate_filter(test_img, box_filter); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#970\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#924\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#924\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -4876,322 +4024,10 @@
         "rettype": "String",
         "samples": [
           [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
+            "true"
           ],
           [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "6ff88cb3-7cca-4091-b914-10c4bdc0d9d2",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#971\" = gray_figure(test_img)\n    return (PlutoIslands._html_body)(var\"##cellval#971\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "9edf2fce-715a-46fc-bc5f-d58e08de789b",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
-      {
-        "cell_id": "9d42dd93-98b4-40db-9d3f-8917d6f72354",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#972\" = gray_figure(demonstrate_filter(test_img, filter); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#972\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "5737939b-0bb9-4ddf-8948-6356e60d79f3",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_img_selected::String)\n    var\"##cellval#973\" = if filter == [0.0 -1.0 0.0; -1.0 5.011872336272722 -1.0; 0.0 -1.0 0.0]\n            #= none:2 =#\n            correct(md\"**Great!** That was a tough question but you figured it out! \n\nNow you know how filters in image processing work.\")\n        else\n            #= none:6 =#\n            hint(md\"The Sharpening filter is applying the edge detection filter on top of the original filter\")\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#973\")\nend",
-        "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported"
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "4b560bf2-00d9-4440-9589-834cd9177f66",
-        "extract_ok": true,
-        "fn_src": "function (a1_s::Float64, a2_s::Float64, a3_s::Float64, b1_s::Float64, b2_s::Float64, b3_s::Float64, c1_s::Float64, c2_s::Float64, c3_s::Float64, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#974\" = gray_figure(demonstrate_filter(test_img, test_filter_selected); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#974\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#983\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
-          ],
-          [
-            "0.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "1.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "0.0",
-            "\"puiselect-1\""
+            "false"
           ]
         ]
       }
@@ -5201,15 +4037,93 @@
     "group_reasons": [],
     "notebook": "convolution_2d.jl",
     "preamble": [
-      "using Images, TestImages, PlutoUI, WasmMakie",
-      "using WasmMakie: Axis",
-      "function convolve(img, filter)\n    #= none:1 =#\n    #= none:4 =#\n    (img_row, img_col) = size(img)\n    #= none:5 =#\n    (filter_row, filter_col) = size(filter)\n    #= none:8 =#\n    filtered = zeros((img_row - filter_row) + 1, (img_col - filter_col) + 1)\n    #= none:9 =#\n    (filtered_row, filtered_col) = size(filtered)\n    #= none:12 =#\n    for i = 1:filtered_row\n        #= none:13 =#\n        for j = 1:filtered_col\n            #= none:14 =#\n            filtered[i, j] = sum(img[i:(i + filter_row) - 1, j:(j + filter_col) - 1] .* filter)\n            #= none:15 =#\n        end\n        #= none:16 =#\n    end\n    #= none:18 =#\n    return filtered\nend",
-      "function demonstrate_filter(image, filter)\n    #= none:2 =#\n    #= none:3 =#\n    (height, width) = size(image)\n    #= none:4 =#\n    filtered_img = Gray.(convolve(image, filter))\n    #= none:5 =#\n    padded_img = image[2:height - 1, 2:width - 1]\n    #= none:6 =#\n    [padded_img filtered_img]\nend",
-      "function gray_figure(m; px = 240, colorrange = (0.0, 1.0))\n    #= none:4 =#\n    #= none:5 =#\n    ms = m[1:max(1, ceil(Int, size(m, 1) / 200)):end, 1:max(1, ceil(Int, size(m, 2) / 200)):end]\n    #= none:7 =#\n    (nr, nc) = size(ms)\n    #= none:8 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:9 =#\n    for i = 1:nr, j = 1:nc\n        #= none:10 =#\n        vals[j + (nr - i) * nc] = Float64(gray(ms[i, j]))\n        #= none:11 =#\n    end\n    #= none:12 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:13 =#\n    ax = Axis(fig[1, 1])\n    #= none:14 =#\n    hidedecorations!(ax)\n    #= none:15 =#\n    hidespines!(ax)\n    #= none:16 =#\n    heatmap!(ax, 1:nc, 1:nr, vals, nc, nr; colorrange = colorrange)\n    #= none:18 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "function rgb_figure(m; px = 240)\n    #= none:21 =#\n    #= none:22 =#\n    ms = m[1:max(1, ceil(Int, size(m, 1) / 200)):end, 1:max(1, ceil(Int, size(m, 2) / 200)):end]\n    #= none:24 =#\n    (nr, nc) = size(ms)\n    #= none:25 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:26 =#\n    for i = 1:nr, j = 1:nc\n        #= none:27 =#\n        v = ms[i, j]\n        #= none:28 =#\n        pix[j + (nr - i) * nc] = (Float64(red(v)), Float64(green(v)), Float64(blue(v)), 1.0)\n        #= none:30 =#\n    end\n    #= none:31 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:32 =#\n    ax = Axis(fig[1, 1])\n    #= none:33 =#\n    hidedecorations!(ax)\n    #= none:34 =#\n    hidespines!(ax)\n    #= none:35 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:37 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "function kernel_figure(k; px = 180)\n    #= none:40 =#\n    #= none:41 =#\n    kf = Float64.(k)\n    #= none:42 =#\n    (lo, hi) = extrema(kf)\n    #= none:43 =#\n    hi = if hi == lo\n            lo + 1.0\n        else\n            hi\n        end\n    #= none:44 =#\n    gray_figure(kf; px = px, colorrange = (lo, hi))\nend",
-      "correct(text = md\"Great! You got the right answer! Let's move on to the next section.\") = begin\n        #= none:1 =#\n        Markdown.MD(Markdown.Admonition(\"correct\", \"Got it!\", [text]))\n    end",
-      "hint(text) = begin\n        #= none:1 =#\n        Markdown.MD(Markdown.Admonition(\"hint\", \"Hint\", [text]))\n    end"
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:9 =#\n    #= none:10 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:11 =#\n    for k = 1:nr * nc\n        #= none:12 =#\n        v = vals[k]\n        #= none:13 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:14 =#\n    end\n    #= none:15 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:16 =#\n    ax = Axis(fig[1, 1])\n    #= none:17 =#\n    hidedecorations!(ax)\n    #= none:18 =#\n    hidespines!(ax)\n    #= none:19 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:21 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:24 =#\n    #= none:26 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:27 =#\n    ax = Axis(fig[1, 1])\n    #= none:28 =#\n    hidedecorations!(ax)\n    #= none:29 =#\n    hidespines!(ax)\n    #= none:30 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:32 =#\n    fig\nend",
+      "function make_kernel(choice::Int, strength::Float64)\n    #= none:4 =#\n    #= none:5 =#\n    c = choice\n    #= none:6 =#\n    c < 1 && (c = 1)\n    #= none:7 =#\n    c > 5 && (c = 5)\n    #= none:8 =#\n    s = strength\n    #= none:9 =#\n    k = Vector{Float64}(undef, 9)\n    #= none:10 =#\n    for t = 1:9\n        #= none:11 =#\n        k[t] = 0.0\n        #= none:12 =#\n    end\n    #= none:13 =#\n    if c == 1\n        #= none:14 =#\n        k[5] = 1.0\n    elseif #= none:15 =# c == 2\n        #= none:16 =#\n        w = (1.0 / 9.0) * s\n        #= none:17 =#\n        for t = 1:9\n            #= none:18 =#\n            k[t] = w\n            #= none:19 =#\n        end\n        #= none:21 =#\n        k[5] = k[5] + (1.0 - s)\n    elseif #= none:22 =# c == 3\n        #= none:23 =#\n        k[2] = -s\n        #= none:23 =#\n        k[4] = -s\n        #= none:23 =#\n        k[6] = -s\n        #= none:23 =#\n        k[8] = -s\n        #= none:24 =#\n        k[5] = 1.0 + 4.0s\n    elseif #= none:25 =# c == 4\n        #= none:26 =#\n        k[2] = -s\n        #= none:26 =#\n        k[4] = -s\n        #= none:26 =#\n        k[6] = -s\n        #= none:26 =#\n        k[8] = -s\n        #= none:27 =#\n        k[5] = 4.0s\n    else\n        #= none:29 =#\n        k[1] = s\n        #= none:29 =#\n        k[3] = -s\n        #= none:30 =#\n        k[4] = 2.0s\n        #= none:30 =#\n        k[6] = -2.0s\n        #= none:31 =#\n        k[7] = s\n        #= none:31 =#\n        k[9] = -s\n    end\n    #= none:33 =#\n    return k\nend",
+      "function pixel_at(vals::Vector{Float64}, nr::Int, nc::Int, i::Int, j::Int)\n    #= none:2 =#\n    #= none:3 =#\n    ii = i\n    #= none:4 =#\n    jj = j\n    #= none:5 =#\n    ii < 1 && (ii = 1)\n    #= none:6 =#\n    ii > nr && (ii = nr)\n    #= none:7 =#\n    jj < 1 && (jj = 1)\n    #= none:8 =#\n    jj > nc && (jj = nc)\n    #= none:9 =#\n    return vals[jj + (nr - ii) * nc]\nend",
+      "function convolve(vals::Vector{Float64}, nr::Int, nc::Int, k::Vector{Float64})\n    #= none:4 =#\n    #= none:5 =#\n    out = Vector{Float64}(undef, nr * nc)\n    #= none:6 =#\n    for i = 1:nr, j = 1:nc\n        #= none:7 =#\n        acc = 0.0\n        #= none:8 =#\n        for di = -1:1, dj = -1:1\n            #= none:9 =#\n            w = k[(di + 1) * 3 + (dj + 2)]\n            #= none:10 =#\n            acc += w * pixel_at(vals, nr, nc, i + di, j + dj)\n            #= none:11 =#\n        end\n        #= none:12 =#\n        acc < 0.0 && (acc = 0.0)\n        #= none:13 =#\n        acc > 1.0 && (acc = 1.0)\n        #= none:14 =#\n        out[j + (nr - i) * nc] = acc\n        #= none:15 =#\n    end\n    #= none:16 =#\n    return out\nend",
+      "using PlutoUI, WasmMakie"
+    ]
+  },
+  {
+    "argtypes": [
+      "Int64",
+      "Float64"
+    ],
+    "bonds": [
+      "filter_choice",
+      "filter_strength"
+    ],
+    "cells": [
+      {
+        "cell_id": "4b560bf2-00d9-4440-9589-834cd9177f66",
+        "extract_ok": true,
+        "fn_src": "function (filter_choice::Int64, filter_strength::Float64)\n    var\"##cellval#920\" = let\n            #= none:2 =#\n            (nr, nc) = (72, 72)\n            #= none:3 =#\n            base = scene(nr, nc)\n            #= none:4 =#\n            k = make_kernel(Int(filter_choice), Float64(filter_strength))\n            #= none:5 =#\n            out = convolve(base, nr, nc, k)\n            #= none:6 =#\n            gray_figure(out, nr, nc; px = 360)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#920\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#925\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#925\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#925\".var\"#4#5\")(::Int64, ::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#925\".var\"#4#5\")(::Int64, !Matched::Float64)\n   @ Main.var\"##hv#925\" none:0\n"
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "2",
+            "1.0"
+          ],
+          [
+            "5",
+            "1.0"
+          ],
+          [
+            "2",
+            "21"
+          ]
+        ]
+      },
+      {
+        "cell_id": "702ab37f-bbeb-4197-807a-b45207598cb1",
+        "extract_ok": true,
+        "fn_src": "function (filter_choice::Int64, filter_strength::Float64)\n    var\"##cellval#921\" = let\n            #= none:3 =#\n            k = make_kernel(Int(filter_choice), Float64(filter_strength))\n            #= none:4 =#\n            lo = k[1]\n            #= none:4 =#\n            hi = k[1]\n            #= none:5 =#\n            for t = 2:9\n                #= none:6 =#\n                k[t] < lo && (lo = k[t])\n                #= none:7 =#\n                k[t] > hi && (hi = k[t])\n                #= none:8 =#\n            end\n            #= none:9 =#\n            span = hi - lo\n            #= none:10 =#\n            span <= 0.0 && (span = 1.0)\n            #= none:11 =#\n            disp = Vector{Float64}(undef, 9)\n            #= none:13 =#\n            for r = 1:3, cc = 1:3\n                #= none:14 =#\n                v = (k[(r - 1) * 3 + cc] - lo) / span\n                #= none:15 =#\n                disp[cc + (3 - r) * 3] = v\n                #= none:16 =#\n            end\n            #= none:17 =#\n            gray_figure(disp, 3, 3; px = 150)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#921\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#925\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#925\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#925\".var\"#7#8\")(::Int64, ::Int64)\nThe function `#7` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#925\".var\"#7#8\")(::Int64, !Matched::Float64)\n   @ Main.var\"##hv#925\" none:0\n"
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "2",
+            "1.0"
+          ],
+          [
+            "5",
+            "1.0"
+          ],
+          [
+            "2",
+            "21"
+          ]
+        ]
+      }
+    ],
+    "group": 3,
+    "group_ok": true,
+    "group_reasons": [],
+    "notebook": "convolution_2d.jl",
+    "preamble": [
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:9 =#\n    #= none:10 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:11 =#\n    for k = 1:nr * nc\n        #= none:12 =#\n        v = vals[k]\n        #= none:13 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:14 =#\n    end\n    #= none:15 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:16 =#\n    ax = Axis(fig[1, 1])\n    #= none:17 =#\n    hidedecorations!(ax)\n    #= none:18 =#\n    hidespines!(ax)\n    #= none:19 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:21 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:24 =#\n    #= none:26 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:27 =#\n    ax = Axis(fig[1, 1])\n    #= none:28 =#\n    hidedecorations!(ax)\n    #= none:29 =#\n    hidespines!(ax)\n    #= none:30 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:32 =#\n    fig\nend",
+      "function scene(nr::Int, nc::Int)\n    #= none:3 =#\n    #= none:4 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:5 =#\n    ci = (nr + 1) / 2\n    #= none:6 =#\n    cj = (nc + 1) / 2\n    #= none:7 =#\n    for i = 1:nr, j = 1:nc\n        #= none:8 =#\n        di = i - ci\n        #= none:9 =#\n        dj = j - cj\n        #= none:10 =#\n        dist = sqrt(di * di + dj * dj)\n        #= none:11 =#\n        rings = 0.5 + 0.5 * cos(dist * 0.8)\n        #= none:12 =#\n        grad = (i + j) / (nr + nc)\n        #= none:13 =#\n        v = 0.55rings + 0.45grad\n        #= none:15 =#\n        if i >= 12 && (i <= 24 && (j >= 12 && j <= 24))\n            #= none:16 =#\n            v = 0.95\n        end\n        #= none:18 =#\n        if i >= 44 && (i <= 60 && (j >= 46 && j <= 62))\n            #= none:19 =#\n            v = 0.1\n        end\n        #= none:21 =#\n        v < 0.0 && (v = 0.0)\n        #= none:22 =#\n        v > 1.0 && (v = 1.0)\n        #= none:23 =#\n        vals[j + (nr - i) * nc] = v\n        #= none:24 =#\n    end\n    #= none:25 =#\n    return vals\nend",
+      "function make_kernel(choice::Int, strength::Float64)\n    #= none:4 =#\n    #= none:5 =#\n    c = choice\n    #= none:6 =#\n    c < 1 && (c = 1)\n    #= none:7 =#\n    c > 5 && (c = 5)\n    #= none:8 =#\n    s = strength\n    #= none:9 =#\n    k = Vector{Float64}(undef, 9)\n    #= none:10 =#\n    for t = 1:9\n        #= none:11 =#\n        k[t] = 0.0\n        #= none:12 =#\n    end\n    #= none:13 =#\n    if c == 1\n        #= none:14 =#\n        k[5] = 1.0\n    elseif #= none:15 =# c == 2\n        #= none:16 =#\n        w = (1.0 / 9.0) * s\n        #= none:17 =#\n        for t = 1:9\n            #= none:18 =#\n            k[t] = w\n            #= none:19 =#\n        end\n        #= none:21 =#\n        k[5] = k[5] + (1.0 - s)\n    elseif #= none:22 =# c == 3\n        #= none:23 =#\n        k[2] = -s\n        #= none:23 =#\n        k[4] = -s\n        #= none:23 =#\n        k[6] = -s\n        #= none:23 =#\n        k[8] = -s\n        #= none:24 =#\n        k[5] = 1.0 + 4.0s\n    elseif #= none:25 =# c == 4\n        #= none:26 =#\n        k[2] = -s\n        #= none:26 =#\n        k[4] = -s\n        #= none:26 =#\n        k[6] = -s\n        #= none:26 =#\n        k[8] = -s\n        #= none:27 =#\n        k[5] = 4.0s\n    else\n        #= none:29 =#\n        k[1] = s\n        #= none:29 =#\n        k[3] = -s\n        #= none:30 =#\n        k[4] = 2.0s\n        #= none:30 =#\n        k[6] = -2.0s\n        #= none:31 =#\n        k[7] = s\n        #= none:31 =#\n        k[9] = -s\n    end\n    #= none:33 =#\n    return k\nend",
+      "function pixel_at(vals::Vector{Float64}, nr::Int, nc::Int, i::Int, j::Int)\n    #= none:2 =#\n    #= none:3 =#\n    ii = i\n    #= none:4 =#\n    jj = j\n    #= none:5 =#\n    ii < 1 && (ii = 1)\n    #= none:6 =#\n    ii > nr && (ii = nr)\n    #= none:7 =#\n    jj < 1 && (jj = 1)\n    #= none:8 =#\n    jj > nc && (jj = nc)\n    #= none:9 =#\n    return vals[jj + (nr - ii) * nc]\nend",
+      "function convolve(vals::Vector{Float64}, nr::Int, nc::Int, k::Vector{Float64})\n    #= none:4 =#\n    #= none:5 =#\n    out = Vector{Float64}(undef, nr * nc)\n    #= none:6 =#\n    for i = 1:nr, j = 1:nc\n        #= none:7 =#\n        acc = 0.0\n        #= none:8 =#\n        for di = -1:1, dj = -1:1\n            #= none:9 =#\n            w = k[(di + 1) * 3 + (dj + 2)]\n            #= none:10 =#\n            acc += w * pixel_at(vals, nr, nc, i + di, j + dj)\n            #= none:11 =#\n        end\n        #= none:12 =#\n        acc < 0.0 && (acc = 0.0)\n        #= none:13 =#\n        acc > 1.0 && (acc = 1.0)\n        #= none:14 =#\n        out[j + (nr - i) * nc] = acc\n        #= none:15 =#\n    end\n    #= none:16 =#\n    return out\nend",
+      "using PlutoUI, WasmMakie"
     ]
   },
   {
@@ -5223,12 +4137,12 @@
       {
         "cell_id": "96a4b35a-5a3a-4ad0-9ffe-306db46d1c03",
         "extract_ok": true,
-        "fn_src": "function (g::Float64,)\n    var\"##cellval#975\" = let\n            #= none:2 =#\n            gv = Float64(g)\n            #= none:3 =#\n            pix = [(gv, gv, gv, 1.0)]\n            #= none:4 =#\n            fig = Figure(size = (80, 80))\n            #= none:5 =#\n            ax = Axis(fig[1, 1])\n            #= none:6 =#\n            hidedecorations!(ax)\n            #= none:7 =#\n            hidespines!(ax)\n            #= none:8 =#\n            image!(ax, (0.0, 1.0), (0.0, 1.0), pix, 1, 1; interpolate = false)\n            #= none:9 =#\n            fig\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#975\")\nend",
+        "fn_src": "function (g::Float64,)\n    var\"##cellval#922\" = let\n            #= none:2 =#\n            gv = Float64(g)\n            #= none:3 =#\n            one = Vector{Float64}(undef, 1)\n            #= none:4 =#\n            one[1] = gv\n            #= none:5 =#\n            gray_figure(one, 1, 1; px = 80)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#922\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#984\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#984\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#984\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#984\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#984\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#984\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#984\" none:0\n",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#984\".var\"#2#3\")(::Int64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#984\".var\"#2#3\")(!Matched::Float64)\n   @ Main.var\"##hv#984\" none:0\n"
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#926\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#926\".var\"#4#5\")(::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#926\".var\"#4#5\")(!Matched::Float64)\n   @ Main.var\"##hv#926\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#926\".var\"#4#5\")(::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#926\".var\"#4#5\")(!Matched::Float64)\n   @ Main.var\"##hv#926\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#926\".var\"#4#5\")(::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#926\".var\"#4#5\")(!Matched::Float64)\n   @ Main.var\"##hv#926\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/html",
@@ -5236,7 +4150,7 @@
         "rettype": "String",
         "samples": [
           [
-            "0.0"
+            "0.5"
           ],
           [
             "1"
@@ -5250,206 +4164,111 @@
         ]
       }
     ],
-    "group": 3,
-    "group_ok": true,
-    "group_reasons": [],
-    "notebook": "convolution_2d.jl",
-    "preamble": [
-      "using Images, TestImages, PlutoUI, WasmMakie",
-      "using WasmMakie: Axis"
-    ]
-  },
-  {
-    "argtypes": [
-      "Matrix{Float64}",
-      "String"
-    ],
-    "bonds": [
-      "test_filter_selected",
-      "test_img_selected"
-    ],
-    "cells": [
-      {
-        "cell_id": "ef0bea69-6dfd-4526-a96e-6607771660fe",
-        "extract_ok": true,
-        "fn_src": "function (test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#976\" = test_img\n    return (PlutoIslands._plain_body)(var\"##cellval#976\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#985\".var\"#5#6\")(::String, ::String)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#985\".var\"#5#6\")(!Matched::Matrix{Float64}, ::String)\n   @ Main.var\"##hv#985\" none:0\n",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "\"puiselect-10\"",
-            "\"puiselect-1\""
-          ],
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-5\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "8ae0248f-6eba-4941-85f4-b21be3c7e725",
-        "extract_ok": true,
-        "fn_src": "function (test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    box_filter = [0.111 0.111 0.111; 0.111 0.111 0.111; 0.111 0.111 0.111]\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#977\" = gray_figure(demonstrate_filter(test_img, box_filter); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#977\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#985\".var\"#8#9\")(::String, ::String)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#985\".var\"#8#9\")(!Matched::Matrix{Float64}, ::String)\n   @ Main.var\"##hv#985\" none:0\n",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "\"puiselect-10\"",
-            "\"puiselect-1\""
-          ],
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-5\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "9d42dd93-98b4-40db-9d3f-8917d6f72354",
-        "extract_ok": true,
-        "fn_src": "function (test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#978\" = gray_figure(demonstrate_filter(test_img, filter); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#978\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#985\".var\"#11#12\")(::String, ::String)\nThe function `#11` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#985\".var\"#11#12\")(!Matched::Matrix{Float64}, ::String)\n   @ Main.var\"##hv#985\" none:0\n",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "\"puiselect-10\"",
-            "\"puiselect-1\""
-          ],
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-5\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "6ff88cb3-7cca-4091-b914-10c4bdc0d9d2",
-        "extract_ok": true,
-        "fn_src": "function (test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#979\" = gray_figure(test_img)\n    return (PlutoIslands._html_body)(var\"##cellval#979\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#985\".var\"#14#15\")(::String, ::String)\nThe function `#14` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#985\".var\"#14#15\")(!Matched::Matrix{Float64}, ::String)\n   @ Main.var\"##hv#985\" none:0\n",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "\"puiselect-10\"",
-            "\"puiselect-1\""
-          ],
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-5\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "6c31cbb0-01ed-40cf-b400-3ed6b7c79ecc",
-        "extract_ok": true,
-        "fn_src": "function (test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    var\"##cellval#980\" = kernel_figure(test_filter_selected)\n    return (PlutoIslands._html_body)(var\"##cellval#980\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#985\".var\"#17#18\")(::String, ::String)\nThe function `#17` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#985\".var\"#17#18\")(!Matched::Matrix{Float64}, ::String)\n   @ Main.var\"##hv#985\" none:0\n",
-          "ERR:UndefVarError: `gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "\"puiselect-10\"",
-            "\"puiselect-1\""
-          ],
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-5\""
-          ]
-        ]
-      },
-      {
-        "cell_id": "4b560bf2-00d9-4440-9589-834cd9177f66",
-        "extract_ok": true,
-        "fn_src": "function (test_filter_selected::Matrix{Float64}, test_img_selected::String)\n    test_img = Gray.(test_img_selected)\n    var\"##cellval#981\" = gray_figure(demonstrate_filter(test_img, test_filter_selected); px = 480)\n    return (PlutoIslands._html_body)(var\"##cellval#981\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#985\".var\"#20#21\")(::String, ::String)\nThe function `#20` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#985\".var\"#20#21\")(!Matched::Matrix{Float64}, ::String)\n   @ Main.var\"##hv#985\" none:0\n",
-          "ERR:UndefVarError: `Gray` not defined in `Main.var\"##hv#985\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-1\""
-          ],
-          [
-            "\"puiselect-10\"",
-            "\"puiselect-1\""
-          ],
-          [
-            "[0.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 0.0]",
-            "\"puiselect-5\""
-          ]
-        ]
-      }
-    ],
     "group": 4,
     "group_ok": true,
     "group_reasons": [],
     "notebook": "convolution_2d.jl",
     "preamble": [
-      "using Images, TestImages, PlutoUI, WasmMakie",
-      "using WasmMakie: Axis",
-      "function convolve(img, filter)\n    #= none:1 =#\n    #= none:4 =#\n    (img_row, img_col) = size(img)\n    #= none:5 =#\n    (filter_row, filter_col) = size(filter)\n    #= none:8 =#\n    filtered = zeros((img_row - filter_row) + 1, (img_col - filter_col) + 1)\n    #= none:9 =#\n    (filtered_row, filtered_col) = size(filtered)\n    #= none:12 =#\n    for i = 1:filtered_row\n        #= none:13 =#\n        for j = 1:filtered_col\n            #= none:14 =#\n            filtered[i, j] = sum(img[i:(i + filter_row) - 1, j:(j + filter_col) - 1] .* filter)\n            #= none:15 =#\n        end\n        #= none:16 =#\n    end\n    #= none:18 =#\n    return filtered\nend",
-      "function demonstrate_filter(image, filter)\n    #= none:2 =#\n    #= none:3 =#\n    (height, width) = size(image)\n    #= none:4 =#\n    filtered_img = Gray.(convolve(image, filter))\n    #= none:5 =#\n    padded_img = image[2:height - 1, 2:width - 1]\n    #= none:6 =#\n    [padded_img filtered_img]\nend",
-      "function gray_figure(m; px = 240, colorrange = (0.0, 1.0))\n    #= none:4 =#\n    #= none:5 =#\n    ms = m[1:max(1, ceil(Int, size(m, 1) / 200)):end, 1:max(1, ceil(Int, size(m, 2) / 200)):end]\n    #= none:7 =#\n    (nr, nc) = size(ms)\n    #= none:8 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:9 =#\n    for i = 1:nr, j = 1:nc\n        #= none:10 =#\n        vals[j + (nr - i) * nc] = Float64(gray(ms[i, j]))\n        #= none:11 =#\n    end\n    #= none:12 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:13 =#\n    ax = Axis(fig[1, 1])\n    #= none:14 =#\n    hidedecorations!(ax)\n    #= none:15 =#\n    hidespines!(ax)\n    #= none:16 =#\n    heatmap!(ax, 1:nc, 1:nr, vals, nc, nr; colorrange = colorrange)\n    #= none:18 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "function rgb_figure(m; px = 240)\n    #= none:21 =#\n    #= none:22 =#\n    ms = m[1:max(1, ceil(Int, size(m, 1) / 200)):end, 1:max(1, ceil(Int, size(m, 2) / 200)):end]\n    #= none:24 =#\n    (nr, nc) = size(ms)\n    #= none:25 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:26 =#\n    for i = 1:nr, j = 1:nc\n        #= none:27 =#\n        v = ms[i, j]\n        #= none:28 =#\n        pix[j + (nr - i) * nc] = (Float64(red(v)), Float64(green(v)), Float64(blue(v)), 1.0)\n        #= none:30 =#\n    end\n    #= none:31 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:32 =#\n    ax = Axis(fig[1, 1])\n    #= none:33 =#\n    hidedecorations!(ax)\n    #= none:34 =#\n    hidespines!(ax)\n    #= none:35 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:37 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "function kernel_figure(k; px = 180)\n    #= none:40 =#\n    #= none:41 =#\n    kf = Float64.(k)\n    #= none:42 =#\n    (lo, hi) = extrema(kf)\n    #= none:43 =#\n    hi = if hi == lo\n            lo + 1.0\n        else\n            hi\n        end\n    #= none:44 =#\n    gray_figure(kf; px = px, colorrange = (lo, hi))\nend"
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:9 =#\n    #= none:10 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:11 =#\n    for k = 1:nr * nc\n        #= none:12 =#\n        v = vals[k]\n        #= none:13 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:14 =#\n    end\n    #= none:15 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:16 =#\n    ax = Axis(fig[1, 1])\n    #= none:17 =#\n    hidedecorations!(ax)\n    #= none:18 =#\n    hidespines!(ax)\n    #= none:19 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:21 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:24 =#\n    #= none:26 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:27 =#\n    ax = Axis(fig[1, 1])\n    #= none:28 =#\n    hidedecorations!(ax)\n    #= none:29 =#\n    hidespines!(ax)\n    #= none:30 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:32 =#\n    fig\nend",
+      "using PlutoUI, WasmMakie"
+    ]
+  },
+  {
+    "argtypes": [
+      "Int64"
+    ],
+    "bonds": [
+      "blur_radius"
+    ],
+    "cells": [
+      {
+        "cell_id": "88933746-6028-11eb-32de-13eb6ff43e29",
+        "extract_ok": true,
+        "fn_src": "function (blur_radius::Int64,)\n    var\"##cellval#959\" = let\n            #= none:2 =#\n            (nr, nc) = (80, 80)\n            #= none:3 =#\n            base = scene(nr, nc)\n            #= none:4 =#\n            rad = blur_radius\n            #= none:5 =#\n            out = Vector{Float64}(undef, nr * nc)\n            #= none:6 =#\n            for i = 1:nr, j = 1:nc\n                #= none:7 =#\n                acc = 0.0\n                #= none:8 =#\n                cnt = 0\n                #= none:9 =#\n                for di = -rad:rad, dj = -rad:rad\n                    #= none:10 =#\n                    ii = i + di\n                    #= none:11 =#\n                    jj = j + dj\n                    #= none:12 =#\n                    if ii >= 1 && (ii <= nr && (jj >= 1 && jj <= nc))\n                        #= none:13 =#\n                        acc += pixel_at(base, nr, nc, ii, jj)\n                        #= none:14 =#\n                        cnt += 1\n                    end\n                    #= none:16 =#\n                end\n                #= none:17 =#\n                out[j + (nr - i) * nc] = acc / cnt\n                #= none:18 =#\n            end\n            #= none:19 =#\n            gray_figure(out, nr, nc)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#959\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#967\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#967\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#967\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#967\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "2"
+          ],
+          [
+            "1"
+          ],
+          [
+            "3"
+          ],
+          [
+            "6"
+          ]
+        ]
+      }
+    ],
+    "group": 1,
+    "group_ok": true,
+    "group_reasons": [],
+    "notebook": "images.jl",
+    "preamble": [
+      "function scene(nr::Int, nc::Int)\n    #= none:3 =#\n    #= none:4 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:5 =#\n    ci = (nr + 1) / 2\n    #= none:6 =#\n    cj = (nc + 1) / 2\n    #= none:7 =#\n    maxr = sqrt(ci * ci + cj * cj)\n    #= none:8 =#\n    for i = 1:nr, j = 1:nc\n        #= none:9 =#\n        di = i - ci\n        #= none:10 =#\n        dj = j - cj\n        #= none:11 =#\n        dist = sqrt(di * di + dj * dj)\n        #= none:12 =#\n        rings = 0.5 + 0.5 * cos(dist * 0.9)\n        #= none:13 =#\n        grad = (i + j) / (nr + nc)\n        #= none:14 =#\n        v = 0.6rings + 0.4grad\n        #= none:15 =#\n        v < 0.0 && (v = 0.0)\n        #= none:16 =#\n        v > 1.0 && (v = 1.0)\n        #= none:17 =#\n        vals[j + (nr - i) * nc] = v\n        #= none:18 =#\n    end\n    #= none:19 =#\n    return vals\nend",
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:10 =#\n    #= none:11 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:12 =#\n    for k = 1:nr * nc\n        #= none:13 =#\n        v = vals[k]\n        #= none:14 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:15 =#\n    end\n    #= none:16 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:17 =#\n    ax = Axis(fig[1, 1])\n    #= none:18 =#\n    hidedecorations!(ax)\n    #= none:19 =#\n    hidespines!(ax)\n    #= none:20 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:22 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:25 =#\n    #= none:27 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:28 =#\n    ax = Axis(fig[1, 1])\n    #= none:29 =#\n    hidedecorations!(ax)\n    #= none:30 =#\n    hidespines!(ax)\n    #= none:31 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:33 =#\n    fig\nend",
+      "function pixel_at(vals::Vector{Float64}, nr::Int, nc::Int, i::Int, j::Int)\n    #= none:2 =#\n    #= none:3 =#\n    return vals[j + (nr - i) * nc]\nend",
+      "using PlutoUI",
+      "using WasmMakie"
+    ]
+  },
+  {
+    "argtypes": [
+      "Float64"
+    ],
+    "bonds": [
+      "brightness"
+    ],
+    "cells": [
+      {
+        "cell_id": "ab9af0f6-64c9-11eb-13d3-5dbdb75a69a7",
+        "extract_ok": true,
+        "fn_src": "function (brightness::Float64,)\n    var\"##cellval#960\" = let\n            #= none:2 =#\n            (nr, nc) = (80, 80)\n            #= none:3 =#\n            base = scene(nr, nc)\n            #= none:4 =#\n            out = Vector{Float64}(undef, nr * nc)\n            #= none:5 =#\n            f = Float64(brightness)\n            #= none:6 =#\n            for k = 1:nr * nc\n                #= none:7 =#\n                v = base[k] * f\n                #= none:8 =#\n                v > 1.0 && (v = 1.0)\n                #= none:9 =#\n                out[k] = v\n                #= none:10 =#\n            end\n            #= none:11 =#\n            gray_figure(out, nr, nc)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#960\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#968\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#968\".var\"#4#5\")(::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#968\".var\"#4#5\")(!Matched::Float64)\n   @ Main.var\"##hv#968\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#968\".var\"#4#5\")(::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#968\".var\"#4#5\")(!Matched::Float64)\n   @ Main.var\"##hv#968\" none:0\n"
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "1.0"
+          ],
+          [
+            "10"
+          ],
+          [
+            "19"
+          ]
+        ]
+      }
+    ],
+    "group": 2,
+    "group_ok": true,
+    "group_reasons": [],
+    "notebook": "images.jl",
+    "preamble": [
+      "function scene(nr::Int, nc::Int)\n    #= none:3 =#\n    #= none:4 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:5 =#\n    ci = (nr + 1) / 2\n    #= none:6 =#\n    cj = (nc + 1) / 2\n    #= none:7 =#\n    maxr = sqrt(ci * ci + cj * cj)\n    #= none:8 =#\n    for i = 1:nr, j = 1:nc\n        #= none:9 =#\n        di = i - ci\n        #= none:10 =#\n        dj = j - cj\n        #= none:11 =#\n        dist = sqrt(di * di + dj * dj)\n        #= none:12 =#\n        rings = 0.5 + 0.5 * cos(dist * 0.9)\n        #= none:13 =#\n        grad = (i + j) / (nr + nc)\n        #= none:14 =#\n        v = 0.6rings + 0.4grad\n        #= none:15 =#\n        v < 0.0 && (v = 0.0)\n        #= none:16 =#\n        v > 1.0 && (v = 1.0)\n        #= none:17 =#\n        vals[j + (nr - i) * nc] = v\n        #= none:18 =#\n    end\n    #= none:19 =#\n    return vals\nend",
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:10 =#\n    #= none:11 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:12 =#\n    for k = 1:nr * nc\n        #= none:13 =#\n        v = vals[k]\n        #= none:14 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:15 =#\n    end\n    #= none:16 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:17 =#\n    ax = Axis(fig[1, 1])\n    #= none:18 =#\n    hidedecorations!(ax)\n    #= none:19 =#\n    hidespines!(ax)\n    #= none:20 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:22 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:25 =#\n    #= none:27 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:28 =#\n    ax = Axis(fig[1, 1])\n    #= none:29 =#\n    hidedecorations!(ax)\n    #= none:30 =#\n    hidespines!(ax)\n    #= none:31 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:33 =#\n    fig\nend",
+      "using PlutoUI",
+      "using WasmMakie"
     ]
   },
   {
@@ -5465,9 +4284,11 @@
       {
         "cell_id": "ff762861-b186-4eb0-9582-0ce66ca10f60",
         "extract_ok": true,
-        "fn_src": "function (col_i::Int64, row_i::Int64)\n    url = $(QuoteNode(\"https://user-images.githubusercontent.com/6933510/107239146-dcc3fd00-6a28-11eb-8c7b-41aaf6618935.png\"))\n    philip_filename = $(QuoteNode(\"/var/folders/cc/2fhyrfnd7x39rgjk39v38nk40000gn/T/jl_6rDxC8/107239146-dcc3fd00-6a28-11eb-8c7b-41aaf6618935.png\"))\n    philip = load(philip_filename)\n    var\"##cellval#1142\" = rgb_figure(philip[row_i, col_i])\n    return (PlutoIslands._html_body)(var\"##cellval#1142\")\nend",
+        "fn_src": "function (col_i::Int64, row_i::Int64)\n    var\"##cellval#961\" = let\n            #= none:2 =#\n            (nr, nc) = (80, 80)\n            #= none:3 =#\n            v = pixel_at(scene(nr, nc), nr, nc, row_i, col_i)\n            #= none:5 =#\n            one = Vector{Float64}(undef, 1)\n            #= none:6 =#\n            one[1] = v\n            #= none:7 =#\n            gray_figure(one, 1, 1; px = 120)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#961\")\nend",
         "golden": [
-          "ERR:UndefVarError: `load` not defined in `Main.var\"##hv#1149\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#969\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#969\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#969\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -5475,124 +4296,44 @@
         "rettype": "String",
         "samples": [
           [
-            "1",
-            "1"
+            "40",
+            "40"
+          ],
+          [
+            "80",
+            "40"
+          ],
+          [
+            "40",
+            "80"
           ]
         ]
       },
       {
         "cell_id": "94b77934-713e-11eb-18cf-c5dc5e7afc5b",
         "extract_ok": true,
-        "fn_src": "function (col_i::Int64, row_i::Int64)\n    var\"##cellval#1143\" = (row_i, col_i)\n    return var\"##cellval#1143\"\nend",
+        "fn_src": "function (col_i::Int64, row_i::Int64)\n    return (((\"<div class=\\\"markdown\\\"><p>The pixel at row \" * string(row_i)) * \", column \") * string(col_i)) * \" has brightness shown above.</p>\\n</div>\"\nend",
         "golden": [
-          "(1, 1)"
-        ],
-        "kind": "tree",
-        "mime": "application/vnd.pluto.tree+object",
-        "reasons": [],
-        "rettype": "Tuple{Int64, Int64}",
-        "samples": [
-          [
-            "1",
-            "1"
-          ]
-        ]
-      }
-    ],
-    "group": 1,
-    "group_ok": true,
-    "group_reasons": [],
-    "notebook": "images.jl",
-    "preamble": [
-      "using Colors, ColorVectorSpace, FileIO, ImageIO",
-      "using WasmMakie",
-      "using PlutoUI",
-      "using PlutoTeachingTools",
-      "using HypertextLiteral",
-      "function rgb_figure(m::AbstractMatrix; px::Int = 240)\n    #= none:2 =#\n    #= none:3 =#\n    small = m[1:ceil(Int, size(m, 1) / px):end, 1:ceil(Int, size(m, 2) / px):end]\n    #= none:4 =#\n    (nrows, ncols) = size(small)\n    #= none:5 =#\n    (nrows == 0 || ncols == 0) && return Figure(size = (80, 80))\n    #= none:6 =#\n    pixels = Vector{NTuple{4, Float64}}(undef, nrows * ncols)\n    #= none:7 =#\n    for i = 1:nrows, j = 1:ncols\n        #= none:8 =#\n        c = RGBA{Float64}(small[i, j])\n        #= none:9 =#\n        pixels[j + (nrows - i) * ncols] = (Float64(red(c)), Float64(green(c)), Float64(blue(c)), Float64(alpha(c)))\n        #= none:11 =#\n    end\n    #= none:12 =#\n    target = if max(nrows, ncols) <= 8\n            80.0\n        else\n            360.0\n        end\n    #= none:13 =#\n    s = target / max(nrows, ncols)\n    #= none:14 =#\n    fig = Figure(size = (max(round(Int, ncols * s), 24), max(round(Int, nrows * s), 24)))\n    #= none:15 =#\n    ax = Axis(fig[1, 1])\n    #= none:16 =#\n    hidedecorations!(ax)\n    #= none:17 =#\n    hidespines!(ax)\n    #= none:18 =#\n    image!(ax, (0, ncols), (0, nrows), pixels, Int64(ncols), Int64(nrows); interpolate = false)\n    #= none:20 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "rgb_figure(v::AbstractVector{<:Colorant}; kwargs...) = begin\n        #= none:22 =#\n        rgb_figure(permutedims(v); kwargs...)\n    end",
-      "rgb_figure(c::Colorant; kwargs...) = begin\n        #= none:23 =#\n        rgb_figure(fill(c, 1, 1); kwargs...)\n    end"
-    ]
-  },
-  {
-    "argtypes": [
-      "Int64"
-    ],
-    "bonds": [
-      "myface1"
-    ],
-    "cells": [
-      {
-        "cell_id": "6224c74b-8915-4983-abf0-30e6ba04a46d",
-        "extract_ok": true,
-        "fn_src": "function (myface1::Int64,)\n    var\"##cellval#1144\" = if myface1 isa AbstractMatrix\n            #= none:2 =#\n            rgb_figure([myface1 myface1[:, end:-1:1]; myface1[end:-1:1, :] myface1[end:-1:1, end:-1:1]])\n        else\n            #= none:7 =#\n            md\"*no webcam image*\"\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#1144\")\nend",
-        "golden": [
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported",
-          "ERR:text/html rendering of Markdown.MD unsupported"
+          "\"<div class=\\\"markdown\\\"><p>The pixel at row 40, column 40 has brightness shown above.</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p>The pixel at row 40, column 80 has brightness shown above.</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p>The pixel at row 80, column 40 has brightness shown above.</p>\\n</div>\""
         ],
         "kind": "string",
         "mime": "text/html",
         "reasons": [],
-        "rettype": "Union{}",
+        "rettype": "String",
         "samples": [
           [
-            "0"
+            "40",
+            "40"
           ],
           [
-            "1"
+            "80",
+            "40"
           ],
           [
-            "2"
-          ]
-        ]
-      }
-    ],
-    "group": 2,
-    "group_ok": true,
-    "group_reasons": [],
-    "notebook": "images.jl",
-    "preamble": [
-      "using Colors, ColorVectorSpace, FileIO, ImageIO",
-      "using WasmMakie",
-      "using PlutoUI",
-      "using PlutoTeachingTools",
-      "using HypertextLiteral",
-      "function rgb_figure(m::AbstractMatrix; px::Int = 240)\n    #= none:2 =#\n    #= none:3 =#\n    small = m[1:ceil(Int, size(m, 1) / px):end, 1:ceil(Int, size(m, 2) / px):end]\n    #= none:4 =#\n    (nrows, ncols) = size(small)\n    #= none:5 =#\n    (nrows == 0 || ncols == 0) && return Figure(size = (80, 80))\n    #= none:6 =#\n    pixels = Vector{NTuple{4, Float64}}(undef, nrows * ncols)\n    #= none:7 =#\n    for i = 1:nrows, j = 1:ncols\n        #= none:8 =#\n        c = RGBA{Float64}(small[i, j])\n        #= none:9 =#\n        pixels[j + (nrows - i) * ncols] = (Float64(red(c)), Float64(green(c)), Float64(blue(c)), Float64(alpha(c)))\n        #= none:11 =#\n    end\n    #= none:12 =#\n    target = if max(nrows, ncols) <= 8\n            80.0\n        else\n            360.0\n        end\n    #= none:13 =#\n    s = target / max(nrows, ncols)\n    #= none:14 =#\n    fig = Figure(size = (max(round(Int, ncols * s), 24), max(round(Int, nrows * s), 24)))\n    #= none:15 =#\n    ax = Axis(fig[1, 1])\n    #= none:16 =#\n    hidedecorations!(ax)\n    #= none:17 =#\n    hidespines!(ax)\n    #= none:18 =#\n    image!(ax, (0, ncols), (0, nrows), pixels, Int64(ncols), Int64(nrows); interpolate = false)\n    #= none:20 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "rgb_figure(v::AbstractVector{<:Colorant}; kwargs...) = begin\n        #= none:22 =#\n        rgb_figure(permutedims(v); kwargs...)\n    end",
-      "rgb_figure(c::Colorant; kwargs...) = begin\n        #= none:23 =#\n        rgb_figure(fill(c, 1, 1); kwargs...)\n    end"
-    ]
-  },
-  {
-    "argtypes": [
-      "Int64"
-    ],
-    "bonds": [
-      "number_reds"
-    ],
-    "cells": [
-      {
-        "cell_id": "88933746-6028-11eb-32de-13eb6ff43e29",
-        "extract_ok": true,
-        "fn_src": "function (number_reds::Int64,)\n    var\"##cellval#1145\" = rgb_figure([RGB(red_value / number_reds, 0, 0) for red_value = 0:number_reds])\n    return (PlutoIslands._html_body)(var\"##cellval#1145\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `RGB` not defined in `Main.var\"##hv#1151\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `RGB` not defined in `Main.var\"##hv#1151\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `RGB` not defined in `Main.var\"##hv#1151\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "1"
-          ],
-          [
-            "50"
-          ],
-          [
-            "100"
+            "40",
+            "80"
           ]
         ]
       }
@@ -5602,50 +4343,31 @@
     "group_reasons": [],
     "notebook": "images.jl",
     "preamble": [
-      "using Colors, ColorVectorSpace, FileIO, ImageIO",
-      "using WasmMakie",
+      "function scene(nr::Int, nc::Int)\n    #= none:3 =#\n    #= none:4 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:5 =#\n    ci = (nr + 1) / 2\n    #= none:6 =#\n    cj = (nc + 1) / 2\n    #= none:7 =#\n    maxr = sqrt(ci * ci + cj * cj)\n    #= none:8 =#\n    for i = 1:nr, j = 1:nc\n        #= none:9 =#\n        di = i - ci\n        #= none:10 =#\n        dj = j - cj\n        #= none:11 =#\n        dist = sqrt(di * di + dj * dj)\n        #= none:12 =#\n        rings = 0.5 + 0.5 * cos(dist * 0.9)\n        #= none:13 =#\n        grad = (i + j) / (nr + nc)\n        #= none:14 =#\n        v = 0.6rings + 0.4grad\n        #= none:15 =#\n        v < 0.0 && (v = 0.0)\n        #= none:16 =#\n        v > 1.0 && (v = 1.0)\n        #= none:17 =#\n        vals[j + (nr - i) * nc] = v\n        #= none:18 =#\n    end\n    #= none:19 =#\n    return vals\nend",
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:10 =#\n    #= none:11 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:12 =#\n    for k = 1:nr * nc\n        #= none:13 =#\n        v = vals[k]\n        #= none:14 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:15 =#\n    end\n    #= none:16 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:17 =#\n    ax = Axis(fig[1, 1])\n    #= none:18 =#\n    hidedecorations!(ax)\n    #= none:19 =#\n    hidespines!(ax)\n    #= none:20 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:22 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:25 =#\n    #= none:27 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:28 =#\n    ax = Axis(fig[1, 1])\n    #= none:29 =#\n    hidedecorations!(ax)\n    #= none:30 =#\n    hidespines!(ax)\n    #= none:31 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:33 =#\n    fig\nend",
+      "function pixel_at(vals::Vector{Float64}, nr::Int, nc::Int, i::Int, j::Int)\n    #= none:2 =#\n    #= none:3 =#\n    return vals[j + (nr - i) * nc]\nend",
       "using PlutoUI",
-      "using PlutoTeachingTools",
-      "using HypertextLiteral",
-      "function rgb_figure(m::AbstractMatrix; px::Int = 240)\n    #= none:2 =#\n    #= none:3 =#\n    small = m[1:ceil(Int, size(m, 1) / px):end, 1:ceil(Int, size(m, 2) / px):end]\n    #= none:4 =#\n    (nrows, ncols) = size(small)\n    #= none:5 =#\n    (nrows == 0 || ncols == 0) && return Figure(size = (80, 80))\n    #= none:6 =#\n    pixels = Vector{NTuple{4, Float64}}(undef, nrows * ncols)\n    #= none:7 =#\n    for i = 1:nrows, j = 1:ncols\n        #= none:8 =#\n        c = RGBA{Float64}(small[i, j])\n        #= none:9 =#\n        pixels[j + (nrows - i) * ncols] = (Float64(red(c)), Float64(green(c)), Float64(blue(c)), Float64(alpha(c)))\n        #= none:11 =#\n    end\n    #= none:12 =#\n    target = if max(nrows, ncols) <= 8\n            80.0\n        else\n            360.0\n        end\n    #= none:13 =#\n    s = target / max(nrows, ncols)\n    #= none:14 =#\n    fig = Figure(size = (max(round(Int, ncols * s), 24), max(round(Int, nrows * s), 24)))\n    #= none:15 =#\n    ax = Axis(fig[1, 1])\n    #= none:16 =#\n    hidedecorations!(ax)\n    #= none:17 =#\n    hidespines!(ax)\n    #= none:18 =#\n    image!(ax, (0, ncols), (0, nrows), pixels, Int64(ncols), Int64(nrows); interpolate = false)\n    #= none:20 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "rgb_figure(v::AbstractVector{<:Colorant}; kwargs...) = begin\n        #= none:22 =#\n        rgb_figure(permutedims(v); kwargs...)\n    end",
-      "rgb_figure(c::Colorant; kwargs...) = begin\n        #= none:23 =#\n        rgb_figure(fill(c, 1, 1); kwargs...)\n    end"
+      "using WasmMakie"
     ]
   },
   {
     "argtypes": [
-      "StepRange{Int64, Int64}",
-      "StepRange{Int64, Int64}"
+      "Int64"
     ],
     "bonds": [
-      "range_cols",
-      "range_rows"
+      "crop_half"
     ],
     "cells": [
       {
-        "cell_id": "2ac47b91-bbc3-49ae-9bf5-4def30ff46f4",
-        "extract_ok": true,
-        "fn_src": "function (range_cols::StepRange{Int64, Int64}, range_rows::StepRange{Int64, Int64})\n    url = $(QuoteNode(\"https://user-images.githubusercontent.com/6933510/107239146-dcc3fd00-6a28-11eb-8c7b-41aaf6618935.png\"))\n    philip_filename = $(QuoteNode(\"/var/folders/cc/2fhyrfnd7x39rgjk39v38nk40000gn/T/jl_6rDxC8/107239146-dcc3fd00-6a28-11eb-8c7b-41aaf6618935.png\"))\n    philip = load(philip_filename)\n    philip_head = philip[470:800, 140:410]\n    nose = philip_head[range_rows, range_cols]\n    var\"##cellval#1146\" = nose\n    return (PlutoIslands._plain_body)(var\"##cellval#1146\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `load` not defined in `Main.var\"##hv#1152\"`\nSuggestion: check for spelling errors or missing imports."
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "1:1:271",
-            "1:1:331"
-          ]
-        ]
-      },
-      {
         "cell_id": "93b18ee8-f11c-40e2-b292-562798100ba4",
         "extract_ok": true,
-        "fn_src": "function (range_cols::StepRange{Int64, Int64}, range_rows::StepRange{Int64, Int64})\n    url = $(QuoteNode(\"https://user-images.githubusercontent.com/6933510/107239146-dcc3fd00-6a28-11eb-8c7b-41aaf6618935.png\"))\n    philip_filename = $(QuoteNode(\"/var/folders/cc/2fhyrfnd7x39rgjk39v38nk40000gn/T/jl_6rDxC8/107239146-dcc3fd00-6a28-11eb-8c7b-41aaf6618935.png\"))\n    philip = load(philip_filename)\n    philip_head = philip[470:800, 140:410]\n    nose = philip_head[range_rows, range_cols]\n    var\"##cellval#1147\" = rgb_figure(nose)\n    return (PlutoIslands._html_body)(var\"##cellval#1147\")\nend",
+        "fn_src": "function (crop_half::Int64,)\n    var\"##cellval#963\" = let\n            #= none:2 =#\n            (nr, nc) = (80, 80)\n            #= none:3 =#\n            mid = 40\n            #= none:4 =#\n            r0 = mid - crop_half\n            #= none:4 =#\n            r1 = mid + crop_half\n            #= none:5 =#\n            c0 = mid - crop_half\n            #= none:5 =#\n            c1 = mid + crop_half\n            #= none:6 =#\n            on = (r1 - r0) + 1\n            #= none:6 =#\n            om = (c1 - c0) + 1\n            #= none:7 =#\n            sub = crop(scene(nr, nc), nr, nc, r0, r1, c0, c1)\n            #= none:8 =#\n            gray_figure(sub, on, om)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#963\")\nend",
         "golden": [
-          "ERR:UndefVarError: `load` not defined in `Main.var\"##hv#1152\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#970\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#970\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#970\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#970\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -5653,8 +4375,16 @@
         "rettype": "String",
         "samples": [
           [
-            "1:1:271",
-            "1:1:331"
+            "20"
+          ],
+          [
+            "1"
+          ],
+          [
+            "9"
+          ],
+          [
+            "18"
           ]
         ]
       }
@@ -5664,14 +4394,103 @@
     "group_reasons": [],
     "notebook": "images.jl",
     "preamble": [
-      "using Colors, ColorVectorSpace, FileIO, ImageIO",
-      "using WasmMakie",
+      "function scene(nr::Int, nc::Int)\n    #= none:3 =#\n    #= none:4 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:5 =#\n    ci = (nr + 1) / 2\n    #= none:6 =#\n    cj = (nc + 1) / 2\n    #= none:7 =#\n    maxr = sqrt(ci * ci + cj * cj)\n    #= none:8 =#\n    for i = 1:nr, j = 1:nc\n        #= none:9 =#\n        di = i - ci\n        #= none:10 =#\n        dj = j - cj\n        #= none:11 =#\n        dist = sqrt(di * di + dj * dj)\n        #= none:12 =#\n        rings = 0.5 + 0.5 * cos(dist * 0.9)\n        #= none:13 =#\n        grad = (i + j) / (nr + nc)\n        #= none:14 =#\n        v = 0.6rings + 0.4grad\n        #= none:15 =#\n        v < 0.0 && (v = 0.0)\n        #= none:16 =#\n        v > 1.0 && (v = 1.0)\n        #= none:17 =#\n        vals[j + (nr - i) * nc] = v\n        #= none:18 =#\n    end\n    #= none:19 =#\n    return vals\nend",
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:10 =#\n    #= none:11 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:12 =#\n    for k = 1:nr * nc\n        #= none:13 =#\n        v = vals[k]\n        #= none:14 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:15 =#\n    end\n    #= none:16 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:17 =#\n    ax = Axis(fig[1, 1])\n    #= none:18 =#\n    hidedecorations!(ax)\n    #= none:19 =#\n    hidespines!(ax)\n    #= none:20 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:22 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:25 =#\n    #= none:27 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:28 =#\n    ax = Axis(fig[1, 1])\n    #= none:29 =#\n    hidedecorations!(ax)\n    #= none:30 =#\n    hidespines!(ax)\n    #= none:31 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:33 =#\n    fig\nend",
+      "function pixel_at(vals::Vector{Float64}, nr::Int, nc::Int, i::Int, j::Int)\n    #= none:2 =#\n    #= none:3 =#\n    return vals[j + (nr - i) * nc]\nend",
+      "function crop(vals::Vector{Float64}, nr::Int, nc::Int, r0::Int, r1::Int, c0::Int, c1::Int)\n    #= none:3 =#\n    #= none:5 =#\n    on = (r1 - r0) + 1\n    #= none:6 =#\n    om = (c1 - c0) + 1\n    #= none:7 =#\n    out = Vector{Float64}(undef, on * om)\n    #= none:8 =#\n    for i = 1:on, j = 1:om\n        #= none:9 =#\n        src = pixel_at(vals, nr, nc, (r0 + i) - 1, (c0 + j) - 1)\n        #= none:10 =#\n        out[j + (on - i) * om] = src\n        #= none:11 =#\n    end\n    #= none:12 =#\n    return out\nend",
       "using PlutoUI",
-      "using PlutoTeachingTools",
-      "using HypertextLiteral",
-      "function rgb_figure(m::AbstractMatrix; px::Int = 240)\n    #= none:2 =#\n    #= none:3 =#\n    small = m[1:ceil(Int, size(m, 1) / px):end, 1:ceil(Int, size(m, 2) / px):end]\n    #= none:4 =#\n    (nrows, ncols) = size(small)\n    #= none:5 =#\n    (nrows == 0 || ncols == 0) && return Figure(size = (80, 80))\n    #= none:6 =#\n    pixels = Vector{NTuple{4, Float64}}(undef, nrows * ncols)\n    #= none:7 =#\n    for i = 1:nrows, j = 1:ncols\n        #= none:8 =#\n        c = RGBA{Float64}(small[i, j])\n        #= none:9 =#\n        pixels[j + (nrows - i) * ncols] = (Float64(red(c)), Float64(green(c)), Float64(blue(c)), Float64(alpha(c)))\n        #= none:11 =#\n    end\n    #= none:12 =#\n    target = if max(nrows, ncols) <= 8\n            80.0\n        else\n            360.0\n        end\n    #= none:13 =#\n    s = target / max(nrows, ncols)\n    #= none:14 =#\n    fig = Figure(size = (max(round(Int, ncols * s), 24), max(round(Int, nrows * s), 24)))\n    #= none:15 =#\n    ax = Axis(fig[1, 1])\n    #= none:16 =#\n    hidedecorations!(ax)\n    #= none:17 =#\n    hidespines!(ax)\n    #= none:18 =#\n    image!(ax, (0, ncols), (0, nrows), pixels, Int64(ncols), Int64(nrows); interpolate = false)\n    #= none:20 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "rgb_figure(v::AbstractVector{<:Colorant}; kwargs...) = begin\n        #= none:22 =#\n        rgb_figure(permutedims(v); kwargs...)\n    end",
-      "rgb_figure(c::Colorant; kwargs...) = begin\n        #= none:23 =#\n        rgb_figure(fill(c, 1, 1); kwargs...)\n    end"
+      "using WasmMakie"
+    ]
+  },
+  {
+    "argtypes": [
+      "Bool",
+      "Bool"
+    ],
+    "bonds": [
+      "flip_lr",
+      "flip_tb"
+    ],
+    "cells": [
+      {
+        "cell_id": "1bd53326-d705-4d1a-bf8f-5d7f2a4e696f",
+        "extract_ok": true,
+        "fn_src": "function (flip_lr::Bool, flip_tb::Bool)\n    var\"##cellval#964\" = let\n            #= none:2 =#\n            (nr, nc) = (80, 80)\n            #= none:3 =#\n            base = scene(nr, nc)\n            #= none:4 =#\n            out = Vector{Float64}(undef, nr * nc)\n            #= none:5 =#\n            for i = 1:nr, j = 1:nc\n                #= none:6 =#\n                si = if flip_tb\n                        (nr - i) + 1\n                    else\n                        i\n                    end\n                #= none:7 =#\n                sj = if flip_lr\n                        (nc - j) + 1\n                    else\n                        j\n                    end\n                #= none:8 =#\n                out[j + (nr - i) * nc] = pixel_at(base, nr, nc, si, sj)\n                #= none:9 =#\n            end\n            #= none:10 =#\n            gray_figure(out, nr, nc)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#964\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#971\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#971\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "true",
+            "false"
+          ],
+          [
+            "true",
+            "true"
+          ]
+        ]
+      }
+    ],
+    "group": 5,
+    "group_ok": true,
+    "group_reasons": [],
+    "notebook": "images.jl",
+    "preamble": [
+      "function scene(nr::Int, nc::Int)\n    #= none:3 =#\n    #= none:4 =#\n    vals = Vector{Float64}(undef, nr * nc)\n    #= none:5 =#\n    ci = (nr + 1) / 2\n    #= none:6 =#\n    cj = (nc + 1) / 2\n    #= none:7 =#\n    maxr = sqrt(ci * ci + cj * cj)\n    #= none:8 =#\n    for i = 1:nr, j = 1:nc\n        #= none:9 =#\n        di = i - ci\n        #= none:10 =#\n        dj = j - cj\n        #= none:11 =#\n        dist = sqrt(di * di + dj * dj)\n        #= none:12 =#\n        rings = 0.5 + 0.5 * cos(dist * 0.9)\n        #= none:13 =#\n        grad = (i + j) / (nr + nc)\n        #= none:14 =#\n        v = 0.6rings + 0.4grad\n        #= none:15 =#\n        v < 0.0 && (v = 0.0)\n        #= none:16 =#\n        v > 1.0 && (v = 1.0)\n        #= none:17 =#\n        vals[j + (nr - i) * nc] = v\n        #= none:18 =#\n    end\n    #= none:19 =#\n    return vals\nend",
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:10 =#\n    #= none:11 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:12 =#\n    for k = 1:nr * nc\n        #= none:13 =#\n        v = vals[k]\n        #= none:14 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:15 =#\n    end\n    #= none:16 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:17 =#\n    ax = Axis(fig[1, 1])\n    #= none:18 =#\n    hidedecorations!(ax)\n    #= none:19 =#\n    hidespines!(ax)\n    #= none:20 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:22 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:25 =#\n    #= none:27 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:28 =#\n    ax = Axis(fig[1, 1])\n    #= none:29 =#\n    hidedecorations!(ax)\n    #= none:30 =#\n    hidespines!(ax)\n    #= none:31 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:33 =#\n    fig\nend",
+      "function pixel_at(vals::Vector{Float64}, nr::Int, nc::Int, i::Int, j::Int)\n    #= none:2 =#\n    #= none:3 =#\n    return vals[j + (nr - i) * nc]\nend",
+      "using PlutoUI",
+      "using WasmMakie"
+    ]
+  },
+  {
+    "argtypes": [
+      "Bool",
+      "Bool",
+      "Bool"
+    ],
+    "bonds": [
+      "show_b",
+      "show_g",
+      "show_r"
+    ],
+    "cells": [
+      {
+        "cell_id": "d1174f21-5c74-4934-acdf-716671cfc2db",
+        "extract_ok": true,
+        "fn_src": "function (show_b::Bool, show_g::Bool, show_r::Bool)\n    var\"##cellval#965\" = let\n            #= none:2 =#\n            (nr, nc) = (80, 80)\n            #= none:3 =#\n            ci = (nr + 1) / 2\n            #= none:3 =#\n            cj = (nc + 1) / 2\n            #= none:4 =#\n            pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n            #= none:5 =#\n            for i = 1:nr, j = 1:nc\n                #= none:6 =#\n                di = i - ci\n                #= none:6 =#\n                dj = j - cj\n                #= none:7 =#\n                dist = sqrt(di * di + dj * dj)\n                #= none:8 =#\n                r = if show_r\n                        (j - 1) / (nc - 1)\n                    else\n                        0.0\n                    end\n                #= none:9 =#\n                g = if show_g\n                        (i - 1) / (nr - 1)\n                    else\n                        0.0\n                    end\n                #= none:10 =#\n                b = if show_b\n                        0.5 + 0.5 * cos(dist * 0.6)\n                    else\n                        0.0\n                    end\n                #= none:11 =#\n                pix[j + (nr - i) * nc] = (r, g, b, 1.0)\n                #= none:12 =#\n            end\n            #= none:13 =#\n            rgb_figure(pix, nr, nc)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#965\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#972\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "true",
+            "true",
+            "true"
+          ]
+        ]
+      }
+    ],
+    "group": 6,
+    "group_ok": true,
+    "group_reasons": [],
+    "notebook": "images.jl",
+    "preamble": [
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:10 =#\n    #= none:11 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:12 =#\n    for k = 1:nr * nc\n        #= none:13 =#\n        v = vals[k]\n        #= none:14 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:15 =#\n    end\n    #= none:16 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:17 =#\n    ax = Axis(fig[1, 1])\n    #= none:18 =#\n    hidedecorations!(ax)\n    #= none:19 =#\n    hidespines!(ax)\n    #= none:20 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:22 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:25 =#\n    #= none:27 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:28 =#\n    ax = Axis(fig[1, 1])\n    #= none:29 =#\n    hidedecorations!(ax)\n    #= none:30 =#\n    hidespines!(ax)\n    #= none:31 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:33 =#\n    fig\nend",
+      "using PlutoUI",
+      "using WasmMakie"
     ]
   },
   {
@@ -5689,11 +4508,12 @@
       {
         "cell_id": "ff9eea3f-cab0-4030-8337-f519b94316c5",
         "extract_ok": true,
-        "fn_src": "function (test_b::Float64, test_g::Float64, test_r::Float64)\n    var\"##cellval#1148\" = rgb_figure(RGB(test_r, test_g, test_b))\n    return (PlutoIslands._html_body)(var\"##cellval#1148\")\nend",
+        "fn_src": "function (test_b::Float64, test_g::Float64, test_r::Float64)\n    var\"##cellval#966\" = let\n            #= none:2 =#\n            r = Float64(test_r)\n            #= none:2 =#\n            g = Float64(test_g)\n            #= none:2 =#\n            b = Float64(test_b)\n            #= none:4 =#\n            pix = Vector{NTuple{4, Float64}}(undef, 1)\n            #= none:5 =#\n            pix[1] = (r, g, b, 1.0)\n            #= none:6 =#\n            rgb_figure(pix, 1, 1; px = 120)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#966\")\nend",
         "golden": [
-          "ERR:UndefVarError: `RGB` not defined in `Main.var\"##hv#1153\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `RGB` not defined in `Main.var\"##hv#1153\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `RGB` not defined in `Main.var\"##hv#1153\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#973\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#973\".var\"#4#5\")(::Int64, ::Float64, ::Float64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#973\".var\"#4#5\")(!Matched::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#973\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#973\".var\"#4#5\")(::Float64, ::Int64, ::Float64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#973\".var\"#4#5\")(::Float64, !Matched::Float64, ::Float64)\n   @ Main.var\"##hv#973\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#973\".var\"#4#5\")(::Float64, ::Float64, ::Int64)\nThe function `#4` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#973\".var\"#4#5\")(::Float64, ::Float64, !Matched::Float64)\n   @ Main.var\"##hv#973\" none:0\n"
         ],
         "kind": "string",
         "mime": "text/html",
@@ -5706,148 +4526,52 @@
             "0.1"
           ],
           [
+            "21",
+            "0.5",
+            "0.1"
+          ],
+          [
             "1.0",
-            "1.0",
+            "21",
             "0.1"
           ],
           [
             "1.0",
             "0.5",
-            "1.0"
+            "21"
           ]
         ]
       }
     ],
-    "group": 5,
+    "group": 7,
     "group_ok": true,
     "group_reasons": [],
     "notebook": "images.jl",
     "preamble": [
-      "using Colors, ColorVectorSpace, FileIO, ImageIO",
-      "using WasmMakie",
+      "function gray_figure(vals::Vector{Float64}, nr::Int, nc::Int; px::Int = 320)\n    #= none:10 =#\n    #= none:11 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:12 =#\n    for k = 1:nr * nc\n        #= none:13 =#\n        v = vals[k]\n        #= none:14 =#\n        pix[k] = (v, v, v, 1.0)\n        #= none:15 =#\n    end\n    #= none:16 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:17 =#\n    ax = Axis(fig[1, 1])\n    #= none:18 =#\n    hidedecorations!(ax)\n    #= none:19 =#\n    hidespines!(ax)\n    #= none:20 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:22 =#\n    fig\nend",
+      "function rgb_figure(pix::Vector{NTuple{4, Float64}}, nr::Int, nc::Int; px::Int = 320)\n    #= none:25 =#\n    #= none:27 =#\n    fig = Figure(size = (px, max(40, round(Int, (px * nr) / nc))))\n    #= none:28 =#\n    ax = Axis(fig[1, 1])\n    #= none:29 =#\n    hidedecorations!(ax)\n    #= none:30 =#\n    hidespines!(ax)\n    #= none:31 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:33 =#\n    fig\nend",
       "using PlutoUI",
-      "using PlutoTeachingTools",
-      "using HypertextLiteral",
-      "function rgb_figure(m::AbstractMatrix; px::Int = 240)\n    #= none:2 =#\n    #= none:3 =#\n    small = m[1:ceil(Int, size(m, 1) / px):end, 1:ceil(Int, size(m, 2) / px):end]\n    #= none:4 =#\n    (nrows, ncols) = size(small)\n    #= none:5 =#\n    (nrows == 0 || ncols == 0) && return Figure(size = (80, 80))\n    #= none:6 =#\n    pixels = Vector{NTuple{4, Float64}}(undef, nrows * ncols)\n    #= none:7 =#\n    for i = 1:nrows, j = 1:ncols\n        #= none:8 =#\n        c = RGBA{Float64}(small[i, j])\n        #= none:9 =#\n        pixels[j + (nrows - i) * ncols] = (Float64(red(c)), Float64(green(c)), Float64(blue(c)), Float64(alpha(c)))\n        #= none:11 =#\n    end\n    #= none:12 =#\n    target = if max(nrows, ncols) <= 8\n            80.0\n        else\n            360.0\n        end\n    #= none:13 =#\n    s = target / max(nrows, ncols)\n    #= none:14 =#\n    fig = Figure(size = (max(round(Int, ncols * s), 24), max(round(Int, nrows * s), 24)))\n    #= none:15 =#\n    ax = Axis(fig[1, 1])\n    #= none:16 =#\n    hidedecorations!(ax)\n    #= none:17 =#\n    hidespines!(ax)\n    #= none:18 =#\n    image!(ax, (0, ncols), (0, nrows), pixels, Int64(ncols), Int64(nrows); interpolate = false)\n    #= none:20 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "rgb_figure(v::AbstractVector{<:Colorant}; kwargs...) = begin\n        #= none:22 =#\n        rgb_figure(permutedims(v); kwargs...)\n    end",
-      "rgb_figure(c::Colorant; kwargs...) = begin\n        #= none:23 =#\n        rgb_figure(fill(c, 1, 1); kwargs...)\n    end"
+      "using WasmMakie"
     ]
   },
   {
     "argtypes": [
-      "String",
-      "Vector{String}",
       "Int64",
-      "Bool",
       "Int64"
     ],
     "bonds": [
-      "algorithm",
-      "colors",
-      "img_raw",
-      "to_gray",
-      "width"
+      "imgsize",
+      "levels"
     ],
     "cells": [
       {
-        "cell_id": "354f38ba-a8cf-4405-a0ef-1ec243f18acf",
+        "cell_id": "0210462f-851b-4e2b-ba99-d7ade531fe11",
         "extract_ok": true,
-        "fn_src": "function (algorithm::String, colors::Vector{String}, img_raw::Int64, to_gray::Bool, width::Int64)\n    maxsize = maximum(size(img_raw))\n    var\"##cellval#1176\" = maxsize\n    return (PlutoIslands._plain_body)(var\"##cellval#1176\")\nend",
+        "fn_src": "function (imgsize::Int64, levels::Int64)\n    var\"##cellval#992\" = let\n            #= none:2 =#\n            n = imgsize\n            #= none:3 =#\n            img = make_gradient(n, n)\n            #= none:4 =#\n            d = floyd_steinberg(img, n, n, levels)\n            #= none:5 =#\n            gray_figure(d, n, n)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#992\")\nend",
         "golden": [
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer"
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "Union{}",
-        "samples": [
-          [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
-          ],
-          [
-            "\"puiselect-13\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
-          ],
-          [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#ffffff\"]",
-            "0",
-            "true",
-            "200"
-          ],
-          [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "2",
-            "true",
-            "200"
-          ]
-        ]
-      },
-      {
-        "cell_id": "7d1ced8c-8a33-4429-b8fb-f06eb4bc7b1b",
-        "extract_ok": true,
-        "fn_src": "function (algorithm::String, colors::Vector{String}, img_raw::Int64, to_gray::Bool, width::Int64)\n    colorscheme = [colors...]\n    var\"##cellval#1177\" = colorscheme\n    return (PlutoIslands._plain_body)(var\"##cellval#1177\")\nend",
-        "golden": [
-          "\"[\\\"#264653\\\", \\\"#2a9d8f\\\", \\\"#e9c46a\\\", \\\"#f4a261\\\", \\\"#e76f51\\\"]\"",
-          "\"[\\\"#264653\\\", \\\"#2a9d8f\\\", \\\"#e9c46a\\\", \\\"#f4a261\\\", \\\"#e76f51\\\"]\"",
-          "\"[\\\"#264653\\\", \\\"#2a9d8f\\\", \\\"#e9c46a\\\", \\\"#f4a261\\\", \\\"#ffffff\\\"]\"",
-          "\"[\\\"#264653\\\", \\\"#2a9d8f\\\", \\\"#e9c46a\\\", \\\"#f4a261\\\", \\\"#e76f51\\\"]\""
-        ],
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": [],
-        "rettype": "String",
-        "samples": [
-          [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
-          ],
-          [
-            "\"puiselect-13\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
-          ],
-          [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#ffffff\"]",
-            "0",
-            "true",
-            "200"
-          ],
-          [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "2",
-            "true",
-            "200"
-          ]
-        ]
-      },
-      {
-        "cell_id": "57a15a1a-32d8-4a75-9a65-18363a3c8f03",
-        "extract_ok": true,
-        "fn_src": "function (algorithm::String, colors::Vector{String}, img_raw::Int64, to_gray::Bool, width::Int64)\n    colorscheme = [colors...]\n    var\"##cellval#1178\" = rgb_figure(reshape(colorscheme, 1, :))\n    return (PlutoIslands._html_body)(var\"##cellval#1178\")\nend",
-        "golden": [
-          "ERR:UndefVarError: `RGBA` not defined in `Main.var\"##hv#1181\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `RGBA` not defined in `Main.var\"##hv#1181\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `RGBA` not defined in `Main.var\"##hv#1181\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `RGBA` not defined in `Main.var\"##hv#1181\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -5855,122 +4579,184 @@
         "rettype": "String",
         "samples": [
           [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
+            "48",
+            "2"
           ],
           [
-            "\"puiselect-13\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
+            "7",
+            "2"
           ],
           [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#ffffff\"]",
-            "0",
-            "true",
-            "200"
+            "48",
+            "5"
+          ]
+        ]
+      },
+      {
+        "cell_id": "09cbe381-c39e-4431-a9d3-624091ea42d0",
+        "extract_ok": true,
+        "fn_src": "function (imgsize::Int64, levels::Int64)\n    var\"##cellval#993\" = let\n            #= none:2 =#\n            n = imgsize\n            #= none:3 =#\n            img = make_gradient(n, n)\n            #= none:4 =#\n            gray_figure(img, n, n)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#993\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "48",
+            "2"
           ],
           [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "2",
-            "true",
-            "200"
+            "7",
+            "2"
+          ],
+          [
+            "48",
+            "5"
+          ]
+        ]
+      },
+      {
+        "cell_id": "8a718f57-740b-43a8-9f05-6c699f982220",
+        "extract_ok": true,
+        "fn_src": "function (imgsize::Int64, levels::Int64)\n    var\"##cellval#994\" = let\n            #= none:2 =#\n            n = imgsize\n            #= none:3 =#\n            img = make_gradient(n, n)\n            #= none:4 =#\n            q = quantize(img, levels)\n            #= none:5 =#\n            gray_figure(q, n, n)\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#994\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#999\"`\nSuggestion: check for spelling errors or missing imports."
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "48",
+            "2"
+          ],
+          [
+            "7",
+            "2"
+          ],
+          [
+            "48",
+            "5"
           ]
         ]
       },
       {
         "cell_id": "c4799684-46b7-4783-99de-c8946e7067de",
         "extract_ok": true,
-        "fn_src": "function (algorithm::String, colors::Vector{String}, img_raw::Int64, to_gray::Bool, width::Int64)\n    maxsize = maximum(size(img_raw))\n    img = let\n            #= none:2 =#\n            ratio = width / maxsize\n            #= none:3 =#\n            img_sized = if maxsize == 1\n                    img_raw\n                else\n                    imresize(img_raw; ratio = ratio)\n                end\n            #= none:4 =#\n            img = if to_gray\n                    Gray.(img_sized)\n                else\n                    img_sized\n                end\n        end\n    var\"##cellval#1179\" = img\n    return (PlutoIslands._plain_body)(var\"##cellval#1179\")\nend",
+        "fn_src": "function (imgsize::Int64, levels::Int64)\n    err_dither = let\n            #= none:2 =#\n            n = imgsize\n            #= none:3 =#\n            img = make_gradient(n, n)\n            #= none:4 =#\n            mean_abs_error(floyd_steinberg(img, n, n, levels), img)\n        end\n    var\"##cellval#995\" = err_dither\n    return (PlutoIslands._plain_body)(var\"##cellval#995\")\nend",
         "golden": [
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer"
+          "\"0.3623699989702734\"",
+          "\"0.31524302955366273\"",
+          "\"0.08431709947986377\""
         ],
         "kind": "string",
         "mime": "text/plain",
         "reasons": [],
-        "rettype": "Union{}",
+        "rettype": "String",
         "samples": [
           [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
+            "48",
+            "2"
           ],
           [
-            "\"puiselect-13\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
+            "7",
+            "2"
           ],
           [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#ffffff\"]",
-            "0",
-            "true",
-            "200"
-          ],
-          [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "2",
-            "true",
-            "200"
+            "48",
+            "5"
           ]
         ]
       },
       {
-        "cell_id": "93e576e2-d5f0-44d9-8747-93ecefc51a8c",
+        "cell_id": "7d1ced8c-8a33-4429-b8fb-f06eb4bc7b1b",
         "extract_ok": true,
-        "fn_src": "function (algorithm::String, colors::Vector{String}, img_raw::Int64, to_gray::Bool, width::Int64)\n    maxsize = maximum(size(img_raw))\n    colorscheme = [colors...]\n    img = let\n            #= none:2 =#\n            ratio = width / maxsize\n            #= none:3 =#\n            img_sized = if maxsize == 1\n                    img_raw\n                else\n                    imresize(img_raw; ratio = ratio)\n                end\n            #= none:4 =#\n            img = if to_gray\n                    Gray.(img_sized)\n                else\n                    img_sized\n                end\n        end\n    var\"##cellval#1180\" = rgb_figure(dither(img, algorithm(), colorscheme); px = 400)\n    return (PlutoIslands._html_body)(var\"##cellval#1180\")\nend",
+        "fn_src": "function (imgsize::Int64, levels::Int64)\n    err_quantize = let\n            #= none:2 =#\n            n = imgsize\n            #= none:3 =#\n            img = make_gradient(n, n)\n            #= none:4 =#\n            mean_abs_error(quantize(img, levels), img)\n        end\n    var\"##cellval#996\" = err_quantize\n    return (PlutoIslands._plain_body)(var\"##cellval#996\")\nend",
         "golden": [
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer",
-          "ERR:ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer"
+          "\"0.2780832216763785\"",
+          "\"0.25976719897495776\"",
+          "\"0.0692280606653714\""
+        ],
+        "kind": "string",
+        "mime": "text/plain",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "48",
+            "2"
+          ],
+          [
+            "7",
+            "2"
+          ],
+          [
+            "48",
+            "5"
+          ]
+        ]
+      },
+      {
+        "cell_id": "a52bdeb6-35c4-4a70-bfa4-469912b30b27",
+        "extract_ok": true,
+        "fn_src": "function (imgsize::Int64, levels::Int64)\n    err_quantize = let\n            #= none:2 =#\n            n = imgsize\n            #= none:3 =#\n            img = make_gradient(n, n)\n            #= none:4 =#\n            mean_abs_error(quantize(img, levels), img)\n        end\n    return (\"<div class=\\\"markdown\\\"><p><strong>Mean abs. error — plain rounding:</strong> \" * string(err_quantize)) * \"</p>\\n</div>\"\nend",
+        "golden": [
+          "\"<div class=\\\"markdown\\\"><p><strong>Mean abs. error — plain rounding:</strong> 0.2780832216763785</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p><strong>Mean abs. error — plain rounding:</strong> 0.25976719897495776</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p><strong>Mean abs. error — plain rounding:</strong> 0.0692280606653714</p>\\n</div>\""
         ],
         "kind": "string",
         "mime": "text/html",
         "reasons": [],
-        "rettype": "Union{}",
+        "rettype": "String",
         "samples": [
           [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
+            "48",
+            "2"
           ],
           [
-            "\"puiselect-13\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "0",
-            "true",
-            "200"
+            "7",
+            "2"
           ],
           [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#ffffff\"]",
-            "0",
-            "true",
-            "200"
+            "48",
+            "5"
+          ]
+        ]
+      },
+      {
+        "cell_id": "ce25faed-be1c-4b74-9c3c-968638eb7813",
+        "extract_ok": true,
+        "fn_src": "function (imgsize::Int64, levels::Int64)\n    err_dither = let\n            #= none:2 =#\n            n = imgsize\n            #= none:3 =#\n            img = make_gradient(n, n)\n            #= none:4 =#\n            mean_abs_error(floyd_steinberg(img, n, n, levels), img)\n        end\n    return (\"<div class=\\\"markdown\\\"><p><strong>Mean abs. error — Floyd–Steinberg:</strong> \" * string(err_dither)) * \"</p>\\n<p>Per-pixel, dithering does <em>not</em> reduce the absolute error &#40;it still snaps to the same few levels&#41;. What it changes is <em>where</em> the error goes: it scatters it as high-frequency noise that the eye averages out, instead of leaving big visible bands. That&#39;s the whole trick. ✨</p>\\n</div>\"\nend",
+        "golden": [
+          "\"<div class=\\\"markdown\\\"><p><strong>Mean abs. error — Floyd–Steinberg:</strong> 0.3623699989702734</p>\\n<p>Per-pixel, dithering does <em>not</em> reduce the absolute error &#40;it still snaps to the same few levels&#41;. What it changes is <em>where</em> the error goes: it scatters it as high-frequency noise that the eye averages out, instead of leaving big visible bands. That&#39;s the whole trick. ✨</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p><strong>Mean abs. error — Floyd–Steinberg:</strong> 0.31524302955366273</p>\\n<p>Per-pixel, dithering does <em>not</em> reduce the absolute error &#40;it still snaps to the same few levels&#41;. What it changes is <em>where</em> the error goes: it scatters it as high-frequency noise that the eye averages out, instead of leaving big visible bands. That&#39;s the whole trick. ✨</p>\\n</div>\"",
+          "\"<div class=\\\"markdown\\\"><p><strong>Mean abs. error — Floyd–Steinberg:</strong> 0.08431709947986377</p>\\n<p>Per-pixel, dithering does <em>not</em> reduce the absolute error &#40;it still snaps to the same few levels&#41;. What it changes is <em>where</em> the error goes: it scatters it as high-frequency noise that the eye averages out, instead of leaving big visible bands. That&#39;s the whole trick. ✨</p>\\n</div>\""
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "48",
+            "2"
           ],
           [
-            "\"puiselect-1\"",
-            "[\"#264653\", \"#2a9d8f\", \"#e9c46a\", \"#f4a261\", \"#e76f51\"]",
-            "2",
-            "true",
-            "200"
+            "7",
+            "2"
+          ],
+          [
+            "48",
+            "5"
           ]
         ]
       }
@@ -5980,14 +4766,13 @@
     "group_reasons": [],
     "notebook": "dither.jl",
     "preamble": [
-      "using PlutoUI",
-      "using DitherPunk",
-      "using ImageIO, Colors, ImageTransformations",
-      "using TestImages",
-      "using WasmMakie",
-      "function _wasmmakie_figure(m::AbstractMatrix; px::Int = 256)\n    #= none:5 =#\n    #= none:6 =#\n    step = max(ceil(Int, size(m, 1) / px), ceil(Int, size(m, 2) / px))\n    #= none:7 =#\n    mm = m[1:step:end, 1:step:end]\n    #= none:8 =#\n    (nrows, ncols) = size(mm)\n    #= none:9 =#\n    pixels = Vector{NTuple{4, Float64}}(undef, nrows * ncols)\n    #= none:10 =#\n    for i = 1:nrows, j = 1:ncols\n        #= none:11 =#\n        c = convert(RGBA{Float64}, mm[i, j])\n        #= none:12 =#\n        pixels[j + (nrows - i) * ncols] = (Float64(red(c)), Float64(green(c)), Float64(blue(c)), Float64(alpha(c)))\n        #= none:14 =#\n    end\n    #= none:15 =#\n    w = 520.0\n    #= none:16 =#\n    h = max(48.0, round((w * nrows) / ncols))\n    #= none:17 =#\n    fig = Figure(size = (w, h))\n    #= none:18 =#\n    ax = Axis(fig[1, 1])\n    #= none:19 =#\n    hidedecorations!(ax)\n    #= none:20 =#\n    hidespines!(ax)\n    #= none:21 =#\n    image!(ax, (0.0, Float64(ncols)), (0.0, Float64(nrows)), pixels, Int64(ncols), Int64(nrows); interpolate = false)\n    #= none:24 =#\n    HTML(WasmMakie.html_snippet(fig; fonts = false))\nend",
-      "gray_figure(m; px::Int = 256) = begin\n        #= none:26 =#\n        _wasmmakie_figure(Gray.(m); px = px)\n    end",
-      "rgb_figure(m; px::Int = 256) = begin\n        #= none:27 =#\n        _wasmmakie_figure(m; px = px)\n    end"
+      "function snap(v::Float64, levels::Int64)\n    #= none:2 =#\n    #= none:3 =#\n    steps = levels - 1\n    #= none:4 =#\n    q = round(v * steps) / steps\n    #= none:5 =#\n    if q < 0.0\n        #= none:6 =#\n        q = 0.0\n    elseif #= none:7 =# q > 1.0\n        #= none:8 =#\n        q = 1.0\n    end\n    #= none:10 =#\n    return q\nend",
+      "function floyd_steinberg(img::Vector{Float64}, nr::Int64, nc::Int64, levels::Int64)\n    #= none:5 =#\n    #= none:7 =#\n    buf = Vector{Float64}(undef, nr * nc)\n    #= none:8 =#\n    for k = 1:length(img)\n        #= none:9 =#\n        buf[k] = img[k]\n        #= none:10 =#\n    end\n    #= none:11 =#\n    out = Vector{Float64}(undef, nr * nc)\n    #= none:12 =#\n    for i = 1:nr\n        #= none:13 =#\n        for j = 1:nc\n            #= none:14 =#\n            idx = i + (j - 1) * nr\n            #= none:15 =#\n            old = buf[idx]\n            #= none:16 =#\n            new = snap(old, levels)\n            #= none:17 =#\n            out[idx] = new\n            #= none:18 =#\n            err = old - new\n            #= none:20 =#\n            if j < nc\n                #= none:21 =#\n                r = i + j * nr\n                #= none:22 =#\n                buf[r] = buf[r] + (err * 7.0) / 16.0\n            end\n            #= none:25 =#\n            if i < nr && j > 1\n                #= none:26 =#\n                bl = (i + 1) + (j - 2) * nr\n                #= none:27 =#\n                buf[bl] = buf[bl] + (err * 3.0) / 16.0\n            end\n            #= none:30 =#\n            if i < nr\n                #= none:31 =#\n                b = (i + 1) + (j - 1) * nr\n                #= none:32 =#\n                buf[b] = buf[b] + (err * 5.0) / 16.0\n            end\n            #= none:35 =#\n            if i < nr && j < nc\n                #= none:36 =#\n                br = (i + 1) + j * nr\n                #= none:37 =#\n                buf[br] = buf[br] + (err * 1.0) / 16.0\n            end\n            #= none:39 =#\n        end\n        #= none:40 =#\n    end\n    #= none:41 =#\n    return out\nend",
+      "function gray_figure(img::Vector{Float64}, nr::Int64, nc::Int64; px::Int64 = 320)\n    #= none:7 =#\n    #= none:10 =#\n    pix = Vector{NTuple{4, Float64}}(undef, nr * nc)\n    #= none:11 =#\n    for i = 1:nr\n        #= none:12 =#\n        for j = 1:nc\n            #= none:13 =#\n            v = img[i + (j - 1) * nr]\n            #= none:14 =#\n            pix[j + (nr - i) * nc] = (v, v, v, 1.0)\n            #= none:15 =#\n        end\n        #= none:16 =#\n    end\n    #= none:17 =#\n    fig = Figure(size = (px, px))\n    #= none:18 =#\n    ax = Axis(fig[1, 1])\n    #= none:19 =#\n    hidedecorations!(ax)\n    #= none:20 =#\n    hidespines!(ax)\n    #= none:21 =#\n    image!(ax, (0.0, Float64(nc)), (0.0, Float64(nr)), pix, Int64(nc), Int64(nr); interpolate = false)\n    #= none:23 =#\n    return fig\nend",
+      "function make_gradient(nr::Int64, nc::Int64)\n    #= none:2 =#\n    #= none:3 =#\n    img = Vector{Float64}(undef, nr * nc)\n    #= none:4 =#\n    cx = (nc + 1) / 2.0\n    #= none:5 =#\n    cy = (nr + 1) / 2.0\n    #= none:6 =#\n    rad = (0.5 * sqrt(Float64(nr * nr + nc * nc))) / 2.0\n    #= none:7 =#\n    for j = 1:nc\n        #= none:8 =#\n        for i = 1:nr\n            #= none:9 =#\n            ramp = ((i - 1) + (j - 1)) / ((nr + nc) - 2)\n            #= none:10 =#\n            dx = (Float64(j) - cx) / rad\n            #= none:11 =#\n            dy = (Float64(i) - cy) / rad\n            #= none:12 =#\n            bump = 0.35 * exp(-((dx * dx + dy * dy)))\n            #= none:13 =#\n            v = ramp + bump\n            #= none:14 =#\n            if v < 0.0\n                #= none:15 =#\n                v = 0.0\n            elseif #= none:16 =# v > 1.0\n                #= none:17 =#\n                v = 1.0\n            end\n            #= none:19 =#\n            img[i + (j - 1) * nr] = v\n            #= none:20 =#\n        end\n        #= none:21 =#\n    end\n    #= none:22 =#\n    return img\nend",
+      "using PlutoUI, WasmMakie",
+      "function quantize(img::Vector{Float64}, levels::Int64)\n    #= none:2 =#\n    #= none:3 =#\n    out = Vector{Float64}(undef, length(img))\n    #= none:4 =#\n    for k = 1:length(img)\n        #= none:5 =#\n        out[k] = snap(img[k], levels)\n        #= none:6 =#\n    end\n    #= none:7 =#\n    return out\nend",
+      "function mean_abs_error(a::Vector{Float64}, b::Vector{Float64})\n    #= none:2 =#\n    #= none:3 =#\n    s = 0.0\n    #= none:4 =#\n    for k = 1:length(a)\n        #= none:5 =#\n        d = a[k] - b[k]\n        #= none:6 =#\n        if d < 0.0\n            #= none:7 =#\n            d = -d\n        end\n        #= none:9 =#\n        s = s + d\n        #= none:10 =#\n    end\n    #= none:11 =#\n    return s / length(a)\nend"
     ]
   },
   {
@@ -6001,9 +4786,9 @@
       {
         "cell_id": "70402e12-22c2-47fd-99be-aa6cd15ce2c3",
         "extract_ok": true,
-        "fn_src": "function (GO_gogh::Int64,)\n    starry_night = turtle_drawing_fast(background = \"#000088\") do t\n            #= none:2 =#\n            rng = ArtRNG(GO_gogh + 7)\n            #= none:4 =#\n            star_count = 100\n            #= none:6 =#\n            color!(t, \"yellow\")\n            #= none:8 =#\n            for i = 1:star_count\n                #= none:10 =#\n                penup!(t)\n                #= none:11 =#\n                random_angle = nextfloat!(rng) * 360\n                #= none:12 =#\n                right!(t, random_angle)\n                #= none:13 =#\n                random_distance = rand_between!(rng, 1.0, 8.0)\n                #= none:14 =#\n                forward!(t, random_distance)\n                #= none:17 =#\n                pendown!(t)\n                #= none:19 =#\n                draw_star(t, 5, 1)\n                #= none:20 =#\n            end\n        end\n    var\"##cellval#1194\" = starry_night\n    return (PlutoIslands._html_body)(var\"##cellval#1194\")\nend",
+        "fn_src": "function (GO_gogh::Int64,)\n    starry_night = turtle_drawing_fast(background = \"#000088\") do t\n            #= none:2 =#\n            rng = ArtRNG(GO_gogh + 7)\n            #= none:4 =#\n            star_count = 100\n            #= none:6 =#\n            color!(t, \"yellow\")\n            #= none:8 =#\n            for i = 1:star_count\n                #= none:10 =#\n                penup!(t)\n                #= none:11 =#\n                random_angle = nextfloat!(rng) * 360\n                #= none:12 =#\n                right!(t, random_angle)\n                #= none:13 =#\n                random_distance = rand_between!(rng, 1.0, 8.0)\n                #= none:14 =#\n                forward!(t, random_distance)\n                #= none:17 =#\n                pendown!(t)\n                #= none:19 =#\n                draw_star(t, 5, 1)\n                #= none:20 =#\n            end\n        end\n    var\"##cellval#1012\" = starry_night\n    return (PlutoIslands._html_body)(var\"##cellval#1012\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1198\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1016\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -6053,9 +4838,9 @@
       {
         "cell_id": "d400d8d6-de2c-4886-86b9-ffd9e5f4e073",
         "extract_ok": true,
-        "fn_src": "function (GO_mondriaan::Int64,)\n    mondriaan = turtle_drawing_fast() do t\n            #= none:4 =#\n            rng = ArtRNG(GO_mondriaan + 7)\n            #= none:5 =#\n            size = 30\n            #= none:8 =#\n            penup!(t)\n            #= none:9 =#\n            forward!(t, size / 2)\n            #= none:10 =#\n            left!(t, 90)\n            #= none:11 =#\n            forward!(t, size / 2)\n            #= none:12 =#\n            right!(t, 180)\n            #= none:15 =#\n            draw_mondriaan(rng, t, size, size)\n            #= none:18 =#\n            color!(t, \"white\")\n            #= none:19 =#\n            pendown!(t)\n            #= none:20 =#\n            for i = 1:4\n                #= none:21 =#\n                forward!(t, size)\n                #= none:22 =#\n                right!(t, 90)\n                #= none:23 =#\n            end\n        end\n    var\"##cellval#1195\" = mondriaan\n    return (PlutoIslands._html_body)(var\"##cellval#1195\")\nend",
+        "fn_src": "function (GO_mondriaan::Int64,)\n    mondriaan = turtle_drawing_fast() do t\n            #= none:4 =#\n            rng = ArtRNG(GO_mondriaan + 7)\n            #= none:5 =#\n            size = 30.0\n            #= none:8 =#\n            penup!(t)\n            #= none:9 =#\n            forward!(t, size / 2)\n            #= none:10 =#\n            left!(t, 90)\n            #= none:11 =#\n            forward!(t, size / 2)\n            #= none:12 =#\n            right!(t, 180)\n            #= none:15 =#\n            draw_mondriaan(rng, t, size, size)\n            #= none:18 =#\n            color!(t, \"white\")\n            #= none:19 =#\n            pendown!(t)\n            #= none:20 =#\n            for i = 1:4\n                #= none:21 =#\n                forward!(t, size)\n                #= none:22 =#\n                right!(t, 90)\n                #= none:23 =#\n            end\n        end\n    var\"##cellval#1013\" = mondriaan\n    return (PlutoIslands._html_body)(var\"##cellval#1013\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1199\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1017\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -6090,7 +4875,7 @@
       "function nextfloat!(r::ArtRNG)\n    #= none:9 =#\n    #= none:10 =#\n    s = r.state\n    #= none:11 =#\n    s ⊻= s << 13\n    #= none:12 =#\n    s ⊻= s >> 7\n    #= none:13 =#\n    s ⊻= s << 17\n    #= none:14 =#\n    r.state = s\n    #= none:15 =#\n    Float64(s >> 11) / 9.007199254740992e15\nend",
       "rand_between!(r::ArtRNG, lo, hi) = begin\n        #= none:17 =#\n        Float64(lo) + nextfloat!(r) * (Float64(hi) - Float64(lo))\n    end",
       "rand_choice!(r::ArtRNG, xs) = begin\n        #= none:18 =#\n        xs[1 + Int(floor(nextfloat!(r) * length(xs)))]\n    end",
-      "function draw_mondriaan(rng, turtle, width, height)\n    #= none:1 =#\n    #= none:3 =#\n    p = if width * height < 8\n            #= none:4 =#\n            0\n        else\n            #= none:6 =#\n            ((width * height) / 900) ^ 0.5\n        end\n    #= none:9 =#\n    if nextfloat!(rng) < p\n        #= none:12 =#\n        split = rand_between!(rng, width * 0.1, width * 0.9)\n        #= none:15 =#\n        forward!(turtle, split)\n        #= none:16 =#\n        right!(turtle, 90)\n        #= none:17 =#\n        color!(turtle, \"black\")\n        #= none:18 =#\n        pendown!(turtle)\n        #= none:19 =#\n        forward!(turtle, height)\n        #= none:20 =#\n        penup!(turtle)\n        #= none:23 =#\n        right!(turtle, 90)\n        #= none:24 =#\n        forward!(turtle, split)\n        #= none:25 =#\n        right!(turtle, 90)\n        #= none:26 =#\n        draw_mondriaan(rng, turtle, height, split)\n        #= none:29 =#\n        forward!(turtle, height)\n        #= none:30 =#\n        right!(turtle, 90)\n        #= none:31 =#\n        forward!(turtle, width)\n        #= none:32 =#\n        right!(turtle, 90)\n        #= none:33 =#\n        draw_mondriaan(rng, turtle, height, width - split)\n        #= none:36 =#\n        right!(turtle, 90)\n        #= none:37 =#\n        forward!(turtle, width)\n        #= none:38 =#\n        right!(turtle, 180)\n    else\n        #= none:42 =#\n        square_color = rand_choice!(rng, (\"white\", \"white\", \"white\", \"red\", \"yellow\", \"blue\"))\n        #= none:43 =#\n        color!(turtle, square_color)\n        #= none:44 =#\n        stripe_xs = Float64[]\n        #= none:45 =#\n        let sx = 0.4\n            #= none:46 =#\n            while sx <= width - 0.4\n                #= none:47 =#\n                push!(stripe_xs, sx)\n                #= none:48 =#\n                sx += 0.4\n                #= none:49 =#\n            end\n        end\n        #= none:51 =#\n        (isempty(stripe_xs) || stripe_xs[end] != width - 0.4) && push!(stripe_xs, width - 0.4)\n        #= none:52 =#\n        for x = stripe_xs\n            #= none:53 =#\n            forward!(turtle, x)\n            #= none:54 =#\n            right!(turtle, 90)\n            #= none:55 =#\n            forward!(turtle, 0.2)\n            #= none:56 =#\n            pendown!(turtle)\n            #= none:57 =#\n            forward!(turtle, height - 0.4)\n            #= none:58 =#\n            penup!(turtle)\n            #= none:59 =#\n            right!(turtle, 180)\n            #= none:60 =#\n            forward!(turtle, height - 0.2)\n            #= none:61 =#\n            right!(turtle, 90)\n            #= none:62 =#\n            backward!(turtle, x)\n            #= none:63 =#\n        end\n    end\nend",
+      "function draw_mondriaan(rng::ArtRNG, turtle::Turtle, width::Float64, height::Float64)\n    #= none:1 =#\n    #= none:3 =#\n    p = if width * height < 8.0\n            #= none:4 =#\n            0.0\n        else\n            #= none:6 =#\n            ((width * height) / 900.0) ^ 0.5\n        end\n    #= none:9 =#\n    if nextfloat!(rng) < p\n        #= none:12 =#\n        split = rand_between!(rng, width * 0.1, width * 0.9)\n        #= none:15 =#\n        forward!(turtle, split)\n        #= none:16 =#\n        right!(turtle, 90)\n        #= none:17 =#\n        color!(turtle, \"black\")\n        #= none:18 =#\n        pendown!(turtle)\n        #= none:19 =#\n        forward!(turtle, height)\n        #= none:20 =#\n        penup!(turtle)\n        #= none:23 =#\n        right!(turtle, 90)\n        #= none:24 =#\n        forward!(turtle, split)\n        #= none:25 =#\n        right!(turtle, 90)\n        #= none:26 =#\n        draw_mondriaan(rng, turtle, height, split)\n        #= none:29 =#\n        forward!(turtle, height)\n        #= none:30 =#\n        right!(turtle, 90)\n        #= none:31 =#\n        forward!(turtle, width)\n        #= none:32 =#\n        right!(turtle, 90)\n        #= none:33 =#\n        draw_mondriaan(rng, turtle, height, width - split)\n        #= none:36 =#\n        right!(turtle, 90)\n        #= none:37 =#\n        forward!(turtle, width)\n        #= none:38 =#\n        right!(turtle, 180)\n    else\n        #= none:42 =#\n        square_color = rand_choice!(rng, (\"white\", \"white\", \"white\", \"red\", \"yellow\", \"blue\"))\n        #= none:43 =#\n        color!(turtle, square_color)\n        #= none:44 =#\n        stripe_xs = Float64[]\n        #= none:45 =#\n        let sx = 0.4\n            #= none:46 =#\n            while sx <= width - 0.4\n                #= none:47 =#\n                push!(stripe_xs, sx)\n                #= none:48 =#\n                sx += 0.4\n                #= none:49 =#\n            end\n        end\n        #= none:51 =#\n        (isempty(stripe_xs) || stripe_xs[end] != width - 0.4) && push!(stripe_xs, width - 0.4)\n        #= none:52 =#\n        for x = stripe_xs\n            #= none:53 =#\n            forward!(turtle, x)\n            #= none:54 =#\n            right!(turtle, 90)\n            #= none:55 =#\n            forward!(turtle, 0.2)\n            #= none:56 =#\n            pendown!(turtle)\n            #= none:57 =#\n            forward!(turtle, height - 0.4)\n            #= none:58 =#\n            penup!(turtle)\n            #= none:59 =#\n            right!(turtle, 180)\n            #= none:60 =#\n            forward!(turtle, height - 0.2)\n            #= none:61 =#\n            right!(turtle, 90)\n            #= none:62 =#\n            backward!(turtle, x)\n            #= none:63 =#\n        end\n    end\nend",
       "using WasmMakie, PlutoUI"
     ]
   },
@@ -6105,12 +4890,12 @@
       {
         "cell_id": "c668c791-9c3b-4eed-babe-9a484a88b68e",
         "extract_ok": true,
-        "fn_src": "function (angle::Int64,)\n    var\"##cellval#1196\" = turtle_drawing() do t\n            #= none:3 =#\n            let i = 0.0\n                #= none:4 =#\n                while i <= 10.0\n                    #= none:5 =#\n                    right!(t, angle)\n                    #= none:6 =#\n                    forward!(t, i)\n                    #= none:7 =#\n                    i += 0.1\n                    #= none:8 =#\n                end\n            end\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#1196\")\nend",
+        "fn_src": "function (angle::Int64,)\n    var\"##cellval#1014\" = turtle_drawing() do t\n            #= none:3 =#\n            let i = 0.0\n                #= none:4 =#\n                while i <= 10.0\n                    #= none:5 =#\n                    right!(t, angle)\n                    #= none:6 =#\n                    forward!(t, i)\n                    #= none:7 =#\n                    i += 0.1\n                    #= none:8 =#\n                end\n            end\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#1014\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1200\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1200\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1200\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1200\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1018\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1018\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1018\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1018\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -6167,12 +4952,12 @@
       {
         "cell_id": "83cd894b-2be0-48c7-b5e7-8db7ed96c13f",
         "extract_ok": true,
-        "fn_src": "function (fractal_angle::Int64, fractal_base::Float64, fractal_tilt::Int64)\n    fractal = turtle_drawing_fast() do t\n            #= none:2 =#\n            penup!(t)\n            #= none:3 =#\n            backward!(t, 15)\n            #= none:4 =#\n            pendown!(t)\n            #= none:5 =#\n            lindenmayer(t, 0, fractal_angle, fractal_tilt, fractal_base)\n        end\n    var\"##cellval#1197\" = fractal\n    return (PlutoIslands._html_body)(var\"##cellval#1197\")\nend",
+        "fn_src": "function (fractal_angle::Int64, fractal_base::Float64, fractal_tilt::Int64)\n    fractal = turtle_drawing_fast() do t\n            #= none:2 =#\n            penup!(t)\n            #= none:3 =#\n            backward!(t, 15)\n            #= none:4 =#\n            pendown!(t)\n            #= none:5 =#\n            lindenmayer(t, 0, fractal_angle, fractal_tilt, fractal_base)\n        end\n    var\"##cellval#1015\" = fractal\n    return (PlutoIslands._html_body)(var\"##cellval#1015\")\nend",
         "golden": [
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1201\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1201\"`\nSuggestion: check for spelling errors or missing imports.",
-          "ERR:MethodError: no method matching (::Main.var\"##hv#1201\".var\"#5#6\")(::Int64, ::Int64, ::Int64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1201\".var\"#5#6\")(::Int64, !Matched::Float64, ::Int64)\n   @ Main.var\"##hv#1201\" none:0\n",
-          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1201\"`\nSuggestion: check for spelling errors or missing imports."
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1019\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1019\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1019\".var\"#5#6\")(::Int64, ::Int64, ::Int64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1019\".var\"#5#6\")(::Int64, !Matched::Float64, ::Int64)\n   @ Main.var\"##hv#1019\" none:0\n",
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1019\"`\nSuggestion: check for spelling errors or missing imports."
         ],
         "kind": "string",
         "mime": "text/html",
@@ -6225,93 +5010,153 @@
   },
   {
     "argtypes": [
-      "String",
-      "String",
-      "String",
       "Float64",
-      "String"
+      "Float64",
+      "Float64",
+      "Float64",
+      "Float64"
     ],
     "bonds": [
-      "Acid",
-      "c0_Acid_string",
-      "c0_Base_string",
+      "c0_Acid",
+      "c0_Base",
+      "pKa",
       "pointX",
-      "v0_Acid_string"
+      "v0_Acid"
     ],
     "cells": [
       {
-        "cell_id": "41bed3bd-75f9-4b1a-9ea8-786b338b7503",
-        "eval_err": "LoadError: UndefVarError: `@L_str` not defined in `Main.var\"##hv#1349\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (Acid::String, c0_Acid_string::String, c0_Base_string::String, pointX::Float64, v0_Acid_string::String)\n    latexacids = [L\"\\mathrm{HClO_4}\", L\"\\mathrm{HCl}\", L\"\\mathrm{HSO_4^-}\", L\"\\mathrm{HNO_{2}}\", L\"\\mathrm{HF}\", L\"\\mathrm{HCOOH}\", L\"\\mathrm{CH_{3}COOH}\"]\n    stringacids = [\"HClO4\", \"HCl\", \"HSO4-\", \"HNO2\", \"HF\", \"HCOOH\", \"CH3COOH\"]\n    acidmap = Dict((s => l for (s, l) = zip(stringacids, latexacids)))\n    df = DataFrame(Dict(\"Acid\" => latexacids, \"pKa\" => [-10.0, -6.0, 1.92, 3.15, 3.17, 3.75, 4.76]))\n    pKa = (filter((row->(#= none:3 =#\n                    row.:(\"Acid\") == acidmap[Acid])), df)).:(\"pKa\")[1]\n    Ka = 10 ^ -pKa\n    pKb = 14 - pKa\n    Kb = 10 ^ -pKb\n    c0_Acid = parse(Float64, c0_Acid_string)\n    v0_Acid = parse(Float64, v0_Acid_string)\n    c0_Base = parse(Float64, c0_Base_string)\n    v_Base_end = ((v0_Acid * c0_Acid) / c0_Base) * 2\n    v_Base = convert(Vector{Float64}, Float64[])\n    let t = 0.0\n        #= none:13 =#\n        while t <= v_Base_end + 0.0025\n            #= none:14 =#\n            push!(v_Base, t)\n            #= none:15 =#\n            t += 0.005\n            #= none:16 =#\n        end\n    end\n    if pKa <= 0\n        #= none:19 =#\n        c0_H⁺ = Float64(c0_Acid * v0_Acid)\n        #= none:20 =#\n        c0_OH⁻ = Float64(10 ^ -7)\n    else\n        #= none:22 =#\n        c0_H⁺ = -Ka / 2 + sqrt(Ka ^ 2 / 4 + Ka * c0_Acid)\n        #= none:23 =#\n        c0_OH⁻ = -Kb / 2 + sqrt(Kb ^ 2 / 4 + Kb * c0_Acid)\n    end\n    var\"##cellval#1342\" = nothing\n    return (PlutoIslands._plain_body)(var\"##cellval#1342\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "831198d1-d22c-42b5-a198-3bd34139eb0e",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "text/html",
-        "reasons": [
-          "dependent cell re-defines a bond (bond-defines-bond) — unsupported in v0"
-        ]
-      },
-      {
-        "cell_id": "af04638c-2615-4195-a45e-d6d85af6d6cd",
-        "eval_err": "LoadError: UndefVarError: `@L_str` not defined in `Main.var\"##hv#1349\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (Acid::String, c0_Acid_string::String, c0_Base_string::String, pointX::Float64, v0_Acid_string::String)\n    latexacids = [L\"\\mathrm{HClO_4}\", L\"\\mathrm{HCl}\", L\"\\mathrm{HSO_4^-}\", L\"\\mathrm{HNO_{2}}\", L\"\\mathrm{HF}\", L\"\\mathrm{HCOOH}\", L\"\\mathrm{CH_{3}COOH}\"]\n    stringacids = [\"HClO4\", \"HCl\", \"HSO4-\", \"HNO2\", \"HF\", \"HCOOH\", \"CH3COOH\"]\n    acidmap = Dict((s => l for (s, l) = zip(stringacids, latexacids)))\n    df = DataFrame(Dict(\"Acid\" => latexacids, \"pKa\" => [-10.0, -6.0, 1.92, 3.15, 3.17, 3.75, 4.76]))\n    pKa = (filter((row->(#= none:3 =#\n                    row.:(\"Acid\") == acidmap[Acid])), df)).:(\"pKa\")[1]\n    Ka = 10 ^ -pKa\n    pKb = 14 - pKa\n    Kb = 10 ^ -pKb\n    c0_Acid = parse(Float64, c0_Acid_string)\n    v0_Acid = parse(Float64, v0_Acid_string)\n    c0_Base = parse(Float64, c0_Base_string)\n    v_Base_end = ((v0_Acid * c0_Acid) / c0_Base) * 2\n    v_Base = convert(Vector{Float64}, Float64[])\n    let t = 0.0\n        #= none:13 =#\n        while t <= v_Base_end + 0.0025\n            #= none:14 =#\n            push!(v_Base, t)\n            #= none:15 =#\n            t += 0.005\n            #= none:16 =#\n        end\n    end\n    if pKa <= 0\n        #= none:19 =#\n        c0_H⁺ = Float64(c0_Acid * v0_Acid)\n        #= none:20 =#\n        c0_OH⁻ = Float64(10 ^ -7)\n    else\n        #= none:22 =#\n        c0_H⁺ = -Ka / 2 + sqrt(Ka ^ 2 / 4 + Ka * c0_Acid)\n        #= none:23 =#\n        c0_OH⁻ = -Kb / 2 + sqrt(Kb ^ 2 / 4 + Kb * c0_Acid)\n    end\n    nothing\n    var\"##cellval#1343\" = nothing\n    return (PlutoIslands._plain_body)(var\"##cellval#1343\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
         "cell_id": "02c0320c-7c56-4fe5-8f8c-9ab0f733b28e",
-        "eval_err": "LoadError: UndefVarError: `@L_str` not defined in `Main.var\"##hv#1349\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
         "extract_ok": true,
-        "fn_src": "function (Acid::String, c0_Acid_string::String, c0_Base_string::String, pointX::Float64, v0_Acid_string::String)\n    latexacids = [L\"\\mathrm{HClO_4}\", L\"\\mathrm{HCl}\", L\"\\mathrm{HSO_4^-}\", L\"\\mathrm{HNO_{2}}\", L\"\\mathrm{HF}\", L\"\\mathrm{HCOOH}\", L\"\\mathrm{CH_{3}COOH}\"]\n    stringacids = [\"HClO4\", \"HCl\", \"HSO4-\", \"HNO2\", \"HF\", \"HCOOH\", \"CH3COOH\"]\n    acidmap = Dict((s => l for (s, l) = zip(stringacids, latexacids)))\n    df = DataFrame(Dict(\"Acid\" => latexacids, \"pKa\" => [-10.0, -6.0, 1.92, 3.15, 3.17, 3.75, 4.76]))\n    pKa = (filter((row->(#= none:3 =#\n                    row.:(\"Acid\") == acidmap[Acid])), df)).:(\"pKa\")[1]\n    Ka = 10 ^ -pKa\n    pKb = 14 - pKa\n    Kb = 10 ^ -pKb\n    c0_Acid = parse(Float64, c0_Acid_string)\n    v0_Acid = parse(Float64, v0_Acid_string)\n    c0_Base = parse(Float64, c0_Base_string)\n    v_Base_end = ((v0_Acid * c0_Acid) / c0_Base) * 2\n    v_Base = convert(Vector{Float64}, Float64[])\n    let t = 0.0\n        #= none:13 =#\n        while t <= v_Base_end + 0.0025\n            #= none:14 =#\n            push!(v_Base, t)\n            #= none:15 =#\n            t += 0.005\n            #= none:16 =#\n        end\n    end\n    if pKa <= 0\n        #= none:19 =#\n        c0_H⁺ = Float64(c0_Acid * v0_Acid)\n        #= none:20 =#\n        c0_OH⁻ = Float64(10 ^ -7)\n    else\n        #= none:22 =#\n        c0_H⁺ = -Ka / 2 + sqrt(Ka ^ 2 / 4 + Ka * c0_Acid)\n        #= none:23 =#\n        c0_OH⁻ = -Kb / 2 + sqrt(Kb ^ 2 / 4 + Kb * c0_Acid)\n    end\n    nothing\n    nothing\n    var\"##cellval#1344\" = if pKa < 7.0\n            #= none:3 =#\n            pH_total = map(calc_pH, v_Base)\n            #= none:5 =#\n            pH_Value = round(calc_pH(pointX), sigdigits = 3)\n            #= none:7 =#\n            fig_titr = Figure(size = (620, 420))\n            #= none:8 =#\n            ax_titr = Axis(fig_titr[1, 1]; title = \"Titration curve of \" * c0_Acid_string * \" M \" * Acid * \" against \" * c0_Base_string * \" M NaOH\", xlabel = \"Added volume of titrant / [mL]\", ylabel = \"pH-Value\")\n            #= none:12 =#\n            ax_titr.xmin = -1.0\n            #= none:13 =#\n            ax_titr.xmax = Float64(v_Base_end + 2)\n            #= none:14 =#\n            ax_titr.ymin = 0.0\n            #= none:15 =#\n            ax_titr.ymax = 14.0\n            #= none:17 =#\n            lines!(ax_titr, v_Base, pH_total; linewidth = 2, label = \"titration curve\")\n            #= none:18 =#\n            scatter!(ax_titr, [Float64(pointX)], [Float64(calc_pH(pointX))]; label = \"Current point of titration\")\n            #= none:20 =#\n            if pKa <= 1.74\n                #= none:21 =#\n                let ev = 0.0\n                    #= none:22 =#\n                    for i = v_Base\n                        #= none:23 =#\n                        if i * c0_Base == v0_Acid * c0_Acid\n                            #= none:24 =#\n                            ev = i\n                        end\n                        #= none:26 =#\n                    end\n                    #= none:27 =#\n                    scatter!(ax_titr, [ev], [calc_pH(ev)]; label = \"Equivalence point\")\n                end\n            else\n                #= none:30 =#\n                let hev = 0.0, ev = 0.0\n                    #= none:31 =#\n                    for i = v_Base\n                        #= none:32 =#\n                        if round((c0_Acid * v0_Acid) / (c0_H⁺ * v0_Acid + c0_Base * i), digits = 3) == 2.0\n                            #= none:33 =#\n                            hev = i\n                        elseif #= none:34 =# round((c0_Acid - c0_H⁺) * v0_Acid, digits = 3) == round(c0_Base * i, digits = 3)\n                            #= none:35 =#\n                            ev = i\n                        end\n                        #= none:37 =#\n                    end\n                    #= none:38 =#\n                    scatter!(ax_titr, [ev], [calc_pH(ev)]; label = \"Equivalence point\")\n                    #= none:39 =#\n                    scatter!(ax_titr, [hev], [calc_pH(hev)]; label = \"Half equivalence point\")\n                end\n            end\n            #= none:42 =#\n            axislegend(ax_titr; position = :rb)\n            #= none:43 =#\n            fig_titr\n        else\n            #= none:45 =#\n            println(\"The given pKa-value does not match a strong or weak acid.\")\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#1344\")\nend",
+        "fn_src": "function (c0_Acid::Float64, c0_Base::Float64, pKa::Float64, pointX::Float64, v0_Acid::Float64)\n    var\"##cellval#1068\" = let\n            #= none:3 =#\n            v_end = max(2.0 * equivalence_volume(pKa, c0_Acid, v0_Acid, c0_Base), 1.0)\n            #= none:6 =#\n            xs = Float64[]\n            #= none:7 =#\n            ys = Float64[]\n            #= none:8 =#\n            steps = 400\n            #= none:9 =#\n            k = 0\n            #= none:10 =#\n            while k <= steps\n                #= none:11 =#\n                v = (v_end * k) / steps\n                #= none:12 =#\n                push!(xs, v)\n                #= none:13 =#\n                push!(ys, calc_pH(v, pKa, c0_Acid, v0_Acid, c0_Base))\n                #= none:14 =#\n                k += 1\n                #= none:15 =#\n            end\n            #= none:17 =#\n            ev = equivalence_volume(pKa, c0_Acid, v0_Acid, c0_Base)\n            #= none:19 =#\n            fig = Figure(size = (560, 380))\n            #= none:20 =#\n            ax = Axis(fig[1, 1]; title = \"Titration curve against NaOH\", xlabel = \"Added volume of titrant V(NaOH) / mL\", ylabel = \"pH value\")\n            #= none:24 =#\n            ax.xmin = 0.0\n            #= none:25 =#\n            ax.xmax = v_end\n            #= none:26 =#\n            ax.ymin = 0.0\n            #= none:27 =#\n            ax.ymax = 14.0\n            #= none:29 =#\n            lines!(ax, xs, ys; linewidth = 2.0, label = \"titration curve\")\n            #= none:30 =#\n            scatter!(ax, [pointX], [calc_pH(pointX, pKa, c0_Acid, v0_Acid, c0_Base)]; color = :green, markersize = 12.0, label = \"current point\")\n            #= none:32 =#\n            scatter!(ax, [ev], [calc_pH(ev, pKa, c0_Acid, v0_Acid, c0_Base)]; color = :red, markersize = 12.0, label = \"equivalence point\")\n            #= none:34 =#\n            axislegend(ax; position = :rb)\n            #= none:35 =#\n            fig\n        end\n    return (PlutoIslands._html_body)(var\"##cellval#1068\")\nend",
+        "golden": [
+          "ERR:UndefVarError: `Figure` not defined in `Main.var\"##hv#1071\"`\nSuggestion: check for spelling errors or missing imports.",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#2#3\")(::Int64, ::Float64, ::Float64, ::Float64, ::Float64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#2#3\")(!Matched::Float64, ::Float64, ::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#2#3\")(::Float64, ::Int64, ::Float64, ::Float64, ::Float64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#2#3\")(::Float64, !Matched::Float64, ::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#2#3\")(::Float64, ::Float64, ::Int64, ::Float64, ::Float64)\nThe function `#2` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#2#3\")(::Float64, ::Float64, !Matched::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n"
+        ],
         "kind": "string",
         "mime": "text/html",
-        "reasons": []
-      },
-      {
-        "cell_id": "9dee0462-b5af-4962-a65b-7ac7b2faf3df",
-        "eval_err": "LoadError: UndefVarError: `@L_str` not defined in `Main.var\"##hv#1349\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (Acid::String, c0_Acid_string::String, c0_Base_string::String, pointX::Float64, v0_Acid_string::String)\n    latexacids = [L\"\\mathrm{HClO_4}\", L\"\\mathrm{HCl}\", L\"\\mathrm{HSO_4^-}\", L\"\\mathrm{HNO_{2}}\", L\"\\mathrm{HF}\", L\"\\mathrm{HCOOH}\", L\"\\mathrm{CH_{3}COOH}\"]\n    stringacids = [\"HClO4\", \"HCl\", \"HSO4-\", \"HNO2\", \"HF\", \"HCOOH\", \"CH3COOH\"]\n    acidmap = Dict((s => l for (s, l) = zip(stringacids, latexacids)))\n    df = DataFrame(Dict(\"Acid\" => latexacids, \"pKa\" => [-10.0, -6.0, 1.92, 3.15, 3.17, 3.75, 4.76]))\n    pKa = (filter((row->(#= none:3 =#\n                    row.:(\"Acid\") == acidmap[Acid])), df)).:(\"pKa\")[1]\n    Ka = 10 ^ -pKa\n    pKb = 14 - pKa\n    Kb = 10 ^ -pKb\n    c0_Acid = parse(Float64, c0_Acid_string)\n    v0_Acid = parse(Float64, v0_Acid_string)\n    c0_Base = parse(Float64, c0_Base_string)\n    v_Base_end = ((v0_Acid * c0_Acid) / c0_Base) * 2\n    v_Base = convert(Vector{Float64}, Float64[])\n    let t = 0.0\n        #= none:13 =#\n        while t <= v_Base_end + 0.0025\n            #= none:14 =#\n            push!(v_Base, t)\n            #= none:15 =#\n            t += 0.005\n            #= none:16 =#\n        end\n    end\n    if pKa <= 0\n        #= none:19 =#\n        c0_H⁺ = Float64(c0_Acid * v0_Acid)\n        #= none:20 =#\n        c0_OH⁻ = Float64(10 ^ -7)\n    else\n        #= none:22 =#\n        c0_H⁺ = -Ka / 2 + sqrt(Ka ^ 2 / 4 + Ka * c0_Acid)\n        #= none:23 =#\n        c0_OH⁻ = -Kb / 2 + sqrt(Kb ^ 2 / 4 + Kb * c0_Acid)\n    end\n    nothing\n    nothing\n    if pKa < 7.0\n        #= none:3 =#\n        pH_total = map(calc_pH, v_Base)\n        #= none:5 =#\n        pH_Value = round(calc_pH(pointX), sigdigits = 3)\n        #= none:7 =#\n        fig_titr = Figure(size = (620, 420))\n        #= none:8 =#\n        ax_titr = Axis(fig_titr[1, 1]; title = \"Titration curve of \" * c0_Acid_string * \" M \" * Acid * \" against \" * c0_Base_string * \" M NaOH\", xlabel = \"Added volume of titrant / [mL]\", ylabel = \"pH-Value\")\n        #= none:12 =#\n        ax_titr.xmin = -1.0\n        #= none:13 =#\n        ax_titr.xmax = Float64(v_Base_end + 2)\n        #= none:14 =#\n        ax_titr.ymin = 0.0\n        #= none:15 =#\n        ax_titr.ymax = 14.0\n        #= none:17 =#\n        lines!(ax_titr, v_Base, pH_total; linewidth = 2, label = \"titration curve\")\n        #= none:18 =#\n        scatter!(ax_titr, [Float64(pointX)], [Float64(calc_pH(pointX))]; label = \"Current point of titration\")\n        #= none:20 =#\n        if pKa <= 1.74\n            #= none:21 =#\n            let ev = 0.0\n                #= none:22 =#\n                for i = v_Base\n                    #= none:23 =#\n                    if i * c0_Base == v0_Acid * c0_Acid\n                        #= none:24 =#\n                        ev = i\n                    end\n                    #= none:26 =#\n                end\n                #= none:27 =#\n                scatter!(ax_titr, [ev], [calc_pH(ev)]; label = \"Equivalence point\")\n            end\n        else\n            #= none:30 =#\n            let hev = 0.0, ev = 0.0\n                #= none:31 =#\n                for i = v_Base\n                    #= none:32 =#\n                    if round((c0_Acid * v0_Acid) / (c0_H⁺ * v0_Acid + c0_Base * i), digits = 3) == 2.0\n                        #= none:33 =#\n                        hev = i\n                    elseif #= none:34 =# round((c0_Acid - c0_H⁺) * v0_Acid, digits = 3) == round(c0_Base * i, digits = 3)\n                        #= none:35 =#\n                        ev = i\n                    end\n                    #= none:37 =#\n                end\n                #= none:38 =#\n                scatter!(ax_titr, [ev], [calc_pH(ev)]; label = \"Equivalence point\")\n                #= none:39 =#\n                scatter!(ax_titr, [hev], [calc_pH(hev)]; label = \"Half equivalence point\")\n            end\n        end\n        #= none:42 =#\n        axislegend(ax_titr; position = :rb)\n        #= none:43 =#\n        fig_titr\n    else\n        #= none:45 =#\n        println(\"The given pKa-value does not match a strong or weak acid.\")\n    end\n    var\"##cellval#1345\" = println(\"At this point, $(pointX) millilitre of titrant were added. The pH Value of the \\nsolution is $(pH_Value).\")\n    return (PlutoIslands._plain_body)(var\"##cellval#1345\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "4127a0c7-897b-41c2-9319-2b1c48369699",
-        "eval_err": "LoadError: UndefVarError: `@L_str` not defined in `Main.var\"##hv#1349\"`\nSuggestion: check for spelling errors or missing imports.\nin expression starting at none:2",
-        "extract_ok": true,
-        "fn_src": "function (Acid::String, c0_Acid_string::String, c0_Base_string::String, pointX::Float64, v0_Acid_string::String)\n    latexacids = [L\"\\mathrm{HClO_4}\", L\"\\mathrm{HCl}\", L\"\\mathrm{HSO_4^-}\", L\"\\mathrm{HNO_{2}}\", L\"\\mathrm{HF}\", L\"\\mathrm{HCOOH}\", L\"\\mathrm{CH_{3}COOH}\"]\n    stringacids = [\"HClO4\", \"HCl\", \"HSO4-\", \"HNO2\", \"HF\", \"HCOOH\", \"CH3COOH\"]\n    acidmap = Dict((s => l for (s, l) = zip(stringacids, latexacids)))\n    df = DataFrame(Dict(\"Acid\" => latexacids, \"pKa\" => [-10.0, -6.0, 1.92, 3.15, 3.17, 3.75, 4.76]))\n    pKa = (filter((row->(#= none:3 =#\n                    row.:(\"Acid\") == acidmap[Acid])), df)).:(\"pKa\")[1]\n    Ka = 10 ^ -pKa\n    pKb = 14 - pKa\n    Kb = 10 ^ -pKb\n    c0_Acid = parse(Float64, c0_Acid_string)\n    v0_Acid = parse(Float64, v0_Acid_string)\n    c0_Base = parse(Float64, c0_Base_string)\n    v_Base_end = ((v0_Acid * c0_Acid) / c0_Base) * 2\n    v_Base = convert(Vector{Float64}, Float64[])\n    let t = 0.0\n        #= none:13 =#\n        while t <= v_Base_end + 0.0025\n            #= none:14 =#\n            push!(v_Base, t)\n            #= none:15 =#\n            t += 0.005\n            #= none:16 =#\n        end\n    end\n    if pKa <= 0\n        #= none:19 =#\n        c0_H⁺ = Float64(c0_Acid * v0_Acid)\n        #= none:20 =#\n        c0_OH⁻ = Float64(10 ^ -7)\n    else\n        #= none:22 =#\n        c0_H⁺ = -Ka / 2 + sqrt(Ka ^ 2 / 4 + Ka * c0_Acid)\n        #= none:23 =#\n        c0_OH⁻ = -Kb / 2 + sqrt(Kb ^ 2 / 4 + Kb * c0_Acid)\n    end\n    nothing\n    nothing\n    if pKa < 7.0\n        #= none:3 =#\n        pH_total = map(calc_pH, v_Base)\n        #= none:5 =#\n        pH_Value = round(calc_pH(pointX), sigdigits = 3)\n        #= none:7 =#\n        fig_titr = Figure(size = (620, 420))\n        #= none:8 =#\n        ax_titr = Axis(fig_titr[1, 1]; title = \"Titration curve of \" * c0_Acid_string * \" M \" * Acid * \" against \" * c0_Base_string * \" M NaOH\", xlabel = \"Added volume of titrant / [mL]\", ylabel = \"pH-Value\")\n        #= none:12 =#\n        ax_titr.xmin = -1.0\n        #= none:13 =#\n        ax_titr.xmax = Float64(v_Base_end + 2)\n        #= none:14 =#\n        ax_titr.ymin = 0.0\n        #= none:15 =#\n        ax_titr.ymax = 14.0\n        #= none:17 =#\n        lines!(ax_titr, v_Base, pH_total; linewidth = 2, label = \"titration curve\")\n        #= none:18 =#\n        scatter!(ax_titr, [Float64(pointX)], [Float64(calc_pH(pointX))]; label = \"Current point of titration\")\n        #= none:20 =#\n        if pKa <= 1.74\n            #= none:21 =#\n            let ev = 0.0\n                #= none:22 =#\n                for i = v_Base\n                    #= none:23 =#\n                    if i * c0_Base == v0_Acid * c0_Acid\n                        #= none:24 =#\n                        ev = i\n                    end\n                    #= none:26 =#\n                end\n                #= none:27 =#\n                scatter!(ax_titr, [ev], [calc_pH(ev)]; label = \"Equivalence point\")\n            end\n        else\n            #= none:30 =#\n            let hev = 0.0, ev = 0.0\n                #= none:31 =#\n                for i = v_Base\n                    #= none:32 =#\n                    if round((c0_Acid * v0_Acid) / (c0_H⁺ * v0_Acid + c0_Base * i), digits = 3) == 2.0\n                        #= none:33 =#\n                        hev = i\n                    elseif #= none:34 =# round((c0_Acid - c0_H⁺) * v0_Acid, digits = 3) == round(c0_Base * i, digits = 3)\n                        #= none:35 =#\n                        ev = i\n                    end\n                    #= none:37 =#\n                end\n                #= none:38 =#\n                scatter!(ax_titr, [ev], [calc_pH(ev)]; label = \"Equivalence point\")\n                #= none:39 =#\n                scatter!(ax_titr, [hev], [calc_pH(hev)]; label = \"Half equivalence point\")\n            end\n        end\n        #= none:42 =#\n        axislegend(ax_titr; position = :rb)\n        #= none:43 =#\n        fig_titr\n    else\n        #= none:45 =#\n        println(\"The given pKa-value does not match a strong or weak acid.\")\n    end\n    Methyl_orange = ColorScheme(range(colorant\"red\", colorant\"yellow\", length = 130))\n    Litmus = ColorScheme(range(colorant\"red\", colorant\"blue\", length = 300))\n    Bromothymol_blue = ColorScheme(range(colorant\"yellow\", colorant\"blue\", length = 160))\n    Phenolphthalein = ColorScheme(range(colorant\"white\", colorant\"magenta\", length = 180))\n    Alizarin_yellow = ColorScheme(range(colorant\"yellow\", colorant\"red\", length = 190))\n    nothing\n    if pH_Value < 3.1\n        #= none:11 =#\n        a = convert(Int64, 1)\n    elseif #= none:12 =# 3.1 <= pH_Value < 4.4\n        #= none:13 =#\n        a = convert(Int64, Int64(round(100pH_Value - 309)))\n    elseif #= none:14 =# pH_Value >= 4.4\n        #= none:15 =#\n        a = convert(Int64, size(Methyl_orange))\n    end\n    if pH_Value < 5.0\n        #= none:19 =#\n        b = convert(Int64, 1)\n    elseif #= none:20 =# 5.0 <= pH_Value < 8.0\n        #= none:21 =#\n        b = convert(Int64, Int64(round(100pH_Value - 499)))\n    elseif #= none:22 =# pH_Value >= 8.0\n        #= none:23 =#\n        b = convert(Int64, size(Litmus))\n    end\n    if pH_Value < 6.0\n        #= none:27 =#\n        c = convert(Int64, 1)\n    elseif #= none:28 =# 6.0 <= pH_Value < 7.6\n        #= none:29 =#\n        c = convert(Int64, Int64(round(100pH_Value - 599)))\n    elseif #= none:30 =# pH_Value >= 7.6\n        #= none:31 =#\n        c = convert(Int64, size(Bromothymol_blue))\n    end\n    if pH_Value < 8.3\n        #= none:35 =#\n        d = convert(Int64, 1)\n    elseif #= none:36 =# 8.3 <= pH_Value < 10.0\n        #= none:37 =#\n        d = convert(Int64, Int64(round(100pH_Value - 829)))\n    elseif #= none:38 =# pH_Value >= 10.0\n        #= none:39 =#\n        d = convert(Int64, size(Phenolphthalein))\n    end\n    if pH_Value < 10.1\n        #= none:43 =#\n        e = convert(Int64, 1)\n    elseif #= none:44 =# 10.1 <= pH_Value < 12.0\n        #= none:45 =#\n        e = convert(Int64, Int64(round(100pH_Value - 1009)))\n    elseif #= none:46 =# pH_Value >= 12.0\n        #= none:47 =#\n        e = convert(Int64, size(Alizarin_yellow))\n    end\n    var\"##cellval#1346\" = nothing\n    return (PlutoIslands._plain_body)(var\"##cellval#1346\")\nend",
-        "kind": "string",
-        "mime": "text/plain",
-        "reasons": []
-      },
-      {
-        "cell_id": "6ebfa6d8-b4a7-4d5e-8d3d-ccf0ba596f25",
-        "extract_ok": false,
-        "fn_src": null,
-        "kind": "string",
-        "mime": "application/vnd.pluto.table+object",
-        "reasons": [
-          "unsupported output mime application/vnd.pluto.table+object in v0 (text/plain & md-text/html only)"
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "0.1",
+            "0.1",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "25",
+            "0.1",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "0.1",
+            "25",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "0.1",
+            "0.1",
+            "49",
+            "25.0",
+            "25.0"
+          ]
         ]
       },
       {
-        "cell_id": "2ffcfcc2-ac5f-4293-bab0-3fede68c115a",
-        "extract_ok": false,
-        "fn_src": null,
+        "cell_id": "f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e8",
+        "extract_ok": true,
+        "fn_src": "function (c0_Acid::Float64, c0_Base::Float64, pKa::Float64, pointX::Float64, v0_Acid::Float64)\n    return (\"<div class=\\\"markdown\\\"><p><strong>pH at the current added volume:</strong> \" * string(round(calc_pH(pointX, pKa, c0_Acid, v0_Acid, c0_Base), digits = 2))) * \"</p>\\n</div>\"\nend",
+        "golden": [
+          "\"<div class=\\\"markdown\\\"><p><strong>pH at the current added volume:</strong> 10.83</p>\\n</div>\"",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#5#6\")(::Int64, ::Float64, ::Float64, ::Float64, ::Float64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#5#6\")(!Matched::Float64, ::Float64, ::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#5#6\")(::Float64, ::Int64, ::Float64, ::Float64, ::Float64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#5#6\")(::Float64, !Matched::Float64, ::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#5#6\")(::Float64, ::Float64, ::Int64, ::Float64, ::Float64)\nThe function `#5` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#5#6\")(::Float64, ::Float64, !Matched::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n"
+        ],
         "kind": "string",
-        "mime": "application/vnd.pluto.table+object",
-        "reasons": [
-          "unsupported output mime application/vnd.pluto.table+object in v0 (text/plain & md-text/html only)"
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "0.1",
+            "0.1",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "25",
+            "0.1",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "0.1",
+            "25",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "0.1",
+            "0.1",
+            "49",
+            "25.0",
+            "25.0"
+          ]
+        ]
+      },
+      {
+        "cell_id": "f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e9",
+        "extract_ok": true,
+        "fn_src": "function (c0_Acid::Float64, c0_Base::Float64, pKa::Float64, pointX::Float64, v0_Acid::Float64)\n    return (\"<div class=\\\"markdown\\\"><p><strong>Equivalence-point volume of titrant &#40;mL&#41;:</strong> \" * string(round(equivalence_volume(pKa, c0_Acid, v0_Acid, c0_Base), digits = 2))) * \"</p>\\n</div>\"\nend",
+        "golden": [
+          "\"<div class=\\\"markdown\\\"><p><strong>Equivalence-point volume of titrant &#40;mL&#41;:</strong> 24.67</p>\\n</div>\"",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#8#9\")(::Int64, ::Float64, ::Float64, ::Float64, ::Float64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#8#9\")(!Matched::Float64, ::Float64, ::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#8#9\")(::Float64, ::Int64, ::Float64, ::Float64, ::Float64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#8#9\")(::Float64, !Matched::Float64, ::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n",
+          "ERR:MethodError: no method matching (::Main.var\"##hv#1071\".var\"#8#9\")(::Float64, ::Float64, ::Int64, ::Float64, ::Float64)\nThe function `#8` exists, but no method is defined for this combination of argument types.\n\nClosest candidates are:\n  (::Main.var\"##hv#1071\".var\"#8#9\")(::Float64, ::Float64, !Matched::Float64, ::Float64, ::Float64)\n   @ Main.var\"##hv#1071\" none:0\n"
+        ],
+        "kind": "string",
+        "mime": "text/html",
+        "reasons": [],
+        "rettype": "String",
+        "samples": [
+          [
+            "0.1",
+            "0.1",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "25",
+            "0.1",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "0.1",
+            "25",
+            "4.75",
+            "25.0",
+            "25.0"
+          ],
+          [
+            "0.1",
+            "0.1",
+            "49",
+            "25.0",
+            "25.0"
+          ]
         ]
       }
     ],
@@ -6320,8 +5165,9 @@
     "group_reasons": [],
     "notebook": "Titration.jl",
     "preamble": [
-      "using WasmMakie, PlutoUI, DataFrames, LaTeXStrings, ColorSchemes, Colors, Handcalcs, StructuralUnits",
-      "function calc_pH(v_Base_added::Float64)\n    #= none:3 =#\n    #= none:4 =#\n    if pKa <= 1.74\n        #= none:5 =#\n        if v_Base_added * c0_Base <= v0_Acid * c0_Acid\n            #= none:6 =#\n            c_H⁺::Float64 = (c0_Acid * v0_Acid - c0_Base * v_Base_added) / (v0_Acid + v_Base_added) + 10 ^ -7\n        else\n            #= none:8 =#\n            c_OH⁻::Float64 = (c0_Base * v_Base_added - c0_Acid * v0_Acid) / (v0_Acid + v_Base_added)\n            #= none:9 =#\n            c_H⁺ = 10 ^ -14 / c_OH⁻\n        end\n        #= none:11 =#\n        pH = -(log(10, c_H⁺))\n    else\n        #= none:13 =#\n        if v_Base_added == 0.0\n            #= none:14 =#\n            pH = -(log(10, c0_H⁺))\n        elseif #= none:15 =# round((c0_Acid - c0_H⁺) * v0_Acid, digits = 3) > round(c0_Base * v_Base_added, digits = 3)\n            #= none:16 =#\n            c_H⁺ = Ka * ((c0_Acid * v0_Acid) / (c0_H⁺ * v0_Acid + c0_Base * v_Base_added) - 1)\n            #= none:17 =#\n            pH = -(log(10, c_H⁺))\n        elseif #= none:18 =# round((c0_Acid - c0_H⁺) * v0_Acid, digits = 3) == round(c0_Base * v_Base_added, digits = 3)\n            #= none:19 =#\n            pH = 14 - -(log(10, c0_OH⁻))\n        elseif #= none:20 =# round((c0_Acid - c0_H⁺) * v0_Acid, digits = 3) < round(c0_Base * v_Base_added, digits = 3)\n            #= none:21 =#\n            c_OH⁻ = (c0_Base * v_Base_added - (c0_Acid - c0_H⁺) * v0_Acid) / (v0_Acid + v_Base_added) + c0_OH⁻\n            #= none:22 =#\n            c_H⁺ = 10 ^ -14 / c_OH⁻\n            #= none:23 =#\n            pH = -(log(10, c_H⁺))\n        end\n    end\nend"
+      "function calc_pH(v_Base_added::Float64, pKa::Float64, c0_Acid::Float64, v0_Acid::Float64, c0_Base::Float64)\n    #= none:2 =#\n    #= none:4 =#\n    Ka = 10.0 ^ -pKa\n    #= none:5 =#\n    pKb = 14.0 - pKa\n    #= none:6 =#\n    Kb = 10.0 ^ -pKb\n    #= none:8 =#\n    if pKa <= 1.74\n        #= none:9 =#\n        c_H = 0.0\n        #= none:10 =#\n        if v_Base_added * c0_Base <= v0_Acid * c0_Acid\n            #= none:11 =#\n            c_H = (c0_Acid * v0_Acid - c0_Base * v_Base_added) / (v0_Acid + v_Base_added) + 1.0e-7\n        else\n            #= none:13 =#\n            c_OH = (c0_Base * v_Base_added - c0_Acid * v0_Acid) / (v0_Acid + v_Base_added)\n            #= none:14 =#\n            c_H = 1.0e-14 / c_OH\n        end\n        #= none:16 =#\n        return -(log(10.0, c_H))\n    else\n        #= none:19 =#\n        c0_H = -Ka / 2.0 + sqrt((Ka * Ka) / 4.0 + Ka * c0_Acid)\n        #= none:20 =#\n        c0_OH = -Kb / 2.0 + sqrt((Kb * Kb) / 4.0 + Kb * c0_Acid)\n        #= none:22 =#\n        n_acid = (c0_Acid - c0_H) * v0_Acid\n        #= none:23 =#\n        n_base = c0_Base * v_Base_added\n        #= none:25 =#\n        if v_Base_added == 0.0\n            #= none:26 =#\n            return -(log(10.0, c0_H))\n        elseif #= none:27 =# n_acid > n_base\n            #= none:28 =#\n            c_H = Ka * ((c0_Acid * v0_Acid) / (c0_H * v0_Acid + c0_Base * v_Base_added) - 1.0)\n            #= none:29 =#\n            return -(log(10.0, c_H))\n        else\n            #= none:31 =#\n            c_OH = (c0_Base * v_Base_added - n_acid) / (v0_Acid + v_Base_added) + c0_OH\n            #= none:32 =#\n            c_H = 1.0e-14 / c_OH\n            #= none:33 =#\n            return -(log(10.0, c_H))\n        end\n    end\nend",
+      "function equivalence_volume(pKa::Float64, c0_Acid::Float64, v0_Acid::Float64, c0_Base::Float64)\n    #= none:2 =#\n    #= none:3 =#\n    if pKa <= 1.74\n        #= none:4 =#\n        return (c0_Acid * v0_Acid) / c0_Base\n    else\n        #= none:6 =#\n        Ka = 10.0 ^ -pKa\n        #= none:7 =#\n        c0_H = -Ka / 2.0 + sqrt((Ka * Ka) / 4.0 + Ka * c0_Acid)\n        #= none:8 =#\n        return ((c0_Acid - c0_H) * v0_Acid) / c0_Base\n    end\nend",
+      "using WasmMakie, PlutoUI"
     ]
   }
 ]

--- a/test/integration/pi_island_status.json
+++ b/test/integration/pi_island_status.json
@@ -3,17 +3,9 @@
     "notebook": "Basic mathematics.jl",
     "status": "green"
   },
-  "CollatzConjecture.jl#1#1b48b435-e959-477f-a8d2-3507da73fc28": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#1#1c3f1bea-f1ba-4d64-90ad-584391c01da5": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
   "CollatzConjecture.jl#1#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#1#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
@@ -23,49 +15,21 @@
     "notebook": "CollatzConjecture.jl",
     "status": "harvest_eval_fail"
   },
-  "CollatzConjecture.jl#1#5f074850-b967-4de5-8ca3-b85a74052499": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "runtime_trap"
-  },
-  "CollatzConjecture.jl#1#6693800b-e2bc-46e4-b5f8-004184ef472b": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
   "CollatzConjecture.jl#1#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
     "status": "native_err"
   },
   "CollatzConjecture.jl#1#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#1#7dbfb4dc-c9d0-464d-83b2-18db90d76878": {
     "notebook": "CollatzConjecture.jl",
     "status": "extract_fail"
   },
-  "CollatzConjecture.jl#1#8a64e9e3-477e-4a7e-97f7-61cf5e428731": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#1#af0c36ee-0534-4143-b59b-4ee041ef0f04": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "eval_fail"
-  },
-  "CollatzConjecture.jl#1#f21f1e3e-a3ab-458e-a101-ce824731f0b6": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
-  "CollatzConjecture.jl#2#1b48b435-e959-477f-a8d2-3507da73fc28": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#2#1c3f1bea-f1ba-4d64-90ad-584391c01da5": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
   "CollatzConjecture.jl#2#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#2#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
@@ -75,61 +39,25 @@
     "notebook": "CollatzConjecture.jl",
     "status": "harvest_eval_fail"
   },
-  "CollatzConjecture.jl#2#5f074850-b967-4de5-8ca3-b85a74052499": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
-  },
-  "CollatzConjecture.jl#2#6693800b-e2bc-46e4-b5f8-004184ef472b": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
   "CollatzConjecture.jl#2#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
     "status": "native_err"
   },
   "CollatzConjecture.jl#2#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#2#7dbfb4dc-c9d0-464d-83b2-18db90d76878": {
     "notebook": "CollatzConjecture.jl",
     "status": "extract_fail"
   },
-  "CollatzConjecture.jl#2#8a64e9e3-477e-4a7e-97f7-61cf5e428731": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#2#af0c36ee-0534-4143-b59b-4ee041ef0f04": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "eval_fail"
-  },
-  "CollatzConjecture.jl#2#f21f1e3e-a3ab-458e-a101-ce824731f0b6": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
-  "CollatzConjecture.jl#3#1b48b435-e959-477f-a8d2-3507da73fc28": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#3#1c3f1bea-f1ba-4d64-90ad-584391c01da5": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
   "CollatzConjecture.jl#3#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#3#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
     "status": "native_err"
-  },
-  "CollatzConjecture.jl#3#5f074850-b967-4de5-8ca3-b85a74052499": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "runtime_trap"
-  },
-  "CollatzConjecture.jl#3#6693800b-e2bc-46e4-b5f8-004184ef472b": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
   },
   "CollatzConjecture.jl#3#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
@@ -137,39 +65,15 @@
   },
   "CollatzConjecture.jl#3#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#3#af0c36ee-0534-4143-b59b-4ee041ef0f04": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "eval_fail"
-  },
-  "CollatzConjecture.jl#3#f21f1e3e-a3ab-458e-a101-ce824731f0b6": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
-  "CollatzConjecture.jl#4#1b48b435-e959-477f-a8d2-3507da73fc28": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#4#1c3f1bea-f1ba-4d64-90ad-584391c01da5": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#4#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#4#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
     "status": "native_err"
-  },
-  "CollatzConjecture.jl#4#5f074850-b967-4de5-8ca3-b85a74052499": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "runtime_trap"
-  },
-  "CollatzConjecture.jl#4#6693800b-e2bc-46e4-b5f8-004184ef472b": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
   },
   "CollatzConjecture.jl#4#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
@@ -177,39 +81,15 @@
   },
   "CollatzConjecture.jl#4#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#4#af0c36ee-0534-4143-b59b-4ee041ef0f04": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "eval_fail"
-  },
-  "CollatzConjecture.jl#4#f21f1e3e-a3ab-458e-a101-ce824731f0b6": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
-  "CollatzConjecture.jl#5#1b48b435-e959-477f-a8d2-3507da73fc28": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#5#1c3f1bea-f1ba-4d64-90ad-584391c01da5": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#5#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
+    "status": "native_err"
   },
   "CollatzConjecture.jl#5#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
     "status": "native_err"
-  },
-  "CollatzConjecture.jl#5#5f074850-b967-4de5-8ca3-b85a74052499": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "runtime_trap"
-  },
-  "CollatzConjecture.jl#5#6693800b-e2bc-46e4-b5f8-004184ef472b": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
   },
   "CollatzConjecture.jl#5#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
@@ -217,55 +97,7 @@
   },
   "CollatzConjecture.jl#5#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#5#af0c36ee-0534-4143-b59b-4ee041ef0f04": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "eval_fail"
-  },
-  "CollatzConjecture.jl#5#f21f1e3e-a3ab-458e-a101-ce824731f0b6": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
-  "CollatzConjecture.jl#6#1b48b435-e959-477f-a8d2-3507da73fc28": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#6#1c3f1bea-f1ba-4d64-90ad-584391c01da5": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
-  "CollatzConjecture.jl#6#3550fe19-261e-4069-9bf6-6417dcaac102": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
-  },
-  "CollatzConjecture.jl#6#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
-    "notebook": "CollatzConjecture.jl",
     "status": "native_err"
-  },
-  "CollatzConjecture.jl#6#5f074850-b967-4de5-8ca3-b85a74052499": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "runtime_trap"
-  },
-  "CollatzConjecture.jl#6#6693800b-e2bc-46e4-b5f8-004184ef472b": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#6#66fe673a-7679-4c55-bf59-146a8dd1241c": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
-  },
-  "CollatzConjecture.jl#6#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "harvest_eval_fail"
-  },
-  "CollatzConjecture.jl#6#af0c36ee-0534-4143-b59b-4ee041ef0f04": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "eval_fail"
-  },
-  "CollatzConjecture.jl#6#f21f1e3e-a3ab-458e-a101-ce824731f0b6": {
-    "notebook": "CollatzConjecture.jl",
-    "status": "extract_fail"
   },
   "Interactivity with HTML.jl#1#ede8009e-7f15-11ea-192a-a5c6135a9dcf": {
     "notebook": "Interactivity with HTML.jl",
@@ -417,39 +249,19 @@
   },
   "Titration.jl#1#02c0320c-7c56-4fe5-8f8c-9ab0f733b28e": {
     "notebook": "Titration.jl",
-    "status": "harvest_eval_fail"
+    "status": "native_err"
   },
-  "Titration.jl#1#2ffcfcc2-ac5f-4293-bab0-3fede68c115a": {
+  "Titration.jl#1#f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e8": {
     "notebook": "Titration.jl",
-    "status": "extract_fail"
+    "status": "golden_drift"
   },
-  "Titration.jl#1#4127a0c7-897b-41c2-9319-2b1c48369699": {
+  "Titration.jl#1#f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e9": {
     "notebook": "Titration.jl",
-    "status": "harvest_eval_fail"
-  },
-  "Titration.jl#1#41bed3bd-75f9-4b1a-9ea8-786b338b7503": {
-    "notebook": "Titration.jl",
-    "status": "harvest_eval_fail"
-  },
-  "Titration.jl#1#6ebfa6d8-b4a7-4d5e-8d3d-ccf0ba596f25": {
-    "notebook": "Titration.jl",
-    "status": "extract_fail"
-  },
-  "Titration.jl#1#831198d1-d22c-42b5-a198-3bd34139eb0e": {
-    "notebook": "Titration.jl",
-    "status": "extract_fail"
-  },
-  "Titration.jl#1#9dee0462-b5af-4962-a65b-7ac7b2faf3df": {
-    "notebook": "Titration.jl",
-    "status": "harvest_eval_fail"
-  },
-  "Titration.jl#1#af04638c-2615-4195-a45e-d6d85af6d6cd": {
-    "notebook": "Titration.jl",
-    "status": "harvest_eval_fail"
+    "status": "golden_drift"
   },
   "convolution_1d.jl#1#0dd8235c-c09b-49ae-b02a-4bbb285970a6": {
     "notebook": "convolution_1d.jl",
-    "status": "runtime_trap"
+    "status": "green"
   },
   "convolution_1d.jl#1#380ba7f0-76e6-47ec-98e2-e6c6a3b7f2d5": {
     "notebook": "convolution_1d.jl",
@@ -475,107 +287,35 @@
     "notebook": "convolution_1d.jl",
     "status": "green"
   },
-  "convolution_1d.jl#1#ceb05a23-93b8-4423-a5f9-f6e3d961d0c6": {
-    "notebook": "convolution_1d.jl",
-    "status": "native_err"
-  },
   "convolution_1d.jl#1#f0d08486-0086-48da-baeb-169f3812d0ea": {
     "notebook": "convolution_1d.jl",
     "status": "eval_fail"
   },
-  "convolution_2d.jl#1#4b560bf2-00d9-4440-9589-834cd9177f66": {
+  "convolution_2d.jl#1#88933746-6028-11eb-32de-13eb6ff43e29": {
     "notebook": "convolution_2d.jl",
     "status": "native_err"
   },
-  "convolution_2d.jl#1#5737939b-0bb9-4ddf-8948-6356e60d79f3": {
-    "notebook": "convolution_2d.jl",
-    "status": "eval_fail"
-  },
-  "convolution_2d.jl#1#6c31cbb0-01ed-40cf-b400-3ed6b7c79ecc": {
+  "convolution_2d.jl#2#d1174f21-5c74-4934-acdf-716671cfc2db": {
     "notebook": "convolution_2d.jl",
     "status": "native_err"
   },
-  "convolution_2d.jl#1#6ff88cb3-7cca-4091-b914-10c4bdc0d9d2": {
+  "convolution_2d.jl#3#4b560bf2-00d9-4440-9589-834cd9177f66": {
     "notebook": "convolution_2d.jl",
     "status": "native_err"
   },
-  "convolution_2d.jl#1#8ae0248f-6eba-4941-85f4-b21be3c7e725": {
+  "convolution_2d.jl#3#702ab37f-bbeb-4197-807a-b45207598cb1": {
     "notebook": "convolution_2d.jl",
     "status": "native_err"
   },
-  "convolution_2d.jl#1#9d42dd93-98b4-40db-9d3f-8917d6f72354": {
-    "notebook": "convolution_2d.jl",
-    "status": "outside_bridge"
-  },
-  "convolution_2d.jl#1#9edf2fce-715a-46fc-bc5f-d58e08de789b": {
-    "notebook": "convolution_2d.jl",
-    "status": "extract_fail"
-  },
-  "convolution_2d.jl#1#ef0bea69-6dfd-4526-a96e-6607771660fe": {
+  "convolution_2d.jl#4#96a4b35a-5a3a-4ad0-9ffe-306db46d1c03": {
     "notebook": "convolution_2d.jl",
     "status": "native_err"
   },
-  "convolution_2d.jl#2#4b560bf2-00d9-4440-9589-834cd9177f66": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#2#5737939b-0bb9-4ddf-8948-6356e60d79f3": {
-    "notebook": "convolution_2d.jl",
-    "status": "eval_fail"
-  },
-  "convolution_2d.jl#2#6ff88cb3-7cca-4091-b914-10c4bdc0d9d2": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#2#8ae0248f-6eba-4941-85f4-b21be3c7e725": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#2#9d42dd93-98b4-40db-9d3f-8917d6f72354": {
-    "notebook": "convolution_2d.jl",
-    "status": "outside_bridge"
-  },
-  "convolution_2d.jl#2#9edf2fce-715a-46fc-bc5f-d58e08de789b": {
-    "notebook": "convolution_2d.jl",
-    "status": "extract_fail"
-  },
-  "convolution_2d.jl#2#ef0bea69-6dfd-4526-a96e-6607771660fe": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#3#96a4b35a-5a3a-4ad0-9ffe-306db46d1c03": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#4#4b560bf2-00d9-4440-9589-834cd9177f66": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#4#6c31cbb0-01ed-40cf-b400-3ed6b7c79ecc": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#4#6ff88cb3-7cca-4091-b914-10c4bdc0d9d2": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#4#8ae0248f-6eba-4941-85f4-b21be3c7e725": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "convolution_2d.jl#4#9d42dd93-98b4-40db-9d3f-8917d6f72354": {
-    "notebook": "convolution_2d.jl",
-    "status": "outside_bridge"
-  },
-  "convolution_2d.jl#4#ef0bea69-6dfd-4526-a96e-6607771660fe": {
-    "notebook": "convolution_2d.jl",
-    "status": "native_err"
-  },
-  "dither.jl#1#354f38ba-a8cf-4405-a0ef-1ec243f18acf": {
+  "dither.jl#1#0210462f-851b-4e2b-ba99-d7ade531fe11": {
     "notebook": "dither.jl",
-    "status": "outside_bridge"
+    "status": "native_err"
   },
-  "dither.jl#1#57a15a1a-32d8-4a75-9a65-18363a3c8f03": {
+  "dither.jl#1#09cbe381-c39e-4431-a9d3-624091ea42d0": {
     "notebook": "dither.jl",
     "status": "native_err"
   },
@@ -583,13 +323,21 @@
     "notebook": "dither.jl",
     "status": "green"
   },
-  "dither.jl#1#93e576e2-d5f0-44d9-8747-93ecefc51a8c": {
+  "dither.jl#1#8a718f57-740b-43a8-9f05-6c699f982220": {
     "notebook": "dither.jl",
-    "status": "outside_bridge"
+    "status": "native_err"
+  },
+  "dither.jl#1#a52bdeb6-35c4-4a70-bfa4-469912b30b27": {
+    "notebook": "dither.jl",
+    "status": "green"
   },
   "dither.jl#1#c4799684-46b7-4783-99de-c8946e7067de": {
     "notebook": "dither.jl",
-    "status": "outside_bridge"
+    "status": "green"
+  },
+  "dither.jl#1#ce25faed-be1c-4b74-9c3c-968638eb7813": {
+    "notebook": "dither.jl",
+    "status": "green"
   },
   "fractals.jl#1#4693d328-0907-4d62-b8e4-dcccff803b59": {
     "notebook": "fractals.jl",
@@ -607,10 +355,6 @@
     "notebook": "fractals.jl",
     "status": "green"
   },
-  "fractals.jl#2#8899561d-42e7-4397-a649-8800461c6649": {
-    "notebook": "fractals.jl",
-    "status": "eval_fail"
-  },
   "fractals.jl#3#221742a5-146e-4d7d-8d50-0f7bd5a30cb5": {
     "notebook": "fractals.jl",
     "status": "eval_fail"
@@ -623,129 +367,93 @@
     "notebook": "fractals.jl",
     "status": "runtime_trap"
   },
-  "fractals.jl#4#2e7f10f3-eb4d-40e0-ae48-c0b4563b99c4": {
+  "fractals.jl#4#8899561d-42e7-4397-a649-8800461c6649": {
+    "notebook": "fractals.jl",
+    "status": "native_err"
+  },
+  "fractals.jl#5#d3b2c4e5-9066-4c2f-b14a-3e2c7f8a5d93": {
+    "notebook": "fractals.jl",
+    "status": "native_err"
+  },
+  "fractals.jl#6#2e7f10f3-eb4d-40e0-ae48-c0b4563b99c4": {
     "notebook": "fractals.jl",
     "status": "golden_drift"
   },
-  "fractals.jl#4#4135244d-fb5a-4e8d-ad4b-c4046781b70c": {
+  "fractals.jl#6#4135244d-fb5a-4e8d-ad4b-c4046781b70c": {
     "notebook": "fractals.jl",
     "status": "runtime_trap"
   },
-  "fractals.jl#4#b2a95d75-a254-4918-96d2-7ec5c2a60d8a": {
+  "fractals.jl#6#b2a95d75-a254-4918-96d2-7ec5c2a60d8a": {
     "notebook": "fractals.jl",
     "status": "golden_drift"
   },
-  "fractals.jl#4#cf1f1d8a-c462-47b1-9e17-ea88357570aa": {
+  "fractals.jl#6#cf1f1d8a-c462-47b1-9e17-ea88357570aa": {
     "notebook": "fractals.jl",
     "status": "golden_drift"
   },
-  "fractals.jl#4#d81173b4-8847-4c17-9a30-5e20c6f313dd": {
+  "fractals.jl#6#d81173b4-8847-4c17-9a30-5e20c6f313dd": {
     "notebook": "fractals.jl",
     "status": "golden_drift"
   },
-  "fractals.jl#5#57819281-a466-4f6c-af96-ffe512594270": {
+  "fractals.jl#7#57819281-a466-4f6c-af96-ffe512594270": {
     "notebook": "fractals.jl",
     "status": "eval_fail"
   },
-  "images.jl#1#94b77934-713e-11eb-18cf-c5dc5e7afc5b": {
+  "images.jl#1#88933746-6028-11eb-32de-13eb6ff43e29": {
+    "notebook": "images.jl",
+    "status": "native_err"
+  },
+  "images.jl#2#ab9af0f6-64c9-11eb-13d3-5dbdb75a69a7": {
+    "notebook": "images.jl",
+    "status": "native_err"
+  },
+  "images.jl#3#94b77934-713e-11eb-18cf-c5dc5e7afc5b": {
     "notebook": "images.jl",
     "status": "green"
   },
-  "images.jl#1#ff762861-b186-4eb0-9582-0ce66ca10f60": {
+  "images.jl#3#ff762861-b186-4eb0-9582-0ce66ca10f60": {
     "notebook": "images.jl",
-    "status": "eval_fail"
-  },
-  "images.jl#2#6224c74b-8915-4983-abf0-30e6ba04a46d": {
-    "notebook": "images.jl",
-    "status": "eval_fail"
-  },
-  "images.jl#3#88933746-6028-11eb-32de-13eb6ff43e29": {
-    "notebook": "images.jl",
-    "status": "outside_bridge"
-  },
-  "images.jl#4#2ac47b91-bbc3-49ae-9bf5-4def30ff46f4": {
-    "notebook": "images.jl",
-    "status": "eval_fail"
+    "status": "native_err"
   },
   "images.jl#4#93b18ee8-f11c-40e2-b292-562798100ba4": {
     "notebook": "images.jl",
-    "status": "eval_fail"
+    "status": "native_err"
   },
-  "images.jl#5#ff9eea3f-cab0-4030-8337-f519b94316c5": {
+  "images.jl#5#1bd53326-d705-4d1a-bf8f-5d7f2a4e696f": {
     "notebook": "images.jl",
     "status": "native_err"
   },
-  "newton.jl#1#63dbf052-7c32-11eb-1062-5b3581d38f70": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#1#6dc89964-7c30-11eb-0a41-8d97b210ed34": {
-    "notebook": "newton.jl",
-    "status": "runtime_trap"
-  },
-  "newton.jl#1#9371f930-7c30-11eb-1f77-c7f31b97ea26": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#1#98158a38-7c30-11eb-0796-2335e97ec6d0": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#1#d35e0cc8-7c30-11eb-28d3-17c9e221ea62": {
-    "notebook": "newton.jl",
-    "status": "extract_fail"
-  },
-  "newton.jl#1#db26375a-7c30-11eb-066e-ab9e8ded3356": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#1#e18f2470-7c31-11eb-2b74-d59d00d20ba4": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#1#ea741018-7c30-11eb-3912-a50475e6ec49": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#2#ec6c6328-7b9c-11eb-1c69-dba12ae522ad": {
-    "notebook": "newton.jl",
+  "images.jl#6#d1174f21-5c74-4934-acdf-716671cfc2db": {
+    "notebook": "images.jl",
     "status": "native_err"
   },
-  "newton.jl#3#ecb40aea-7b9c-11eb-1476-e54faf32d91c": {
-    "notebook": "newton.jl",
+  "images.jl#7#ff9eea3f-cab0-4030-8337-f519b94316c5": {
+    "notebook": "images.jl",
     "status": "native_err"
   },
-  "newton.jl#4#09b97be8-7c2e-11eb-05fd-65bbd097afb8": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#4#18ce2fac-7c2e-11eb-03d2-b3a674621662": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#4#35b5c5c6-7c3f-11eb-2723-4b406a809114": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#4#3828b94c-7c2d-11eb-2e01-79038b0f5226": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#4#ed605b90-7c3e-11eb-34e9-776a05a177dd": {
-    "notebook": "newton.jl",
-    "status": "harvest_eval_fail"
-  },
-  "newton.jl#5#02b1b470-7c31-11eb-28f4-411956f73f12": {
+  "newton.jl#1#2e2e5f0e-7c31-11eb-0da7-770b07ee6202": {
     "notebook": "newton.jl",
     "status": "golden_drift"
   },
-  "newton.jl#5#07a754da-7c31-11eb-0394-4bef4d79fc30": {
+  "newton.jl#1#2fb40dc6-7c2f-11eb-2469-8deb4db59b5c": {
     "notebook": "newton.jl",
-    "status": "outside_bridge"
+    "status": "golden_drift"
   },
-  "newton.jl#5#5faa2784-7c31-11eb-34f1-3f8224dbdbde": {
+  "newton.jl#1#9bfafcc0-7ba2-11eb-1b67-e3a3803ead08": {
     "notebook": "newton.jl",
-    "status": "outside_bridge"
+    "status": "golden_drift"
+  },
+  "newton.jl#1#f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e8": {
+    "notebook": "newton.jl",
+    "status": "golden_drift"
+  },
+  "newton.jl#1#f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e9": {
+    "notebook": "newton.jl",
+    "status": "golden_drift"
+  },
+  "newton.jl#1#f25af026-7b9c-11eb-1f11-77a8b06b2d71": {
+    "notebook": "newton.jl",
+    "status": "native_err"
   },
   "turtles-art.jl#1#70402e12-22c2-47fd-99be-aa6cd15ce2c3": {
     "notebook": "turtles-art.jl",


### PR DESCRIPTION
Clean re-harvest of the PlutoIslands featured corpus (the old `pi_island_fixtures.json` had grown stale/bloated — 473KB with duplicate & outdated group records, so it misrepresented current extraction).

## What
- **Refreshed `pi_island_fixtures.json`** — clean re-harvest: 65 group-records / 118 cells.
- **Regenerated `pi_island_status.json`** — integration suite green, lock fully consistent. **True baseline: 42/118 green.**
- **Vendored `pi_bind_audit.json`** — output of the harvester's new completeness audit (companion PlutoIslands PR). Every notebook: registered-bonds == extracted-bonds, **zero errored `@bind` cells** → PI extraction drops nothing.

## Reframed work queue
Non-green is dominated by genuinely **out-of-scope** cells (Makie `Figure`, image processing, Luxor graphics → `native_err` ×45). The real WT codegen queue is the **5 `runtime_trap`** pieces (fractals ×2, PlutoUI ×3). `eval_fail` ×9 are a fixable test-sandbox setup issue (`@md_str`).

Test-infra only — no `src/` change, no release bump.
