### PR TITLE
feat: caller-facing diagnostics ledger (diagnostics_sink + WasmCompileError.all)

### DIFF
--- a/src/WasmTarget.jl
+++ b/src/WasmTarget.jl
@@ -104,12 +104,22 @@ Set `optimize=true` for size-optimized output (default `-Os` like dart2wasm),
 `optimize=:speed` for `-O3`, or `optimize=:debug` for `-O1` without `--traps-never-happen`.
 """
 function compile(f, arg_types::Tuple; optimize=false, optimize_ir::Bool=true,
-                 strict::Bool=true, validate::Bool=_wt_default_validate())::Vector{UInt8}
+                 strict::Bool=true, validate::Bool=_wt_default_validate(),
+                 diagnostics_sink::Union{Nothing,Vector{WasmDiagnostic}}=nothing)::Vector{UInt8}
     # Get function name for export
     func_name = string(nameof(f))
 
-    # Compile to WasmModule (strict=true raises WasmCompileError on unsupported constructs)
-    mod = compile_function(f, arg_types, func_name; optimize_ir=optimize_ir, strict=strict)
+    # Caller-facing diagnostics ledger: mirror every recorded WasmDiagnostic (fatal AND
+    # non-fatal downgraded dependency stubs) into the caller's vector. On WasmCompileError
+    # the same ledger also rides the exception (`err.all`).
+    _prev_sink = DIAGNOSTICS_SINK[]
+    diagnostics_sink !== nothing && (DIAGNOSTICS_SINK[] = diagnostics_sink)
+    mod = try
+        # Compile to WasmModule (strict=true raises WasmCompileError on unsupported constructs)
+        compile_function(f, arg_types, func_name; optimize_ir=optimize_ir, strict=strict)
+    finally
+        DIAGNOSTICS_SINK[] = _prev_sink
+    end
 
     # Serialize to bytes
     bytes = to_bytes(mod)
@@ -150,10 +160,17 @@ Functions can call each other within the module.
 function compile_multi(functions::Vector; optimize=false, stub_names::Set{String}=Set{String}(),
                        return_registries::Bool=false, optimize_ir::Bool=true,
                        register_ir_types::Bool=false, strict::Bool=true, validate::Bool=_wt_default_validate(),
-                       discovery::Symbol=:trim)
-    result = compile_module(functions; stub_names=stub_names, return_registries=return_registries,
-                           optimize_ir=optimize_ir, register_ir_types=register_ir_types, strict=strict,
-                           discovery=discovery)
+                       discovery::Symbol=:trim,
+                       diagnostics_sink::Union{Nothing,Vector{WasmDiagnostic}}=nothing)
+    _prev_sink = DIAGNOSTICS_SINK[]
+    diagnostics_sink !== nothing && (DIAGNOSTICS_SINK[] = diagnostics_sink)
+    result = try
+        compile_module(functions; stub_names=stub_names, return_registries=return_registries,
+                       optimize_ir=optimize_ir, register_ir_types=register_ir_types, strict=strict,
+                       discovery=discovery)
+    finally
+        DIAGNOSTICS_SINK[] = _prev_sink
+    end
     if return_registries
         mod, type_registry, func_registry, dispatch_registry = result
         bytes = to_bytes(mod)

--- a/src/codegen/diagnostics.jl
+++ b/src/codegen/diagnostics.jl
@@ -50,7 +50,9 @@ Carries the [`WasmDiagnostic`](@ref) so callers can inspect `.diag`.
 """
 struct WasmCompileError <: Exception
     diag::WasmDiagnostic
+    all::Vector{WasmDiagnostic}   # every diagnostic recorded before the fatal one (the full ledger)
 end
+WasmCompileError(diag::WasmDiagnostic) = WasmCompileError(diag, WasmDiagnostic[diag])
 
 function Base.showerror(io::IO, e::WasmCompileError)
     d = e.diag
