### PR TITLE
fix(ci): docs build — update the cached General registry

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,9 @@ jobs:
           julia --project=docs -e '
             using Pkg
             Pkg.Registry.add("General")
+            # add() is a NO-OP when the actions cache already holds a General clone —
+            # update() is what actually pulls newly registered packages (WasmMakie).
+            Pkg.Registry.update()
             Pkg.resolve()
             Pkg.instantiate()
           '


### PR DESCRIPTION
Registry.add is a no-op against the cached clone; update() actually pulls WasmMakie's registration. Docs builds have failed since v0.4.0 with "expected package WasmMakie to be registered".
