### PR TITLE
fix(codegen): scoped type-level concrete-eval fold — close the cor cluster

### DIFF
--- a/src/codegen/interpreter.jl
+++ b/src/codegen/interpreter.jl
@@ -2283,9 +2283,49 @@ CC.codegen_cache(interp::WasmInterpreter) = interp.codegen
 # IR shapes). Reverted to the blanket `:none`; the cor root cause + the type-level
 # fold approach are recorded in test/fuzz/failures/3fd2f07bfc5c.md — re-attempt only
 # with a Julia 1.13 environment available to verify against.
+# A CURATED set of pure TYPE-LEVEL functions that concrete-eval may fold. They
+# produce Types (or values trivially derived from Types) that WT fundamentally
+# cannot lower as runtime values — so folding them is MANDATORY, not an
+# optimization. They have no value-level overlays to bypass, and strings never
+# call them, so re-enabling eval for ONLY these can't perturb WT's
+# version-specific string IR (the failure mode that reverted the prior blanket
+# `all-Type-args` attempts — see test/fuzz/failures/3fd2f07bfc5c.md). This is the
+# `cor`/SparseArrays insight generalized: route the runtime type-machinery to its
+# known compile-time constant, scoped surgically. MUST be total (runs during
+# inference of arbitrary code).
+function _is_typelevel_foldable(@nospecialize(f))::Bool
+    f === Core.apply_type && return true
+    (isdefined(Core, :_compute_sparams) && f === Core._compute_sparams) && return true
+    (isdefined(Core, :_svec_ref)        && f === Core._svec_ref)        && return true
+    (isdefined(Core, :_typevar)         && f === Core._typevar)         && return true
+    f === Base.nonmissingtype && return true
+    f === Base.promote_type   && return true
+    (isdefined(Base, :typesplit) && f === Base.typesplit) && return true
+    f === Base.eltype && return true
+    # float/one fold only on a Type arg — concrete-eval fires ONLY on constant
+    # args, so the value forms (one(::Float64)) never reach the fold here.
+    f === Base.float && return true
+    f === Base.one   && return true
+    # SciML in-place detection (ODEProblem/ODEFunction): a Bool from method arity,
+    # feeding apply_type. Match `isinplace` AND its kwarg body `#isinplace#NN`.
+    # `nameof` throws for some callables (Base.BottomRF) — guard it.
+    if f isa Function
+        nm = try string(nameof(f)) catch; "" end
+        (startswith(nm, "isinplace") || startswith(nm, "#isinplace#")) && return true
+    end
+    return false
+end
+
 function CC.concrete_eval_eligible(interp::WasmInterpreter,
         @nospecialize(f), result::CC.MethodCallResult, arginfo::CC.ArgInfo,
         sv::Union{CC.InferenceState, CC.IRInterpretationState})
+    # Delegate to the normal effect-based eligibility ONLY for whitelisted pure
+    # type-level functions; everything else stays disabled (overlays win, and
+    # value-level/string codegen is byte-for-byte unchanged).
+    if _is_typelevel_foldable(f)
+        return @invoke CC.concrete_eval_eligible(interp::CC.AbstractInterpreter,
+                                                 f, result, arginfo, sv)
+    end
     return :none
 end
 

--- a/test/fuzz/FINDINGS.md
+++ b/test/fuzz/FINDINGS.md
@@ -932,3 +932,35 @@ OUT-OF-SCOPE: the `GradientConfig`/`JacobianConfig`/`HessianConfig`/`Chunk`
 preallocation API (chunk-size tuning — the cyclic-`Method` `@generated` seeder;
 unnecessary, the standard API yields the same results). Future: nested/higher-order
 beyond Hessian; `Dual` over non-Float64 value types at the bridge boundary.
