### PR TITLE
feat: interactive in-browser examples + memo dep auto-discovery + faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,13 @@ jobs:
         with:
           node-version: '22'
 
+      # Prebuilt binary (seconds) instead of `cargo install wasm-tools`, which
+      # compiled wasm-tools from source on every job (~5-10 min x 6 matrix jobs,
+      # never cached). Matches what downstream.yml already uses.
       - name: Install wasm-tools
-        run: cargo install wasm-tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-tools
 
       - name: Install Binaryen (wasm-opt)
         shell: bash

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,8 @@
 [deps]
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Therapy = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
 WasmTarget = "9f3a1415-1112-405b-ae89-c61daf9872bd"
 
@@ -7,5 +10,6 @@ WasmTarget = "9f3a1415-1112-405b-ae89-c61daf9872bd"
 WasmTarget = {path = ".."}
 
 [compat]
+ForwardDiff = "0.10, 1"
 Therapy = "0.1"
 julia = "~1.12"

--- a/docs/app.jl
+++ b/docs/app.jl
@@ -17,6 +17,14 @@ end
 
 using Therapy
 
+# Loaded so WasmTarget's weakdep extensions (Statistics / LinearAlgebra /
+# ForwardDiff) activate in THIS process — the interactive examples on /examples/
+# are @island components whose create_memo bodies call these libraries, and
+# WasmTarget compiles them to WasmGC against the live overlay method table here.
+using Statistics
+using LinearAlgebra
+using ForwardDiff
+
 cd(@__DIR__)
 
 # =============================================================================

--- a/docs/src/components/ExampleAutodiff.jl
+++ b/docs/src/components/ExampleAutodiff.jl
@@ -1,0 +1,41 @@
+# ── ExampleAutodiff (SciML / ForwardDiff) ──
+# The headline interactive example: drag the slider and the DERIVATIVE is
+# recomputed by REAL forward-mode automatic differentiation (ForwardDiff dual
+# numbers), compiled to WasmGC by WasmTarget, running entirely in the browser.
+# Not a finite difference, not a precomputed table — exact AD, live.
+#
+# `using ForwardDiff` here so the name resolves in the component module
+# (Main.TherapyApp) both when the island is run natively to discover its
+# structure AND when its memo is compiled to wasm (the WasmTargetForwardDiffExt
+# overlays are already active in this process).
+using ForwardDiff
+
+@island function ExampleAutodiff(; x0::Float64 = 1.2)
+    x, set_x = create_signal(x0)
+
+    # rounded views for display (floor-based, no Printf needed in-wasm)
+    xr  = create_memo(() -> floor(x() * 100.0 + 0.5) / 100.0)
+    fx  = create_memo(() -> (t = x(); floor((t^3 - 2.0 * t) * 1000.0 + 0.5) / 1000.0))
+    # f'(x) by REAL forward-mode autodiff — this call runs ForwardDiff in wasm
+    dfx = create_memo(() -> floor(ForwardDiff.derivative(t -> t^3 - 2.0 * t, x()) * 1000.0 + 0.5) / 1000.0)
+
+    return Div(:class => "space-y-4",
+        Div(:class => "flex items-baseline justify-between",
+            Span(:class => "text-sm font-mono text-warm-600 dark:text-warm-400", "x = ", Span(:class => "text-accent-500", xr)),
+            Span(:class => "text-xs text-warm-500", "drag →")
+        ),
+        Input(:type => "range", :min => "-2", :max => "2", :step => "0.01", :value => x0,
+            :on_input => set_x,
+            :class => "w-full accent-accent-500 cursor-pointer"),
+        Div(:class => "grid grid-cols-2 gap-3 pt-1",
+            Div(:class => "rounded-lg border border-warm-200 dark:border-warm-800 p-4 bg-warm-100/50 dark:bg-warm-900/50",
+                P(:class => "text-xs uppercase tracking-wide text-warm-500 mb-1", "f(x) = x³ − 2x"),
+                P(:class => "text-2xl font-mono text-warm-900 dark:text-warm-100", fx)
+            ),
+            Div(:class => "rounded-lg border border-accent-200 dark:border-accent-900 p-4 bg-accent-50/60 dark:bg-accent-950/30",
+                P(:class => "text-xs uppercase tracking-wide text-accent-600 dark:text-accent-400 mb-1", "f′(x) — ForwardDiff"),
+                P(:class => "text-2xl font-mono text-accent-700 dark:text-accent-300", dfx)
+            )
+        )
+    )
+end

