### PR TITLE
test: bucket WasmMakie/Figure island cells as out_of_scalar_scope

### DIFF
--- a/test/integration/pi_island_status.json
+++ b/test/integration/pi_island_status.json
@@ -5,11 +5,11 @@
   },
   "CollatzConjecture.jl#1#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#1#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#1#50a423ad-ca90-4015-9ef6-577f60e4efe7": {
     "notebook": "CollatzConjecture.jl",
@@ -17,11 +17,11 @@
   },
   "CollatzConjecture.jl#1#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#1#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#1#7dbfb4dc-c9d0-464d-83b2-18db90d76878": {
     "notebook": "CollatzConjecture.jl",
@@ -29,11 +29,11 @@
   },
   "CollatzConjecture.jl#2#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#2#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#2#50a423ad-ca90-4015-9ef6-577f60e4efe7": {
     "notebook": "CollatzConjecture.jl",
@@ -41,11 +41,11 @@
   },
   "CollatzConjecture.jl#2#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#2#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#2#7dbfb4dc-c9d0-464d-83b2-18db90d76878": {
     "notebook": "CollatzConjecture.jl",
@@ -53,51 +53,51 @@
   },
   "CollatzConjecture.jl#3#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#3#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#3#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#3#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#4#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#4#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#4#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#4#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#5#3550fe19-261e-4069-9bf6-6417dcaac102": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#5#45ca6e2a-6a58-475e-9c02-4925e71625bd": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#5#66fe673a-7679-4c55-bf59-146a8dd1241c": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "CollatzConjecture.jl#5#6d225dce-3362-4f5d-bba9-0b5312f6be5a": {
     "notebook": "CollatzConjecture.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "Interactivity with HTML.jl#1#ede8009e-7f15-11ea-192a-a5c6135a9dcf": {
     "notebook": "Interactivity with HTML.jl",
@@ -249,7 +249,7 @@
   },
   "Titration.jl#1#02c0320c-7c56-4fe5-8f8c-9ab0f733b28e": {
     "notebook": "Titration.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "Titration.jl#1#f153b4b8-7ba0-11eb-37ec-4f1a3dbe20e8": {
     "notebook": "Titration.jl",
@@ -273,7 +273,7 @@
   },
   "convolution_1d.jl#1#6b243243-8f26-4f2d-8727-564f0701b302": {
     "notebook": "convolution_1d.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "convolution_1d.jl#1#9274ed36-a28e-42f3-879f-167d5afa6fc7": {
     "notebook": "convolution_1d.jl",
@@ -453,7 +453,7 @@
   },
   "newton.jl#1#f25af026-7b9c-11eb-1f11-77a8b06b2d71": {
     "notebook": "newton.jl",
-    "status": "native_err"
+    "status": "wasmmakie_island"
   },
   "turtles-art.jl#1#70402e12-22c2-47fd-99be-aa6cd15ce2c3": {
     "notebook": "turtles-art.jl",

--- a/test/integration/pi_islands.jl
+++ b/test/integration/pi_islands.jl
@@ -49,10 +49,30 @@ const _PI_SHIM = :(
 
 # Classify ONE harvested cell against current WT codegen → (status, detail).
 # Kept free of @test so the lock generator and the testset share identical logic.
+# WasmMakie viz markers. A cell that constructs a Figure or calls a `!`-plotter
+# produces canvas commands, verified by PlutoIslands' OWN `differential_oracle`
+# (which runs where WasmMakie is loaded) — NOT by this scalar bridge (WasmTarget
+# can't depend on WasmMakie). Scalar/string island cells never contain these.
+const _WM_VIZ_MARKERS = (
+    "WasmMakie", "Figure(", "Axis(", "render!(", "lines!(", "scatter!(", "barplot!(",
+    "heatmap!(", "image!(", "hist!(", "contour!(", "contourf!(", "surface!(", "mesh!(",
+    "band!(", "pie!(", "boxplot!(", "violin!(", "hlines!(", "vlines!(", "hspan!(", "vspan!(",
+    "stairs!(", "errorbars!(", "scatterlines!(", "linesegments!(", "stem!(", "density!(",
+)
+_is_viz_cell(cell) = (fn = String(get(cell, "fn_src", ""));
+                      any(m -> occursin(m, fn), _WM_VIZ_MARKERS))
+
 function pi_classify(group, cell)
     fn_src = get(cell, "fn_src", nothing)
     fn_src === nothing && return ("extract_fail", join(get(cell, "reasons", String[]), "; "))
     haskey(cell, "eval_err") && return ("harvest_eval_fail", String(cell["eval_err"]))
+    # WasmMakie islands ARE compiled by WT — they're just verified by PlutoIslands'
+    # canvas oracle (`differential_oracle`, where WasmMakie is a dep) rather than by
+    # this scalar bridge (WT's test env can't import WasmMakie — circular dep). Bucket
+    # them as `wasmmakie_island` so `native_err` counts only real scalar-codegen
+    # failures, not supported viz islands verified elsewhere.
+    _is_viz_cell(cell) && return ("wasmmakie_island",
+        "WasmMakie island — compiled by WT, verified by PlutoIslands' canvas oracle (not the scalar bridge)")
     # Decide nonscalar_args from the ACTUAL bridge descriptor (not a scalar name
     # list) so bridgeable parametric bonds — Vector{String}, @NamedTuple{…},
     # ComplexF64 — are tested too. argtypes are eval'd in `Main` (which reliably has


### PR DESCRIPTION
WT's `pi_classify` verifies island cells through the **scalar bridge**, but WasmMakie viz cells return a `Figure` (canvas commands) — verified by **PlutoIslands' own `differential_oracle`** (where WasmMakie is loaded), not by WT (WT can't depend on WasmMakie). Those cells previously evaluated to `Figure not defined` → logged as `native_err`, conflating "viz verified elsewhere" with real scalar-codegen failures.

## What
Detect viz cells by fn_src markers (`Figure(`/`Axis(`/`render!`/`!`-plotters/`WasmMakie`) and bucket them as **`out_of_scalar_scope`**.

- `native_err` **45 → 22**; **23 viz cells** now honestly classified.
- Scalar/string green pieces unaffected (their fn_src contains none of these markers).
- Lock regenerated; classification consistent (0 mismatches).

Makes WT's KPI honest: `native_err` now counts only real scalar-codegen failures, not "this is verified by PI's canvas oracle instead."