@@ -147,6 +149,17 @@ end
 _paranoid_stubs() = get(ENV, "WT_PARANOID_STUBS", "0") != "0"
 
 """
+    DIAGNOSTICS_SINK
+
+When set (see `compile(...; diagnostics_sink=...)`), every `WasmDiagnostic` recorded by any
+compilation context — including non-fatal downgraded dependency stubs — is mirrored here.
+This is the caller-facing ledger: tools like PlutoIslands read it to explain *why* a
+compilation degraded, with source attribution per diagnostic.
+"""
+const DIAGNOSTICS_SINK = Base.RefValue{Union{Nothing,Vector{WasmDiagnostic}}}(nothing)
+
+
+"""
     record_unsupported!(ctx, kind, construct; idx=0, detail=nothing, soundness_fatal=(kind===:value_stub)) -> Nothing
 
 Single funnel for "codegen cannot fully translate this". Always records a
@@ -174,6 +187,7 @@ function record_unsupported!(ctx, kind::Symbol, construct::AbstractString;
     diag = WasmDiagnostic(kind, _ctx_func_name(ctx), String(construct),
                           idx > 0 ? julia_loc(ctx, idx) : nothing, detail)
     push!(ctx.diagnostics, diag)
+    DIAGNOSTICS_SINK[] !== nothing && push!(DIAGNOSTICS_SINK[]::Vector{WasmDiagnostic}, diag)
     # P5-trim: the closed-world collection is MORE complete than legacy
     # discovery — it includes error-formatting dead paths (show/print
     # machinery) the whitelist never compiled. On DISCOVERED (non-entry)
@@ -200,7 +214,8 @@ function record_unsupported!(ctx, kind::Symbol, construct::AbstractString;
         end
     end
     if _fatal
-        throw(WasmCompileError(diag))
+        _sink = DIAGNOSTICS_SINK[]
+        throw(WasmCompileError(diag, _sink === nothing ? WasmDiagnostic[diag] : copy(_sink)))
     else
         @debug "WasmTarget stub: $diag"
     end

--- a/test/diagnostics_sink.jl
+++ b/test/diagnostics_sink.jl
@@ -1,0 +1,32 @@
+# The caller-facing diagnostics ledger (compile(...; diagnostics_sink=...)) — the surface
+# PlutoIslands' failure cards read. Contract: fatal errors carry the FULL ledger on
+# `err.all`; the sink mirrors every recorded diagnostic; the Ref is always restored.
+@testset "diagnostics sink (caller-facing ledger)" begin
+    _ds_bad(x::Any) = Int64(x) + 1          # unresolved dynamic call on the entry
+    sink = WasmTarget.WasmDiagnostic[]
+    err = try
+        WasmTarget.compile(_ds_bad, (Any,); diagnostics_sink=sink)
+        nothing
+    catch e
+        e
+    end
+    @test err isa WasmTarget.WasmCompileError
+    @test !isempty(err.all)
+    @test err.diag in err.all
+    @test !isempty(sink)
+    @test err.diag.kind === :unsupported_method
+    @test occursin("dynamic", err.diag.construct)
+    @test WasmTarget.DIAGNOSTICS_SINK[] === nothing       # restored after the call
+
+    # success path: no worries recorded, sink untouched but valid
+    _ds_good(x::Int64) = x + 1
+    sink2 = WasmTarget.WasmDiagnostic[]
+    bytes = WasmTarget.compile(_ds_good, (Int64,); diagnostics_sink=sink2)
+    @test !isempty(bytes)
+    @test WasmTarget.DIAGNOSTICS_SINK[] === nothing
+
+    # back-compat: 1-arg WasmCompileError constructor still works
+    d = WasmTarget.WasmDiagnostic(:unsupported_method, "f", "x", nothing, nothing)
+    e1 = WasmTarget.WasmCompileError(d)
+    @test e1.all == [d]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,7 @@ using Dates: Dates, @dateformat_str
 # Package-level QA runs first so structural failures surface
 # before the ~hour-long codegen suite spins up. (Shard 0 only — it's process-wide.)
 _wt_shard0() && include("test_aqua.jl")
+_wt_shard0() && include("diagnostics_sink.jl")
 
 include("utils.jl")
 include(joinpath(@__DIR__, "integration", "pi_islands.jl"))  # PlutoIslands island fixtures


### PR DESCRIPTION
Exposes the full M5 diagnostics ledger to callers: `compile(...; diagnostics_sink=vec)` mirrors every recorded `WasmDiagnostic`, and `WasmCompileError.all` carries the ledger on throw. Powers PlutoIslands' new wasm-failure diagnostic cards (bound-dependents + exact source attribution).