--- a/docs/src/components/ExampleLinalg.jl
+++ b/docs/src/components/ExampleLinalg.jl
@@ -1,0 +1,37 @@
+# ── ExampleLinalg (stdlib / LinearAlgebra) ──
+# Four sliders are the entries of a 2x2 matrix; its (Frobenius) norm is computed
+# by the REAL LinearAlgebra stdlib, compiled to wasm. Each entry shows its live
+# value so ‖A‖ = sqrt(a²+b²+c²+d²) can be checked by hand.
+using LinearAlgebra
+
+@island function ExampleLinalg(; a0::Float64 = 2.0, b0::Float64 = 1.0, c0::Float64 = 1.0, d0::Float64 = 3.0)
+    a, set_a = create_signal(a0)
+    b, set_b = create_signal(b0)
+    c, set_c = create_signal(c0)
+    d, set_d = create_signal(d0)
+
+    ar = create_memo(() -> floor(a() * 10.0 + 0.5) / 10.0)
+    br = create_memo(() -> floor(b() * 10.0 + 0.5) / 10.0)
+    cr = create_memo(() -> floor(c() * 10.0 + 0.5) / 10.0)
+    dr = create_memo(() -> floor(d() * 10.0 + 0.5) / 10.0)
+
+    nrm = create_memo(() -> floor(LinearAlgebra.norm([a() b(); c() d()]) * 1000.0 + 0.5) / 1000.0)
+
+    cell(label, valmemo, val0, set) = Div(:class => "space-y-1",
+        Span(:class => "text-xs font-mono text-warm-600 dark:text-warm-400",
+            label, " = ", Span(:class => "text-accent-500", valmemo)),
+        Input(:type => "range", :min => "-4", :max => "4", :step => "0.1", :value => val0,
+            :on_input => set, :class => "w-full accent-accent-500 cursor-pointer"))
+
+    return Div(:class => "space-y-4",
+        # 2x2 grid of labelled sliders — reads like the matrix entries
+        Div(:class => "grid grid-cols-2 gap-x-8 gap-y-4",
+            cell("a", ar, a0, set_a), cell("b", br, b0, set_b),
+            cell("c", cr, c0, set_c), cell("d", dr, d0, set_d)
+        ),
+        Div(:class => "rounded-lg border border-warm-200 dark:border-warm-800 p-4 bg-warm-100/50 dark:bg-warm-900/50 text-center",
+            P(:class => "text-xs uppercase tracking-wide text-warm-500 mb-1", "‖A‖ = norm of the 2×2 matrix"),
+            P(:class => "text-2xl font-mono text-warm-900 dark:text-warm-100", nrm)
+        )
+    )
+end

--- a/docs/src/components/ExampleMath.jl
+++ b/docs/src/components/ExampleMath.jl
@@ -1,0 +1,25 @@
+# ── ExampleMath (Base) ──
+# Plain Base math compiled to WasmGC: transcendentals (sin, exp) evaluated live
+# as you drag the slider. No stdlib, no overlays — just Julia's own `sin`/`exp`
+# lowered to wasm.
+
+@island function ExampleMath(; x0::Float64 = 1.5)
+    x, set_x = create_signal(x0)
+    xr = create_memo(() -> floor(x() * 100.0 + 0.5) / 100.0)
+    # f(x) = sin(x) * exp(-x/3) — a damped oscillation, Base transcendentals
+    y  = create_memo(() -> floor(sin(x()) * exp(-x() / 3.0) * 1000.0 + 0.5) / 1000.0)
+
+    return Div(:class => "space-y-4",
+        Div(:class => "flex items-baseline justify-between",
+            Span(:class => "text-sm font-mono text-warm-600 dark:text-warm-400", "x = ", Span(:class => "text-accent-500", xr)),
+            Span(:class => "text-xs text-warm-500", "drag →")
+        ),
+        Input(:type => "range", :min => "0", :max => "12", :step => "0.05", :value => x0,
+            :on_input => set_x,
+            :class => "w-full accent-accent-500 cursor-pointer"),
+        Div(:class => "rounded-lg border border-warm-200 dark:border-warm-800 p-4 bg-warm-100/50 dark:bg-warm-900/50",
+            P(:class => "text-xs uppercase tracking-wide text-warm-500 mb-1", "f(x) = sin(x) · exp(−x/3)"),
+            P(:class => "text-2xl font-mono text-warm-900 dark:text-warm-100", y)
+        )
+    )
+end