+
+## Type-level concrete-eval fold (core, 2026-06-26) — closes the cor cluster
+WT's `WasmInterpreter` disables concrete-eval globally (`concrete_eval_eligible
+→ :none`) so overlays aren't bypassed. Side effect: pure TYPE-LEVEL calls (e.g.
+`one(float(nonmissingtype(eltype)))` in `Statistics.cor`) stay as runtime
+`dynamic` dispatch on Type VALUES that WT can't lower → `unreachable` stub /
+validation error (the `cor` cluster, gap 3fd2f07bfc5c — 1-arg `cor` was left
+unfixed because it genuinely needs the type-level path, not a value reroute).
+
+FIX (`src/codegen/interpreter.jl`): re-enable concrete-eval for a CURATED
+whitelist of pure type-level functions ONLY — `Core.apply_type`/`_compute_sparams`/
+`_svec_ref`/`_typevar`, `nonmissingtype`/`promote_type`/`typesplit`/`eltype`,
+`float`/`one` (which fold only on a Type arg since concrete-eval fires only on
+const args), and `isinplace`. These produce Types WT fundamentally cannot lower
+as runtime values (so folding is MANDATORY, not an optimization), have no
+value-level overlays to bypass, and strings never call them — so re-enabling eval
+for ONLY these can't perturb WT's version-specific string IR. That string-IR
+perturbation is exactly what reverted the prior TWO blanket `all-Type-args`
+attempts (see the doc); the surgical whitelist is the difference. Delegates to the
+normal effect-based eligibility for the whitelisted fns (keeps `:none` for all
+else), so overlays still win and value/string codegen is byte-identical.
+
+Verified: 1-arg `cor` (the open gap) + 2-arg `cor` now differential (wasm==native,
+test/fuzz/stats_diff.jl "cor (type-level concrete-eval fold)"); full Pkg.test green
+on 1.12; every string op that broke the prior attempts (repeat/lpad/rpad/chop/
+split/string/string-chains) still compiles. ⚠ MUST clear the full 1.12+1.13 CI
+matrix before trusting (the prior reverts passed 1.12-local but broke 1.13-rc1).
+
+NB this does NOT reach the SciML/SimpleDiffEq `ODEProblem` construction: its
+`isinplace` is kwarg METHOD-ARITY reflection whose args aren't const, so
+concrete-eval can't fold it even when forced. That needs a concrete-construction
+ext overlay (sparse-style) — a separate effort.

--- a/test/fuzz/stats_diff.jl
+++ b/test/fuzz/stats_diff.jl
@@ -11,7 +11,7 @@ using Random
 using Test
 
 const _ST_B = WasmTarget.Bridge
-const STATS_VERIFIED = Set{Symbol}([:mean!, :median!, :quantile!])
+const STATS_VERIFIED = Set{Symbol}([:mean!, :median!, :quantile!, :cor])
 
 function _st_diff(fn, argTs::Tuple, inputs::Vector, rettype)
     res = bridge_run_args(fn, argTs, inputs; rettype = rettype)
@@ -31,6 +31,12 @@ _st_rm(rng, r, c) = Float64[2rand(rng) - 1 for _ in 1:r, _ in 1:c]
 _st_medb(v)    = median!(v)
 _st_quab(v, p) = quantile!(v, p)
 _st_meanb(r, A) = mean!(r, A)
+# cor exercises the type-level concrete-eval fold (src/codegen/interpreter.jl):
+# its result type is `one(float(nonmissingtype(eltype)))` — a pure type-level
+# chain that WT could not lower until the fold. 1-arg autocorrelation = 1.0 hits
+# the chain directly; 2-arg uses the corm reroute (Statistics ext) for the value.
+_st_cor1(v)    = cor(v)
+_st_cor2(a, b) = cor(a, b)
 
 function run_stats_tests(; reps::Int = 40)
     FuzzHarness.NODE_OK || (@test_skip true; return)
@@ -45,5 +51,11 @@ function run_stats_tests(; reps::Int = 40)
         @test _st_diff(_st_meanb, (Vector{Float64}, Matrix{Float64}),
                        [ (m = rand(rng, 2:4); n = rand(rng, 2:5); (zeros(m), _st_rm(rng, m, n))) for _ in 1:reps ],
                        Vector{Float64})
+    end
+    @testset "cor (type-level concrete-eval fold)" begin
+        @test _st_diff(_st_cor1, (Vector{Float64},),
+                       [ (_st_rv(rng, rand(rng, 3:7)),) for _ in 1:reps ], Float64)  # 1-arg → fold
+        @test _st_diff(_st_cor2, (Vector{Float64}, Vector{Float64}),
+                       [ (n = rand(rng, 3:7); (_st_rv(rng, n), _st_rv(rng, n))) for _ in 1:reps ], Float64)  # 2-arg
     end
 end


### PR DESCRIPTION
## What
Re-enable concrete-eval for a **curated whitelist of pure type-level functions only** (`apply_type`/sparams/svec/typevar, `nonmissingtype`/`promote_type`/`typesplit`/`eltype`, `float`/`one`-on-Type, `isinplace`), delegating to the normal effect-based eligibility for *just* those and keeping `:none` for everything else.

## Why
WT disables concrete-eval globally so overlays aren't bypassed. Side effect: pure type-level chains like `Statistics.cor`'s `one(float(nonmissingtype(eltype)))` stay as runtime `dynamic` dispatch on **Type values** WT can't lower → `unreachable` stub (the `cor` cluster; **1-arg `cor` was the deliberately-unfixed gap** since it needs the type-level path, not a value reroute). These calls *must* fold — there's no runtime representation of a Type.

## Why it's safe where the prior attempts weren't
The prior **two** `all-Type-args` attempts closed cor on 1.12 but **regressed 1.13 string codegen** (concrete-eval perturbs WT's version-specific string IR) and were reverted (`failures/3fd2f07bfc5c.md`). The fix here is **surgically scoped**: the whitelisted fns produce Types, have no value-level overlays, and **strings never call them** — so string IR can't be perturbed.

## Verification
- 1-arg + 2-arg `cor` now **differential** (wasm==native) — `test/fuzz/stats_diff.jl` "cor (type-level concrete-eval fold)".
- Full `Pkg.test` **green on 1.12**.
- Every string op that broke the prior attempts (`repeat`/`lpad`/`rpad`/`chop`/`split`/`string`/chains) still compiles.

⚠ **Do not merge until the full 1.12 + 1.13 CI matrix is green** — the prior reverts passed 1.12-local but broke 1.13. This PR exists to verify exactly that on CI.

Foundation for the upcoming SciMLBase + SimpleDiffEq integration (which additionally needs a concrete-construction ext overlay — separate effort).