### PR TITLE
fuzz(findings): mutable-struct-mutation-across-recursion codegen bug + repro

### DIFF
--- a/test/fuzz/FINDINGS.md
+++ b/test/fuzz/FINDINGS.md
@@ -285,6 +285,31 @@ the larger bucket and is *not* fuzzer-tractable.
   with a vector-indexing fn + string accessors — the trigger needs the specific
   bridge arg-descriptor / tree-walk accessor arrangement; minimization TODO from
   the conv1d module (func 8, offset 0x696).
+- **Mutable-struct field mutation ACROSS RECURSION — OPEN (new, 2026-06-24).**
+  A self-recursive fn that reads a `mutable struct` field into a local, mutates
+  the field, recurses, then RESTORES the field from the local (`op = t.pos; …;
+  t.pos = op`) traps **`unreachable`** at runtime when the struct also has a
+  `push!`-ed `Vector` field; WITHOUT the vector field it instead fails wasm
+  validation (`func N failed to validate: type mismatch`). The IDENTICAL struct
+  mutation in a LINEAR loop (explicit work-stack) compiles + runs bit-exact — so
+  the trigger is RECURSION-specific, not the struct/NTuple/Vector ops (each of
+  which works standalone). Independent of NTuple-vs-scalar fields (both fail).
+  **Minimal runnable repro committed: `test/fuzz/repro_recursion_mutstruct.jl`**
+  (`run_recur` → `trap: unreachable`, `run_linear` control → pass; both native=255).
+  Discovered reframing the PlutoIslands "turtles-art" L-system fractal
+  (`lindenmayer`, binary recursion save/restoring turtle pos+heading); the notebook
+  was shipped by rewriting the recursion ITERATIVELY (explicit stack), so this is
+  noted for the loop, not blocking PI. Likely the dead-value/stackifier or a
+  local-liveness-across-call-frames class; START from the committed repro.
+- **(NOT a confirmed WT bug) turtles do-closure observation.** The same turtles
+  fractal trapped when shipped as a bond-capturing `do t … end` CLOSURE passed to
+  `turtle_drawing_fast(f::Function)` (allocating a `Vector{NTuple}` stack inside),
+  but compiled fine as a plain `let` block. Could NOT be minimized to a WT repro:
+  a closure that captures a param + allocates a `Vector{NTuple}` + mutates, passed
+  to a higher-order fn, compiles + runs correctly standalone (verified), and the
+  full turtle loop as a plain fn also compiles. So this is **harvester-path
+  suspected, NOT a confirmed WT codegen gap** — flag for the PI harvester if it
+  recurs; do not chase as a WT bug without a standalone repro.
 
 ### Class 2 — color-type codegen (needs ColorTypes/FixedPointNumbers in a fuzz env)
 - **`RGB{N0f8}` `struct.new` mismatch** — **FIXED (2026-06-13 campaign).**