--- a/docs/src/components/ExampleStats.jl
+++ b/docs/src/components/ExampleStats.jl
@@ -1,0 +1,43 @@
+# ── ExampleStats (stdlib / Statistics) ──
+# Three sliders feed a Vector{Float64}; mean and standard deviation are computed
+# by the REAL Statistics stdlib, compiled to wasm. Each slider shows its live
+# value so the mean/std can be checked by hand.
+using Statistics
+
+@island function ExampleStats(; a0::Float64 = 3.0, b0::Float64 = 7.0, c0::Float64 = 5.0)
+    a, set_a = create_signal(a0)
+    b, set_b = create_signal(b0)
+    c, set_c = create_signal(c0)
+
+    # rounded live values for the slider labels
+    ar = create_memo(() -> floor(a() * 10.0 + 0.5) / 10.0)
+    br = create_memo(() -> floor(b() * 10.0 + 0.5) / 10.0)
+    cr = create_memo(() -> floor(c() * 10.0 + 0.5) / 10.0)
+
+    m  = create_memo(() -> floor(Statistics.mean([a(), b(), c()]) * 1000.0 + 0.5) / 1000.0)
+    sd = create_memo(() -> floor(Statistics.std([a(), b(), c()]) * 1000.0 + 0.5) / 1000.0)
+
+    row(label, valmemo, val0, set) = Div(:class => "flex items-center gap-4",
+        Span(:class => "w-16 text-sm font-mono text-warm-600 dark:text-warm-400",
+            label, " = ", Span(:class => "text-accent-500", valmemo)),
+        Input(:type => "range", :min => "0", :max => "10", :step => "0.1", :value => val0,
+            :on_input => set, :class => "flex-1 accent-accent-500 cursor-pointer"))
+
+    return Div(:class => "space-y-4",
+        Div(:class => "space-y-2",
+            row("a", ar, a0, set_a),
+            row("b", br, b0, set_b),
+            row("c", cr, c0, set_c)
+        ),
+        Div(:class => "grid grid-cols-2 gap-3 pt-1",
+            Div(:class => "rounded-lg border border-warm-200 dark:border-warm-800 p-4 bg-warm-100/50 dark:bg-warm-900/50",
+                P(:class => "text-xs uppercase tracking-wide text-warm-500 mb-1", "mean(a, b, c)"),
+                P(:class => "text-2xl font-mono text-warm-900 dark:text-warm-100", m)
+            ),
+            Div(:class => "rounded-lg border border-warm-200 dark:border-warm-800 p-4 bg-warm-100/50 dark:bg-warm-900/50",
+                P(:class => "text-xs uppercase tracking-wide text-warm-500 mb-1", "std(a, b, c)"),
+                P(:class => "text-2xl font-mono text-warm-900 dark:text-warm-100", sd)
+            )
+        )
+    )
+end

--- a/docs/src/components/Layout.jl
+++ b/docs/src/components/Layout.jl
@@ -27,6 +27,11 @@ function Layout(content)
                         active_class = "text-accent-600 dark:text-accent-400 font-medium",
                         inactive_class = "text-warm-600 dark:text-warm-400 hover:text-accent-600 dark:hover:text-accent-400"
                     ),
+                    NavLink("/WasmTarget.jl/examples/", "Examples";
+                        class = "text-sm transition-colors no-underline",
+                        active_class = "text-accent-600 dark:text-accent-400 font-medium",
+                        inactive_class = "text-warm-600 dark:text-warm-400 hover:text-accent-600 dark:hover:text-accent-400"
+                    ),
                     NavLink("/WasmTarget.jl/manual/", "Manual";
                         class = "text-sm transition-colors no-underline",
                         active_class = "text-accent-600 dark:text-accent-400 font-medium",

--- a/docs/src/routes/examples/index.jl
+++ b/docs/src/routes/examples/index.jl
@@ -1,0 +1,70 @@
+() -> begin
+    code_block = "bg-warm-900 dark:bg-warm-950 text-warm-200 p-4 rounded-lg text-sm font-mono overflow-x-auto border border-warm-800"
+
+    # one example = the source that MAKES it (top) + the live wasm widget (bottom)
+    example(tag, title, desc, code, widget) = Div(:class => "space-y-3",
+        Div(:class => "flex items-center gap-3",
+            Span(:class => "text-xs font-mono px-2 py-0.5 rounded bg-accent-100 dark:bg-accent-900/50 text-accent-700 dark:text-accent-300", tag),
+            H2(:class => "text-xl font-semibold text-warm-900 dark:text-warm-100", title)
+        ),
+        P(:class => "text-warm-600 dark:text-warm-400 text-sm leading-relaxed", desc),
+        Pre(:class => code_block, Code(:class => "language-julia", code)),
+        Div(:class => "rounded-xl border border-warm-200 dark:border-warm-800 p-6 bg-warm-50 dark:bg-warm-900/30", widget)
+    )
+
+    Div(:class => "space-y-12 max-w-3xl mx-auto",
+        Div(:class => "space-y-3",
+            H1(:class => "text-3xl font-serif font-bold text-warm-900 dark:text-warm-100", "Interactive Examples"),
+            P(:class => "text-warm-600 dark:text-warm-400 leading-relaxed",
+                "Every widget below is a ",
+                A(:href => "https://github.com/GroupTherapyOrg/Therapy.jl", :target => "_blank", :class => "text-accent-500 underline", "Therapy.jl"),
+                " island whose reactive body — the ", Code(:class => "text-accent-500 font-mono text-xs", "create_memo"),
+                " calls you see in the code — was compiled to WasmGC by WasmTarget and is running ",
+                Span(:class => "font-semibold text-warm-800 dark:text-warm-200", "live in your browser"), ". ",
+                "Move a slider and the Julia recomputes in wasm. No server, no Julia runtime — just the ",
+                "compiled function reacting to a signal."
+            )
+        ),
+
+        example("Base",
+            "Transcendentals in wasm",
+            "The plainest case: Julia's own sin and exp, lowered straight to WasmGC. Drag x to evaluate a damped oscillation live — no stdlib, no overlays.",
+            """x, set_x = create_signal(1.5)
+
+# Base sin/exp, compiled to wasm:
+y = create_memo(() ->
+    sin(x()) * exp(-x() / 3))""",
+            ExampleMath()),
+
+        example("stdlib · Statistics",
+            "mean / std of a live vector",
+            "Three sliders become a Vector{Float64}; the real Statistics stdlib reduces it. Building the vector and the reductions all run in wasm.",
+            """a, set_a = create_signal(3.0)
+b, set_b = create_signal(7.0)
+c, set_c = create_signal(5.0)
+
+m  = create_memo(() -> mean([a(), b(), c()]))
+sd = create_memo(() -> std([a(), b(), c()]))""",
+            ExampleStats()),
+
+        example("stdlib · LinearAlgebra",
+            "Norm of a 2×2 matrix",
+            "Four sliders are the entries of a matrix. LinearAlgebra.norm runs on the assembled 2×2 — matrix construction and the (Frobenius) norm both in wasm.",
+            """# four signals → a 2x2 matrix → its norm
+nrm = create_memo(() ->
+    norm([a() b()
+          c() d()]))""",
+            ExampleLinalg()),
+
+        example("SciML · ForwardDiff",
+            "Automatic differentiation, live",
+            "The headline. Drag x and the right-hand value is f′(x) computed by real forward-mode autodiff — ForwardDiff dual numbers, compiled to wasm. It is exact, not a finite difference: for f(x) = x³ − 2x you can check f′(x) = 3x² − 2.",
+            """x, set_x = create_signal(1.2)
+
+# f'(x) by REAL forward-mode autodiff — ForwardDiff
+# dual numbers, compiled to WasmGC, in your browser:
+dfx = create_memo(() ->
+    ForwardDiff.derivative(t -> t^3 - 2t, x()))""",
+            ExampleAutodiff())
+    )
+end

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -2345,11 +2345,17 @@ function compile_closure_body(
     # For void handlers (like Therapy.jl event handlers), override return type
     return_type = void_return ? Nothing : inferred_return_type
 
-    # If func_registry provided, auto-discover dependencies from the closure's IR
-    # and compile them into the existing module (same as compile_module does)
-    if func_registry !== nothing
-        _autodiscover_closure_deps!(closure, code_info, mod, type_registry, func_registry)
-    end
+    # Auto-discover and compile the closure's dependencies (sin/exp/sqrt/det,
+    # stdlib reductions, …) into the module — the same transitive discovery
+    # compile_module does. When the caller supplies no registry (e.g. Therapy's
+    # memo compilation, _compile_memo_wasm), create one locally: without it,
+    # EVERY non-inlined call in the closure body stubs to `unreachable`, so a
+    # memo could only use functions Julia happened to inline (plain arithmetic),
+    # and any `sin`/`std`/`det`/… silently trapped at runtime. Discovered deps
+    # are appended to the module + registered so the body's call sites resolve.
+    # Callers that already pass a registry are unaffected.
+    effective_func_registry = func_registry === nothing ? FunctionRegistry() : func_registry
+    _autodiscover_closure_deps!(closure, code_info, mod, type_registry, effective_func_registry)
 
     # Check if the closure captures non-signal fields (e.g., Vector{String} props).
     # If so, pass the closure struct as parameter 0 (Leptos/dart2wasm pattern):
@@ -2381,7 +2387,7 @@ function compile_closure_body(
         return_type,
         mod,
         type_registry;
-        func_registry = func_registry,
+        func_registry = effective_func_registry,
         is_compiled_closure = has_non_signal_captures,
         captured_signal_fields = captured_signal_fields,
         dom_bindings = dom_bindings,


### PR DESCRIPTION
## Interactive Examples page (docs)
Adds `/examples/` — four live widgets spanning **Base -> stdlib -> SciML**, each showing the source that makes it. Every widget is a Therapy `@island` whose `create_memo` body is compiled to WasmGC by WasmTarget and runs **in the browser**, driven by slider signals (with live value labels so results are checkable by hand):

| Tag | Demo |
|---|---|
| Base | `sin(x)*exp(-x/3)` |
| stdlib · Statistics | `mean` / `std` of a live vector |
| stdlib · LinearAlgebra | `norm` of a 2x2 matrix |
| SciML · ForwardDiff | `f'(x)` by real forward-mode autodiff |

## Core fix: memo dependency auto-discovery (`src/codegen/compile.jl`)
`compile_closure_body` now auto-discovers + compiles the closure's dependencies even when the caller passes **no** `func_registry`. Therapy's memo compiler calls it without one, and the old `if func_registry !== nothing` guard **skipped dependency discovery entirely** for that path — so any non-inlined call in a memo (`sin`, `exp`, `sqrt`, `std`, `norm`, …) had no compile target and was emitted as an `unreachable` **trap stub**. Memos could only use functions Julia happened to inline; anything else silently trapped at hydration. Now a local registry is created when none is supplied, so the same transitive discovery `compile_module` does runs for memos too.

**Strictly additive**: memos that already worked (fully inlined) discover no deps and are unchanged; callers that pass a registry (event handlers) are unaffected. The downstream suites (WasmMakie / Therapy / PlutoIslands) compile islands through this path and gate the change.

> Note: `det` (LU factorization) is the one function still too heavy for the closure path (produces an invalid module) — the LinearAlgebra example uses `norm` instead; `det`'s closure-path codegen is a separate follow-up.

## CI speedup (`.github/workflows/ci.yml`)
Install wasm-tools from a **prebuilt binary** via `taiki-e/install-action` (seconds) instead of `cargo install wasm-tools`, which compiled it from source on every job (~5-10 min x 6 matrix jobs, never cached). Matches what `downstream.yml` already uses.