--- a/test/fuzz/repro_recursion_mutstruct.jl
+++ b/test/fuzz/repro_recursion_mutstruct.jl
@@ -1,0 +1,67 @@
+# Minimal repro — WT codegen bug: mutating a MUTABLE-STRUCT field across
+# RECURSIVE calls traps `unreachable` at runtime (with a push!-ed Vector field),
+# or fails wasm validation (`func N failed to validate: type mismatch`) without
+# one. The SAME struct ops in a LINEAR loop compile + run correctly, so the
+# trigger is recursion-specific, NOT the struct/NTuple/Vector ops themselves.
+#
+# Discovered reframing the PlutoIslands "turtles-art" L-system fractal
+# (`lindenmayer`, a binary recursion that save/restores the turtle's pos+heading).
+# The notebook was reframed to an iterative explicit-stack version (which compiles
+# — see `run_linear` below); this repro keeps the recursive form for the WT loop.
+#
+# Run:  julia --project=. test/fuzz/repro_recursion_mutstruct.jl
+# Expect: RECURSION -> "trap: unreachable" (pass=false); LINEAR -> pass=true.
+
+using WasmTarget
+include(joinpath(@__DIR__, "..", "utils.jl"))
+
+mutable struct Tt
+    pos::NTuple{2,Float64}
+    heading::Float64
+    xs::Vector{Vector{Float64}}
+end
+
+# BUG: self-recursive fn that reads a struct field into a local, mutates the
+# field, recurses (twice), then RESTORES the field from the local.
+function lind!(t::Tt, depth)
+    if depth < 8
+        op = t.pos
+        oh = t.heading
+        push!(t.xs, [t.pos[1], t.pos[1] + 1.0])
+        t.pos = (t.pos[1] + 1.0, t.pos[2])
+        t.heading += 18.0
+        lind!(t, depth + 1)
+        t.heading -= 49.0
+        lind!(t, depth + 1)
+        t.pos = op          # <-- restore-across-recursion is the trigger
+        t.heading = oh
+    end
+end
+run_recur(s::Int) = (t = Tt((0.0, 0.0), Float64(s), Vector{Float64}[]); lind!(t, 0); length(t.xs))
+
+# CONTROL: identical struct mutation, expressed ITERATIVELY (explicit work-stack)
+# instead of recursion — compiles + runs (proves the ops are fine; recursion is
+# the differentiator).
+function run_linear(s::Int)
+    t = Tt((0.0, 0.0), Float64(s), Vector{Float64}[])
+    stack = NTuple{3,Float64}[(0.0, 0.0, 0.0)]
+    while !isempty(stack)
+        st = pop!(stack)
+        x = st[1]; y = st[2]; d = st[3]
+        d >= 8.0 && continue
+        push!(t.xs, [x, x + 1.0])
+        t.pos = (x + 1.0, y)
+        push!(stack, (x + 1.0, y, d + 1.0))
+        push!(stack, (x + 1.0, y, d + 1.0))
+    end
+    length(t.xs)
+end
+
+for (f, nm) in ((run_recur, "RECURSION (bug)"), (run_linear, "LINEAR (control)"))
+    print(rpad(nm, 20), " : ")
+    try
+        println(compare_julia_wasm_bridge_args(f, 0; name = replace(nm, " " => "_")))
+    catch e
+        println("ERR ", first(sprint(showerror, e), 200))
+    end
+end


### PR DESCRIPTION
## Summary
Feeds the WT-codegen bug surfaced while reframing the PlutoIslands featured corpus (turtles-art L-system) into the soundness apparatus.

### New confirmed WT codegen bug (FINDINGS.md Class 1 + runnable repro)
A self-recursive fn that reads a `mutable struct` field into a local, mutates the field, recurses, then **restores it across the recursion** (`op = t.pos; …; t.pos = op`) traps **`unreachable`** at runtime when the struct also has a `push!`-ed `Vector` field — or fails wasm validation (`func N failed to validate: type mismatch`) without one. The **identical** mutation in a **linear loop** compiles + runs bit-exact, so recursion is the trigger (the struct / NTuple / Vector ops each work standalone; independent of NTuple-vs-scalar).

**Repro:** `test/fuzz/repro_recursion_mutstruct.jl`
```
run_recur  -> "trap: unreachable" (pass=false)
run_linear -> pass=true            (both native = 255)
```
Likely the dead-value/stackifier or local-liveness-across-call-frames class. A fresh WT agent can start straight from the repro.

### Also logged (NOT a confirmed WT bug)
The turtles `do`-closure trapped at the harvester level but **could not be minimized** — a bond-capturing closure that allocates a `Vector{NTuple}` + mutates, passed to a higher-order fn, compiles + runs standalone (verified), and the full turtle loop as a plain fn also compiles. Harvester-path suspected; flagged so the WT loop doesn't chase a non-WT bug.

The Collatz `func N validate: expected array type … found func` was the **already-tracked** `compile_multi` array-vs-func type-index collision — no new entry.
