### PR TITLE
parity: march 5 — the census queue to its floor (closed-world classIds, checked casts, universal wrap, interning)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   test:
+    # a hung worker must SELF-KILL, not sit on GitHub's 6-hour default —
+    # the normal lane is ~30-45 min; 75 is generous headroom (2026-07-05:
+    # a wedged Windows run sat 3h19m before manual intervention)
+    timeout-minutes: 75
     name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -21,6 +21,7 @@ defaults:
     shell: bash
 jobs:
   downstream:
+    timeout-minutes: 60   # hang guard (see ci.yml note)
     name: ${{ matrix.pkg }} (downstream)
     runs-on: ubuntu-latest
     strategy:

--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -580,3 +580,77 @@ catch_all for host exceptions (translator.dart:481-491) · D9.5 the try-driver f
 ONE lowering (f_fin4 = exhibit N that each driver re-derives phi handling). Minor floors:
 multi-range classId checks (value mostly obsoleted by F2's closed world) · LUB dispatch
 signatures · threshold unification · tuple-per-arity sharing · long-string lazy interning.
+
+# ═══════════════════════════════════════════════════════════════════
+# MARCHES 6-10 — THE ROAD TO THE TAG (mapped 2026-07-05, discovery-grounded)
+# ═══════════════════════════════════════════════════════════════════
+
+**THE TARGET (Dale-confirmed 2026-07-05):** the raw 15-dim mean's ceiling is ~72-75 —
+async (~10) and JS-interop (~45) are DIVERGENT-JUSTIFIED and drag it arithmetically.
+THE TAG = **every ACTIONABLE dimension at its documented ceiling ≈ 85-90 mean over the
+12 actionable dims.** Permanent documented deltas (locked as loud/sound, never scored
+against): the async state machine · dynamic forwarders/noSuchMethod (Julia MethodError
+= trap) · JS glue generation (Therapy owns the host boundary) · masquerade classes.
+Ratchets R12-R18 below make each march's progress machine-visible in CI.
+
+## MARCH 6 — EXCEPTIONS (exceptions 58→~85; the bug-richest subsystem)
+Discovery: **13 drivers, ~2,278 LOC = 76% of generate.jl** behind a 643-LOC shape
+selector (dart: visitTryCatch 127 + visitTryFinally 84). 13 throw sites ALL void-tag-0 +
+`$current_exn` stash; 13 try_table sites ALL catch_all; **the typed-catch builder API is
+fully built with ZERO callers** (instr_builder.jl:321-349) — this march is pure codegen.
+Phases: (1) **ONE lowering** — collapse the driver family into one structured try
+lowering (both of the week's real miscompiles lived here) · (2) **the typed tag** —
+`FuncType([exn, stackTrace],[])` (translator.dart:485-491); throw sites push the payload;
+catch sites bind via catch_clause + local_set; `$current_exn` dies (1 read,
+statements.jl:629) · (3) **try/finally lowering** (visitTryFinally 1287-1370 finalizer
+stacks; WT relies on Julia's inlining today — D9.4 battery holds the line) · (4) verify
+the compile.jl:1716 void-tag `inputs=[AnyRef]` anomaly.
+EXITS: R12 13→1 · R13 13→0 · typed catch emissions 0→≥1 · tag arity 0→2.
+
+## MARCH 7 — CONSTANTS (constants 35→~80)
+Discovery: **12 fresh-heap arms** in `_compile_value_b` (Int128/long-String/QuoteNode/
+Symbol[ignores the intern registry!]/Tuple/Module/Fn/closure/Dict/Vector/Memory/generic-
+struct) vs **3 dedup registries + 1 singleton** (dart: ONE constantInfo map for ALL kinds,
+constants.dart:49). No lazy constants (dart 445-476/322-339). **The lazy blocker:** fn
+indices freeze at compile.jl:1641 (PURE-9065) — init fns must pre-create via a
+literal-collection pre-pass (clone the compile.jl:1527-1560 loop; the F2 collector walks
+types, not literals).
+Phases: (1) ONE ensureConstant funnel unifying the registries + routing all 12 arms ·
+(2) the literal pre-pass (unblocks init-fn pre-creation) · (3) lazy constants
+(br_on_non_null use-shape) for large strings/arrays w/ maxArrayNewFixedLength · (4) shared
+string segments + Symbol joins the intern registry · (5) boxed-scalar constant dedup when
+expected is a ref (dart 361-376).
+EXITS: R14 12→2 (helpers only) · R15 2→0 · deduped kinds 3/15→15/15 · br_on_non_null ≥1.
+
+## MARCH 8 — UNIVERSAL WRAP, honestly scoped (visitors 75→~85, translator 78→~85)
+Discovery REFRAME: the generic arg path ALREADY collapsed (march 5); **R3/R5 largely
+SURVIVE as legitimate getStaticType/expectedType surface** (only ~3-9 of R3's 135 callers
+are wrap-collapse targets). The real work: (1) fold the **13 external emit+convert_type!
+ladders** into 4-arg wrap — gated on solving the Nothing-phantom `_ab.instrs` inspection
+(invoke.jl:2135 / calls.jl:6041) generically inside the funnel · (2) the long tail:
+route the **~200 bespoke intrinsic-operand 3-arg emits** through 4-arg wrap with their
+structurally-known expected types (array eltype / index i32 / ref field...) · (3) the
+return channel is nearly done (emit_return_coerced! + 2 callers) — finish it.
+Floor: ~30-40 genuinely-no-expected sites (drops/conditions/pass-throughs).
+EXITS: R17 256→~40 · R16 13→0 · 4-arg adoption 33→rising.
+
+## MARCH 9 — DISPATCH SIGNATURES + TYPES FLOOR + THE CLOSURES DECISION (dispatch 60→~78)
+Discovery: (1) **per-param LUB** (dart _computeSignature dispatch_table.dart:86-205 w/
+the unboxed-primitive fast lane; WT = fill(AnyRef, arity) ×2; hierarchy DAG for the
+struct join exists; the kwargs half is N/A — pre-positionalized) · (2) **the 9-cliff**
+(dispatch.jl:80): dart tables ALL targetCount>1; unification ALSO CLOSES A REAL HOLE —
+**multi-axis 2-8-candidate dispatch falls to `unreachable` today** (calls.jl:1593
+single-axis-only inline) · (3) **multi-range classId checks** (dart 3862-3883): makes isa
+sound INDEPENDENT of numbering order (F2 closed the drift empirically, not structurally;
+46 ensure_type_id! callers survive as synthetic box ids) · (4) **THE CLOSURES DECISION:
+record + DEFER** — closures are 100% static; call_ref! is built with zero callers;
+nothing on the critical path needs first-class function values; the dart layouter
+(closures.dart:41-118,147+) is LARGE net-new — build when a dynamic function-value flow
+lands, recorded as DEFERRED (not justified-forever).
+EXITS: R18 2→0 · threshold=9 1→0 · "multi-arg dispatch unsupported" 1→0 ·
+multi-range support ≥1 · the closures decision recorded (this paragraph).
+
+## MARCH 10 — THE CERTIFICATION CLOSE
+The fresh scored re-audit (the 2026-07-04 instrument, same 6-auditor method), every
+actionable dimension's floor → a LOCK, PARITY_MASTER final record, **THE TAG declared**
+when every actionable dim sits at its documented ceiling.

--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -562,7 +562,7 @@ dynamic forwarders/noSuchMethod (DIM 6 — Julia MethodError = trap), JS glue ge
 | item | status |
 |---|---|
 | F1 box supertype | ✅ CORRECTED (retrofit existed) + FIXED at creation — boxes `sub $JlBase` from birth |
-| F2 closed classId universe | ✅ `_register_reachable_ir_types!` closes the world before the ONE DFS (dart class_info.dart:583-690); $JlType hierarchy creation moved above the collector; **the pinned isa @test_broken FLIPPED to @test** |
+| F2 closed classId universe | ✅ (rebuilt after a WasmMakie-caught regression): `_collect_reachable_ir_types` feeds `assign_type_ids!` a PURE collection — numbering without registration (eager registration forked layouts via field-resolution order). The rebuild exposed the isa bug's SECOND root: `set_struct_supertypes!` ran before bodies, so lazily-registered structs never got `sub $JlBase` and the ref.test gate was false — the idempotent retrofit now re-runs post-bodies in all three pipelines. **The pinned isa @test_broken FLIPPED to @test** |
 | F4 typeassert | ✅ the CHECKED cast (dart emitAsCheck): tee → ref.test $JlBase → typeof → classId range → tag-0 throw on mismatch; statically-proven casts pass through; battery covers structs + boxed numerics |
 | F3 constant interning | ✅ short strings (≤64B) → ONE immutable global each (constant array.new_fixed initializer); `===` identity + code size now dart-shaped; long strings stay inline (dart lazies those — deferred: init fns can't be added during body compile) |
 | F5 dead code | ✅ M8.1 SelectorInfo transcription (6.3KB) + its test + emit_box_type_id! + stale FNV comments — deleted |

--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -570,8 +570,13 @@ dynamic forwarders/noSuchMethod (DIM 6 — Julia MethodError = trap), JS glue ge
 | D9.4 try/finally battery | ✅ committed — **and it caught a real wrong-value miscompile**: nested finally inside catch, non-throwing arm (51→57): the normal path fell through the outer landing end INTO the handler; fixed with the outer-merge skip machinery in generate_nested_try_catch_2 |
 | D10.1 async conformance | ✅ the loud-reject lock committed (a @spawn entry must REJECT at compile) |
 
-**Remaining queue (unchanged ranking):** D9.1/D9.2 typed exception tag + catch_all
-separation (the deep exceptions item) · F8 universal wrap adoption (the arg ladder →
-THE funnel) · D9.5 try-driver family → ONE lowering (f_fin4 is exhibit N that each
-driver re-derives phi handling) · multi-range classId checks · LUB dispatch signatures
-· threshold unification · tuple-per-arity sharing.
+| F8 wrap adoption | ✅ BOTH arg ladders — invoke's (10.9KB, 14 arms) and compile_call's twin (8.2KB, 12 arms) — are ONE convert_type! call each, with tracked-type refinement of `actual`; THE funnel gained its missing quadrants (i64→i32 wrap, f64→f32 demote, externref-source unbox bridge); the two silent drop+zero arms became LOUD funnel traps |
+
+**MARCH 5 CLOSED at the queue's floor.** Two real miscompiles fixed en route (the
+nested-finally wrong-value + march-4-tail's multi-back-edge loop); the pinned isa bug
+flipped to a hard lock. **Remaining (the deep pair, next-phase material):**
+D9.1/D9.2 typed exception tag — carry (exn, stackTrace) as the TAG PAYLOAD, reserve
+catch_all for host exceptions (translator.dart:481-491) · D9.5 the try-driver family →
+ONE lowering (f_fin4 = exhibit N that each driver re-derives phi handling). Minor floors:
+multi-range classId checks (value mostly obsoleted by F2's closed world) · LUB dispatch
+signatures · threshold unification · tuple-per-arity sharing · long-string lazy interning.

--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -556,3 +556,22 @@ re-implements convertType's arms inline. dart: 100% of expressions through wrap.
 **Out-of-scope by design (documented, sound):** async/generators state machine (DIM 10),
 dynamic forwarders/noSuchMethod (DIM 6 — Julia MethodError = trap), JS glue generation
 (DIM 13 — Therapy owns the host boundary), masquerade classes (Julia typeof is concrete).
+
+## MARCH 5 — the census queue executed (2026-07-05, branch `wt-parity-march5`)
+
+| item | status |
+|---|---|
+| F1 box supertype | ✅ CORRECTED (retrofit existed) + FIXED at creation — boxes `sub $JlBase` from birth |
+| F2 closed classId universe | ✅ `_register_reachable_ir_types!` closes the world before the ONE DFS (dart class_info.dart:583-690); $JlType hierarchy creation moved above the collector; **the pinned isa @test_broken FLIPPED to @test** |
+| F4 typeassert | ✅ the CHECKED cast (dart emitAsCheck): tee → ref.test $JlBase → typeof → classId range → tag-0 throw on mismatch; statically-proven casts pass through; battery covers structs + boxed numerics |
+| F3 constant interning | ✅ short strings (≤64B) → ONE immutable global each (constant array.new_fixed initializer); `===` identity + code size now dart-shaped; long strings stay inline (dart lazies those — deferred: init fns can't be added during body compile) |
+| F5 dead code | ✅ M8.1 SelectorInfo transcription (6.3KB) + its test + emit_box_type_id! + stale FNV comments — deleted |
+| F7 stack-trace infra | ✅ dormant PURE-9036 cluster deleted (zero callers); the rebuild is D9.1's typed tag payload |
+| D9.4 try/finally battery | ✅ committed — **and it caught a real wrong-value miscompile**: nested finally inside catch, non-throwing arm (51→57): the normal path fell through the outer landing end INTO the handler; fixed with the outer-merge skip machinery in generate_nested_try_catch_2 |
+| D10.1 async conformance | ✅ the loud-reject lock committed (a @spawn entry must REJECT at compile) |
+
+**Remaining queue (unchanged ranking):** D9.1/D9.2 typed exception tag + catch_all
+separation (the deep exceptions item) · F8 universal wrap adoption (the arg ladder →
+THE funnel) · D9.5 try-driver family → ONE lowering (f_fin4 is exhibit N that each
+driver re-derives phi handling) · multi-range classId checks · LUB dispatch signatures
+· threshold unification · tuple-per-arity sharing.

--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -497,12 +497,13 @@ re-verified in code. Baseline: the 2026-06-30 census scored ~25-30%.
 
 ## LOAD-BEARING FINDINGS (doc-vs-code corrections + rooted bugs)
 
-**F1 — numeric boxes do NOT subtype $JlBase (docstring claims they do — FALSE).**
-`get_numeric_box_type!` (types.jl:1113) adds a plain struct with NO supertype while the
-$JlString struct DOES subtype base (types.jl:990) — the two box families are inconsistent,
-and dart subtypes EVERY class struct (class_info.dart:288). Boxed numerics can only flow
-via anyref. THE concrete blocker for the typed-value-channel north-star. values.jl:499-500
-docstring must be fixed or (better) the claim made true.
+**F1 — numeric boxes subtype $JlBase only via the finalization RETROFIT (CORRECTED +
+FIXED, march5).** The audit's strong claim was wrong: `set_struct_supertypes!` retrofits
+every plain struct to `sub $JlBase` at module finalization, so the EMITTED module was
+already correct (verified in wat: boxes are `(sub 0 …)`). The REAL gap was creation-time —
+during emission the strict builder couldn't use the subtype relation because it was
+declared only at the end. Fixed: `get_numeric_box_type!` now declares `sub $JlBase` AT
+CREATION (dart class_info.dart:288 shape), the typed-channel prerequisite.
 
 **F2 — the isa-over-Any[] @test_broken ROOT CAUSE (pinned in code).** WT numbers classIds
 from an OPEN registry snapshot: `assign_type_ids!` freezes each abstract's [low,high] one-shot

--- a/dev/parity_baseline.toml
+++ b/dev/parity_baseline.toml
@@ -18,8 +18,15 @@ L8_no_silent_traps = 0
 L9_no_unjustified_untyped_emission = 0
 
 [metrics]
-R11_patch_markers = 691
+R11_patch_markers = 678
+R12_try_drivers = 13
+R13_catch_all_clauses = 14
+R14_fresh_constant_structs = 12
+R15_constant_data_segments = 2
+R16_external_convert_ladders = 13
+R17_unwrapped_value_emissions = 256
+R18_anyref_dispatch_sigs = 5
 R2_emit_raw_bridges = 0
 R3_infer_value_type = 134
 R5_julia_type_reguess = 104
-R7_raw_coercion_ops = 130
+R7_raw_coercion_ops = 126

--- a/dev/run_full_gate.sh
+++ b/dev/run_full_gate.sh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+# THE full capped gate with a STALL WATCHDOG (2026-07-05, after a day of silent
+# hangs: overnight machine sleep froze a gate at 6/10 for 5h; a precompile-lock
+# collision wedged a relaunch; a Windows CI job sat 3h19m on GitHub's 6h default).
+# Behavior: launch detached; if the log stops growing for STALL_MIN minutes,
+# kill + relaunch (once); write EXIT= to the log either way.
+# Usage: dev/run_full_gate.sh <logfile>
+set -u
+LOG="${1:?usage: run_full_gate.sh <logfile>}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+STALL_MIN=12
+launch() {
+    : > "$LOG"
+    WT_TEST_CONCURRENCY=2 julia --project="$REPO" -e "using Pkg; Pkg.test()" >> "$LOG" 2>&1 &
+    GATE_PID=$!
+}
+run_watched() {
+    launch
+    while kill -0 $GATE_PID 2>/dev/null; do
+        sleep 60
+        local age=$(( $(date +%s) - $(stat -f %m "$LOG") ))
+        if (( age > STALL_MIN * 60 )); then
+            echo "WATCHDOG: log silent ${age}s — killing stalled gate" >> "$LOG"
+            kill -9 $GATE_PID 2>/dev/null
+            pkill -9 -P $GATE_PID 2>/dev/null
+            return 1
+        fi
+    done
+    wait $GATE_PID
+    return $?
+}
+if run_watched; then
+    echo "EXIT=0" >> "$LOG"
+else
+    rc=$?
+    if grep -q "WATCHDOG" "$LOG"; then
+        echo "WATCHDOG: relaunching once" >> "$LOG"
+        if run_watched; then echo "EXIT=0" >> "$LOG"; else echo "EXIT=$?" >> "$LOG"; fi
+    else
+        echo "EXIT=$rc" >> "$LOG"
+    fi
+fi

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -3708,12 +3708,47 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         return append_builder!(b, fb)
     end
 
-    # Special case for typeassert - just pass through the value
-    # Core.typeassert(x, T) returns x if type matches, throws otherwise
-    # In Wasm we don't do runtime type checks, so just return the value
+    # Core.typeassert(x, T) — dart's CHECKED cast (census F4, march5; emitAsCheck,
+    # types.dart:437-481: is-check, throw on mismatch). Statically-proven casts stay
+    # pass-through (the common case — inference already narrowed). A runtime check
+    # emits when the value is a GC ref and the target has a DFS classId range:
+    # typeId ∈ [low, high] or throw TypeError. Values the discriminator can't see
+    # (non-$JlBase refs) pass through UNCHECKED (under-check, never wrong-throw).
     if is_func(func, :typeassert)
         if length(args) >= 1
-            emit_value!(fb, args[1], ctx)
+            local _ta_ty = emit_value!(fb, args[1], ctx)
+            local _ta_target = length(args) >= 2 ? (args[2] isa Type ? args[2] :
+                args[2] isa GlobalRef ? Core.eval(args[2].mod, args[2].name) : nothing) : nothing
+            local _ta_static = get_ssa_type(ctx, args[1])
+            if _ta_target isa Type && isconcretetype(_ta_target) &&
+               !(_ta_static isa Type && _ta_static <: _ta_target) &&
+               (_ta_ty === AnyRef || _ta_ty isa ConcreteRef || _ta_ty === StructRef) &&
+               ctx.type_registry.base_struct_idx !== nothing
+                local _ta_range = get_type_range(ctx.type_registry, _ta_target)
+                if _ta_range !== nothing
+                    local _ta_low, _ta_high = _ta_range
+                    local _ta_base = ctx.type_registry.base_struct_idx
+                    local _ta_tmp = allocate_local!(ctx, AnyRef)
+                    local_tee!(fb, _ta_tmp)
+                    ref_test!(fb, Int64(_ta_base), false)
+                    if_!(fb)                                   # discriminable ($JlBase struct)
+                    local_get!(fb, UInt32(_ta_tmp))
+                    emit_typeof!(fb, _ta_base)
+                    emit_classid_range_check!(fb, _ta_low, _ta_high)
+                    num!(fb, Opcode.I32_EQZ)
+                    if_!(fb)                                   # out of range → THROW
+                    # null-payload throw (the union_bottom_throw_stub shape): TypeError
+                    # carries 4 fields the check site can't populate; throw-PARITY is the
+                    # contract (native throws TypeError, wasm throws tag 0 — both catchable)
+                    ensure_exception_tag!(ctx.mod)
+                    ref_null!(fb, AnyRef)
+                    global_set!(fb, ensure_exception_global!(ctx.mod))
+                    throw_!(fb, 0)
+                    end_block!(fb)
+                    end_block!(fb)
+                    local_get!(fb, UInt32(_ta_tmp))            # the value survives the check
+                end
+            end
         end
         return append_builder!(b, fb)
     end

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -6020,7 +6020,6 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 for (arg_idx, arg) in enumerate(args)
                     local _cab = _compile_value_b(arg, ctx)
                     local _cw_arg_ty = isempty(_cab.v.stack) ? nothing : _cab.v.stack[end]
-                    local _cab_is_local = length(_cab.instrs) == 1 && _cab.instrs[1] isa InstrIR.LocalGet
                     local _cab_merged = false
                     # Check if arg type matches expected param type (the merge happens
                     # AFTER the phantom/numeric-replacement decisions — the pop! surgeries
@@ -6051,102 +6050,16 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                             end
                         end
 
-                        # merge the arg now (unless replaced) so the bridging casts land after it;
-                        # the numeric-expected arm below REPLACES instead (sets the flag first)
-                        local _cab_numeric_replace = (expected_wasm === I32 || expected_wasm === I64 ||
-                                                      expected_wasm === F32 || expected_wasm === F64) &&
-                                                     (actual_wasm === ExternRef || actual_wasm === AnyRef ||
-                                                      actual_wasm isa ConcreteRef || actual_wasm === StructRef)
-                        (_cab_merged || _cab_numeric_replace) || (append_builder!(fb, _cab); _cab_merged = true)
-                        if expected_wasm isa ConcreteRef && actual_wasm isa ConcreteRef
-                            if expected_wasm.type_idx != actual_wasm.type_idx
-                                # Different ref types — insert ref.cast null to expected type
-                                local _bb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                                ref_cast!(_bb, Int64(expected_wasm.type_idx), true)
-                                append_builder!(fb, _bb)
-                            end
-                        elseif expected_wasm isa ConcreteRef && (actual_wasm === StructRef || actual_wasm === ArrayRef || actual_wasm === AnyRef)
-                            # Abstract ref to concrete ref — insert ref.cast null
-                            local _bb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                            ref_cast!(_bb, Int64(expected_wasm.type_idx), true)
-                            append_builder!(fb, _bb)
-                        elseif expected_wasm isa ConcreteRef && actual_wasm === ExternRef
-                            # PURE-036bj: externref to concrete ref — convert to anyref first, then cast
-                            local _bb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                            any_convert_extern!(_bb)                 # externref → anyref
-                            ref_cast!(_bb, Int64(expected_wasm.type_idx), true)  # anyref → (ref null X)
-                            append_builder!(fb, _bb)
-                        elseif expected_wasm isa ConcreteRef && (actual_wasm === I32 || actual_wasm === I64 || actual_wasm === F32 || actual_wasm === F64)
-                            # PURE-6025: Numeric value to tagged union struct — wrap via emit_wrap_union_value.
-                            # This happens when a function expects a Union param (represented as tagged union struct)
-                            # but the actual value is a numeric type (e.g., NumType passed to Dict{WasmValType,...} key).
-                            # B4/M3: numeric → ref. THE single-source funnel (box arm) — boxes
-                            # with the real classId, then coerces to the expected ref; a genuine
-                            # type mismatch traps LOUDLY (no silent truncation). (The dead
-                            # tagged-union wrapper arm is DELETED — needs_tagged_union was ≡ false.)
-                            local _bb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                            convert_type!(_bb, actual_wasm, expected_wasm, ctx;
-                                          from_julia=(actual_julia_type isa Type && isconcretetype(actual_julia_type)) ? actual_julia_type : nothing)
-                            append_builder!(fb, _bb)
-                        elseif expected_wasm === ExternRef && (actual_wasm isa ConcreteRef || actual_wasm === StructRef || actual_wasm === ArrayRef || actual_wasm === AnyRef)
-                            # Concrete or abstract ref to externref — insert extern.convert_any
-                            local _bb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                            extern_convert_any!(_bb)
-                            append_builder!(fb, _bb)
-                        elseif expected_wasm === AnyRef && actual_wasm === ExternRef
-                            # PURE-9022: externref to anyref — insert any.convert_extern
-                            # Occurs when JS import returns externref but internal code expects anyref
-                            local _bb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                            any_convert_extern!(_bb)
-                            append_builder!(fb, _bb)
-                        elseif expected_wasm === AnyRef && (actual_wasm === I32 || actual_wasm === I64 || actual_wasm === F32 || actual_wasm === F64)
-                            # PURE-9022: Numeric value (on the stack) to anyref via THE single box emitter.
-                            local _bb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                            emit_classid_box!(_bb, ctx, actual_wasm, nothing)
-                            append_builder!(fb, _bb)
-                        elseif expected_wasm === ExternRef && (actual_wasm === I32 || actual_wasm === I64 || actual_wasm === F32 || actual_wasm === F64)
-                            # PURE-6025: Numeric value to externref — box via the one emitter, then extern.convert_any.
-                            local _bb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                            emit_classid_box!(_bb, ctx, actual_wasm, nothing)
-                            extern_convert_any!(_bb)
-                            append_builder!(fb, _bb)
-                        elseif (expected_wasm === I32 || expected_wasm === I64 || expected_wasm === F32 || expected_wasm === F64) &&
-                               (actual_wasm === ExternRef || actual_wasm === AnyRef || actual_wasm isa ConcreteRef || actual_wasm === StructRef)
-                            # PURE-906: Expected numeric but actual is ref-typed.
-                            # This happens when Julia type inference reports arg type as Any
-                            # but the callee's param is a concrete numeric type (Bool, Int, etc.).
-                            # Zero default REPLACES the ref-typed arg (no pop! surgery —
-                            # the un-merged fragment is simply dropped).
-                            _cab_merged = true
-                            local _zb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                            if expected_wasm === I32
-                                i32_const!(_zb, 0)
-                            elseif expected_wasm === I64
-                                i64_const!(_zb, 0)
-                            elseif expected_wasm === F32
-                                f32_const!(_zb, 0.0f0)
-                            elseif expected_wasm === F64
-                                f64_const!(_zb, 0.0)
-                            end
-                            append_builder!(fb, _zb)
-                        elseif expected_wasm === ExternRef && actual_wasm === ExternRef
-                            # PURE-036z: Julia type inference says Any→ExternRef for both, but the actual
-                            # Wasm local might be a ConcreteRef. Check if arg_bytes is local.get of a
-                            # non-externref local and insert extern.convert_any if needed.
-                            if _cab_is_local
-                                # dart2wasm carries the type with the value: derive the actual
-                                # wasm type from the inferred value type rather than the local index.
-                                actual_local_wasm = _cw_arg_ty
-                                if actual_local_wasm isa ConcreteRef || actual_local_wasm === StructRef || actual_local_wasm === ArrayRef || actual_local_wasm === AnyRef
-                                    # Actual local is a ref type but not externref — insert conversion
-                                    local _ecb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
-                                    extern_convert_any!(_ecb)
-                                    append_builder!(fb, _ecb)
-                                end
-                            end
+                        # march5 F8 (twin of the invoke collapse): the bridging chain IS
+                        # one convertType call (dart code_generator.dart:879). The tracked
+                        # emission type refines `actual`; replaced arms incl. the phantom
+                        # handled above.
+                        _cw_arg_ty isa WasmValType && actual_julia_type !== Nothing && (actual_wasm = _cw_arg_ty)
+                        _cab_merged || (append_builder!(fb, _cab); _cab_merged = true)
+                        convert_type!(fb, actual_wasm, expected_wasm, ctx;
+                                      from_julia=(actual_julia_type isa Type && isconcretetype(actual_julia_type)) ? actual_julia_type : nothing)
                         end
-                    end
-                end
+             end
                 # Cross-function call - emit call instruction with target index
                 local _xcb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
                 call!(_xcb, target_info.wasm_idx, WasmValType[], WasmValType[])

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -1571,14 +1571,27 @@ function compile_module(functions::Vector;
         register_core_ir_types!(mod, type_registry)
     end
 
+    # PURE-9063: Create $JlType hierarchy types FIRST (march5 reorder: the closed-world
+    # collector below registers structs whose DataType-typed fields must resolve to
+    # $JlDataType — pre-hierarchy registration resolved them to a stale struct type,
+    # which the Any-only patch pass below can't fix)
+    create_jl_type_hierarchy!(mod, type_registry)
+
+    # census F2 (march5): CLOSE THE TYPE UNIVERSE BEFORE NUMBERING — dart numbers the
+    # whole component ONCE, before codegen (class_info.dart:583-690). Walk every
+    # function's typed IR and register every reachable concrete struct / union member
+    # NOW, so the DFS below sees the closed world and every type gets a real
+    # [low, high] range. Emission-time ensure_type_id! remains the rare fallback
+    # (its max+1 id is range-less — the open-universe drift this pass eliminates
+    # was the root of isa-over-Any[] silently returning false AND typeassert's
+    # checked cast never emitting for runtime-registered types).
+    _register_reachable_ir_types!(mod, type_registry, function_data)
+
     # PURE-9025: Assign DFS type IDs after all types are registered
     assign_type_ids!(type_registry)
 
     # PURE-9028: Create BoxedNothing singleton global (after type IDs assigned)
     get_nothing_global!(mod, type_registry)
-
-    # PURE-9063: Create $JlType hierarchy types (before type globals use them)
-    create_jl_type_hierarchy!(mod, type_registry)
 
     # PURE-9064: Patch struct types registered before JlType hierarchy existed.
     # Any-typed fields were mapped to ExternRef (since jl_type_idx was nothing).
@@ -4282,4 +4295,57 @@ function _compile_module_trim(functions::Vector; kwargs...)
         TRIM_ENTRY_NAMES[] = nothing
         _TRIM_ACTIVE[] = false
     end
+end
+
+"""
+    _register_reachable_ir_types!(mod, type_registry, function_data)
+
+census F2 (march5) — the CLOSED-WORLD type collector (dart class_info.dart:583-690:
+ClassIdNumbering numbers every class of the component once, before codegen). Walks
+every function's typed-IR ssa/arg/return types, decomposes Unions, and registers
+every eligible concrete struct type so `assign_type_ids!` numbers the whole world
+in one DFS. Best-effort per type: `register_struct_type!` self-filters; a type it
+rejects here may still register lazily during emission (the ensure_type_id!
+fallback), which only costs that type its range.
+"""
+function _register_reachable_ir_types!(mod::WasmModule, type_registry::TypeRegistry, function_data)
+    seen = Set{Any}()
+    function reg!(@nospecialize(T))
+        T === nothing && return
+        T in seen && return
+        push!(seen, T)
+        if T isa Union
+            reg!(T.a); reg!(T.b)
+            return
+        end
+        T isa DataType || return
+        # Type{X} carries X (type constants / typeof results)
+        if T <: Type && T !== Type && length(T.parameters) == 1
+            reg!(T.parameters[1])
+            return
+        end
+        if isconcretetype(T) && isstructtype(T) && !(T <: Function && fieldcount(T) == 0)
+            try
+                register_struct_type!(mod, type_registry, T)
+            catch
+                # best-effort: an exotic type the registrar chokes on keeps its
+                # lazy path; it only forfeits a DFS range
+            end
+        end
+    end
+    for fd in function_data
+        code_info = fd[4]
+        code_info === nothing && continue
+        for at in fd[2]
+            reg!(at isa Type ? at : typeof(at))
+        end
+        reg!(fd[5])
+        ssats = code_info.ssavaluetypes
+        if ssats isa Vector
+            for t in ssats
+                reg!(Core.Compiler.widenconst(t))
+            end
+        end
+    end
+    return nothing
 end

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -1579,16 +1579,16 @@ function compile_module(functions::Vector;
 
     # census F2 (march5): CLOSE THE TYPE UNIVERSE BEFORE NUMBERING — dart numbers the
     # whole component ONCE, before codegen (class_info.dart:583-690). Walk every
-    # function's typed IR and register every reachable concrete struct / union member
-    # NOW, so the DFS below sees the closed world and every type gets a real
-    # [low, high] range. Emission-time ensure_type_id! remains the rare fallback
-    # (its max+1 id is range-less — the open-universe drift this pass eliminates
-    # was the root of isa-over-Any[] silently returning false AND typeassert's
-    # checked cast never emitting for runtime-registered types).
-    _register_reachable_ir_types!(mod, type_registry, function_data)
+    # function's typed IR and COLLECT every reachable concrete struct / union member
+    # so the DFS below numbers the closed world (real [low, high] ranges for isa/
+    # typeassert). Collection ONLY — no struct registration: eagerly registering
+    # changed field-resolution ORDER and produced duplicate layouts (caught by
+    # WasmMakie's E-001); numbering needs no wasm struct to exist, and a type
+    # registered lazily later receives its pre-assigned id via ensure_type_id!.
+    _reachable = _collect_reachable_ir_types(function_data)
 
-    # PURE-9025: Assign DFS type IDs after all types are registered
-    assign_type_ids!(type_registry)
+    # PURE-9025: Assign DFS type IDs (the closed world = registered + reachable)
+    assign_type_ids!(type_registry; extra_concrete_types=_reachable)
 
     # PURE-9028: Create BoxedNothing singleton global (after type IDs assigned)
     get_nothing_global!(mod, type_registry)
@@ -1804,6 +1804,17 @@ function compile_module(functions::Vector;
     clear_perf_now!()
     clear_char_array_type!()
     clear_utf8_to_js_func!()
+
+    # census F2 (march5, the ORIGINAL isa bug's second root): structs registered
+    # LAZILY during body compilation never received `sub $JlBase` — the early
+    # retrofit ran before bodies, so `ref.test (ref $JlBase)` (the isa/typeof gate)
+    # was FALSE for every late-registered struct at runtime. Re-run the idempotent
+    # retrofit now that every struct exists. (dart declares supertypes at class
+    # definition — class_info.dart:288 — so this second pass has no dart analog;
+    # it exists because WT registers lazily.)
+    if type_registry.base_struct_idx !== nothing
+        set_struct_supertypes!(mod, type_registry.base_struct_idx; registry=type_registry)
+    end
 
     # WASMTARGET dynamic dispatch: stub any discovery-added function whose ASSEMBLED
     # bytecode fails validation (invalid-but-non-crashing codegen not caught by the
@@ -2021,6 +2032,13 @@ function compile_module_from_ir(ir_entries::Vector)::WasmModule
     end
 
     populate_type_constant_globals!(mod, type_registry)
+    # census F2 (march5): the post-body supertype retrofit — lazily-registered
+    # structs must get `sub $JlBase` or isa/typeof's ref.test gate is false (see
+    # the main pipeline's note).
+    if type_registry.base_struct_idx !== nothing
+        set_struct_supertypes!(mod, type_registry.base_struct_idx; registry=type_registry)
+    end
+
     return mod
 end
 
@@ -2893,6 +2911,13 @@ function compile_module_from_ir_frozen(ir_entries::Vector, frozen::FrozenCompila
     end
 
     populate_type_constant_globals!(mod, type_registry)
+    # census F2 (march5): the post-body supertype retrofit — lazily-registered
+    # structs must get `sub $JlBase` or isa/typeof's ref.test gate is false (see
+    # the main pipeline's note).
+    if type_registry.base_struct_idx !== nothing
+        set_struct_supertypes!(mod, type_registry.base_struct_idx; registry=type_registry)
+    end
+
     return mod
 end  # compile_module_from_ir_frozen
 
@@ -4298,17 +4323,18 @@ function _compile_module_trim(functions::Vector; kwargs...)
 end
 
 """
-    _register_reachable_ir_types!(mod, type_registry, function_data)
+    _collect_reachable_ir_types(function_data) -> Set{DataType}
 
 census F2 (march5) — the CLOSED-WORLD type collector (dart class_info.dart:583-690:
-ClassIdNumbering numbers every class of the component once, before codegen). Walks
-every function's typed-IR ssa/arg/return types, decomposes Unions, and registers
-every eligible concrete struct type so `assign_type_ids!` numbers the whole world
-in one DFS. Best-effort per type: `register_struct_type!` self-filters; a type it
-rejects here may still register lazily during emission (the ensure_type_id!
-fallback), which only costs that type its range.
+number every class of the component once, before codegen). Walks every function's
+typed-IR ssa/arg/return types and decomposes Unions, returning the concrete struct
+types reachable from the IR so `assign_type_ids!` numbers the whole world in one
+DFS. PURE COLLECTION — registration stays lazy (eager registration reorders field
+resolution and forks layouts); a collected type registered later receives its
+pre-assigned id via `ensure_type_id!`.
 """
-function _register_reachable_ir_types!(mod::WasmModule, type_registry::TypeRegistry, function_data)
+function _collect_reachable_ir_types(function_data)::Set{DataType}
+    out = Set{DataType}()
     seen = Set{Any}()
     function reg!(@nospecialize(T))
         T === nothing && return
@@ -4319,18 +4345,12 @@ function _register_reachable_ir_types!(mod::WasmModule, type_registry::TypeRegis
             return
         end
         T isa DataType || return
-        # Type{X} carries X (type constants / typeof results)
         if T <: Type && T !== Type && length(T.parameters) == 1
             reg!(T.parameters[1])
             return
         end
-        if isconcretetype(T) && isstructtype(T) && !(T <: Function && fieldcount(T) == 0)
-            try
-                register_struct_type!(mod, type_registry, T)
-            catch
-                # best-effort: an exotic type the registrar chokes on keeps its
-                # lazy path; it only forfeits a DFS range
-            end
+        if isconcretetype(T) && isstructtype(T) && !(T <: Function) && T !== Core.Box
+            push!(out, T)
         end
     end
     for fd in function_data
@@ -4347,5 +4367,5 @@ function _register_reachable_ir_types!(mod::WasmModule, type_registry::TypeRegis
             end
         end
     end
-    return nothing
+    return out
 end

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -4349,7 +4349,11 @@ function _collect_reachable_ir_types(function_data)::Set{DataType}
             reg!(T.parameters[1])
             return
         end
-        if isconcretetype(T) && isstructtype(T) && !(T <: Function) && T !== Core.Box
+        # exclude what WT represents as NON-structs: Memory/MemoryRef lower to
+        # wasm arrays (an id here admits them as dispatch candidates whose
+        # wrappers then have no struct to cast to — the _la_sub regression)
+        if isconcretetype(T) && isstructtype(T) && !(T <: Function) && T !== Core.Box &&
+           !(T <: GenericMemory) && !(T <: Core.GenericMemoryRef)
             push!(out, T)
         end
     end

--- a/src/codegen/dispatch.jl
+++ b/src/codegen/dispatch.jl
@@ -45,8 +45,8 @@ Registry of dispatch tables for a module.
 mutable struct DispatchTableRegistry
     tables::Dict{Any, DispatchTable}  # func_ref -> DispatchTable
     # parity(M8.2): the dart selector bridge — single-axis tables dispatch via
-    # receiver.classId + offset into the ONE flat table (dispatch_table.dart:445-458)
-    # instead of the FNV probe. Multi-axis tables keep the probe until M8.3.
+    # receiver.classId + offset into the ONE flat table (dispatch_table.dart:445-458);
+    # multi-axis tables via the M8.3 cascade through the SAME table (FNV deleted, M8.4).
     selector_axis::Dict{Any,Int}                      # func_ref → dispatch-axis position
     selector_offset::Dict{Any,Int}                    # func_ref → packed table offset
     selector_positions::Dict{Any,Vector{Tuple{Int,Int}}}  # func_ref → [(table_pos, entry_i)]

--- a/src/codegen/generate.jl
+++ b/src/codegen/generate.jl
@@ -773,46 +773,11 @@ function ensure_exception_global!(mod::WasmModule)::UInt32
     return UInt32(length(mod.globals) - 1)
 end
 
-"""
-PURE-9036: Ensure module has stack trace capture infrastructure.
-Adds `capture_stack` import (env.capture_stack: () → externref) and
-`\$current_stack_trace` global (mut externref). Returns (import_idx, global_idx).
-Idempotent — scans existing imports to avoid duplicates.
-"""
-function ensure_stack_trace_support!(mod::WasmModule)
-    # Check if capture_stack import already exists
-    import_idx = nothing
-    func_count = UInt32(0)
-    for imp in mod.imports
-        if imp.kind == 0x00  # function import
-            if imp.module_name == "env" && imp.field_name == "capture_stack"
-                import_idx = func_count
-            end
-            func_count += 1
-        end
-    end
-
-    if import_idx === nothing
-        import_idx = add_stack_trace_import!(mod)
-    end
-
-    global_idx = ensure_stack_trace_global!(mod)
-    return (import_idx=import_idx, global_idx=global_idx)
-end
-
-"""
-PURE-9036: Emit capture_stack() + global.set at a throw site.
-Call this before emitting the `throw` instruction to capture the stack trace.
-"""
-function emit_capture_stack!(bytes::Vector{UInt8}, capture_import_idx::UInt32, trace_global_idx::UInt32)
-    b = InstrBuilder(; func_name="emit_capture_stack!")
-    # capture_stack() -> externref-on-stack; global.set consumes it. Emitted
-    # mid-stream into a caller buffer, so build into a local builder then splice.
-    call!(b, capture_import_idx, WasmValType[], WasmValType[ExternRef])
-    global_set!(b, trace_global_idx)
-    append!(bytes, builder_code(b))
-    return bytes
-end
+# census F7 (march5): the dormant stack-trace cluster (ensure_stack_trace_support!/
+# emit_capture_stack!) is DELETED — zero callers since introduction (PURE-9036).
+# The dart-shaped rebuild carries (exception, stackTrace) as the TYPED TAG PAYLOAD
+# (translator.dart:481-491 createExceptionTag) — census queue item D9.1; the dart
+# source is the reference, not dead scaffolding.
 
 """
 PURE-6024: Generate try/catch code using generate_stackified_flow for the try body.
@@ -2607,6 +2572,24 @@ function generate_nested_try_catch_2(ctx::AbstractCompilationContext, blocks::Ve
         ctx.last_stmt_was_stub = false
     end
 
+    # march5 (f_fin4 battery, wrong-value 51→57): phis AFTER outer.catch_dest that
+    # merge a NORMAL edge (< catch_dest) with the CATCH edge — the normal path must
+    # store its edge and br PAST the handler head to the merge; previously it fell
+    # THROUGH the landing-block end INTO the handler (pop_exception's block), whose
+    # fall-through phi-edge store overwrote the value with the catch edge's.
+    outer_merge_start = 0
+    for i in outer.catch_dest:length(code)
+        st = code[i]
+        if st isa Core.PhiNode && haskey(ctx.phi_locals, i) &&
+           any(Int(e) < outer.catch_dest for e in st.edges)
+            outer_merge_start = i
+            break
+        end
+    end
+
+    # === Outer skip block (only when a post-outer merge exists) ===
+    outer_merge_start > 0 && block!(bb)
+
     # === Outer catch landing block (void) ===
     block!(bb)
 
@@ -2810,8 +2793,26 @@ function generate_nested_try_catch_2(ctx::AbstractCompilationContext, blocks::Ve
         end
     end
 
+    # Normal path: store the post-outer merge-phi NORMAL edges, then br past the
+    # landing end AND the handler head to the outer-skip end (the merge).
+    if outer_merge_start > 0
+        for i in outer_merge_start:length(code)
+            st = code[i]
+            st isa Core.PhiNode || break
+            haskey(ctx.phi_locals, i) || continue
+            for (k, e) in enumerate(st.edges)
+                if Int(e) < outer.catch_dest && isassigned(st.values, k)
+                    emit_phi_local_set!(bb, st.values[k], i, ctx)
+                    break
+                end
+            end
+        end
+    end
+
     # End outer try_table
     end_block!(bb)
+
+    outer_merge_start > 0 && br!(bb, 1)   # normal path → outer-skip end (the merge)
 
     # End outer catch landing block
     end_block!(bb)
@@ -2819,12 +2820,46 @@ function generate_nested_try_catch_2(ctx::AbstractCompilationContext, blocks::Ve
     # Reset dead code flag — outer catch handler is reachable
     ctx.last_stmt_was_stub = false
 
-    # === Outer catch handler (stmts outer.catch_dest to end) ===
-    # P3: stackified for the same linear-walk reasons as the inner handler.
-    outer_catch = [b for b in blocks if b.start_idx >= outer.catch_dest]
-    if !isempty(outer_catch)
-        generate_stackified_flow!(bb, ctx, outer_catch, code)
-        ctx.last_stmt_was_stub = false
+    if outer_merge_start > 0
+        # === Outer catch handler HEAD (catch_dest .. merge-1), then its merge edges ===
+        outer_head = BasicBlock[]
+        for b in blocks
+            lo = max(b.start_idx, outer.catch_dest)
+            hi = min(b.end_idx, outer_merge_start - 1)
+            lo > hi && continue
+            push!(outer_head, (lo == b.start_idx && hi == b.end_idx) ? b :
+                  BasicBlock(lo, hi, hi == b.end_idx ? b.terminator : nothing))
+        end
+        if !isempty(outer_head)
+            generate_stackified_flow!(bb, ctx, outer_head, code;
+                                                   trailing_unreachable=false)
+            ctx.last_stmt_was_stub = false
+        end
+        for i in outer_merge_start:length(code)
+            st = code[i]
+            st isa Core.PhiNode || break
+            haskey(ctx.phi_locals, i) || continue
+            for (k, e) in enumerate(st.edges)
+                if Int(e) >= outer.catch_dest && isassigned(st.values, k)
+                    emit_phi_local_set!(bb, st.values[k], i, ctx)
+                    break
+                end
+            end
+        end
+        end_block!(bb)   # outer-skip end — BOTH paths at the merge
+        merge_tail = [b for b in blocks if b.start_idx >= outer_merge_start]
+        if !isempty(merge_tail)
+            generate_stackified_flow!(bb, ctx, merge_tail, code)
+            ctx.last_stmt_was_stub = false
+        end
+    else
+        # === Outer catch handler (stmts outer.catch_dest to end) ===
+        # P3: stackified for the same linear-walk reasons as the inner handler.
+        outer_catch = [b for b in blocks if b.start_idx >= outer.catch_dest]
+        if !isempty(outer_catch)
+            generate_stackified_flow!(bb, ctx, outer_catch, code)
+            ctx.last_stmt_was_stub = false
+        end
     end
 
     return bb

--- a/src/codegen/invoke.jl
+++ b/src/codegen/invoke.jl
@@ -2116,20 +2116,12 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                     expected_wasm = get_concrete_wasm_type(expected_julia_type, ctx.mod, ctx.type_registry)
                     actual_julia_type = infer_value_type(arg, ctx)
                     actual_wasm = get_concrete_wasm_type(actual_julia_type, ctx.mod, ctx.type_registry)
-                    # P4-stdlib (Random hash_seed): the type-derived guess says
-                    # I64 for Union{Nothing, UInt64}, but such SSAs live in
-                    # AnyRef locals (boxed) — use the ACTUAL local type so the
-                    # bridging below sees the real representation.
-                    if arg isa Core.SSAValue
-                        local _ivl = get(ctx.ssa_locals, arg.id, nothing)
-                        _ivl === nothing && (_ivl = get(ctx.phi_locals, arg.id, nothing))
-                        if _ivl !== nothing
-                            local _ivo = _ivl - ctx.n_params
-                            if _ivo >= 0 && _ivo < length(ctx.locals)
-                                actual_wasm = ctx.locals[_ivo + 1]
-                            end
-                        end
-                    end
+                    # march5 F8 (census: dart wrap = 100% of expressions through convertType,
+                    # code_generator.dart:879): the whole inline coercion ladder — 14 arms
+                    # re-implementing convertType — is ONE funnel call. The emission's own
+                    # tracked type (dart carries the type with the value) refines `actual`;
+                    # the old ssa_locals re-lookup died with the ladder.
+                    arg_ty isa WasmValType && actual_julia_type !== Nothing && (actual_wasm = arg_ty)
 
                     # PURE-3111/4155: Handle Nothing→ref conversion.
                     # compile_value emits i32_const 0 for Nothing,
@@ -2151,115 +2143,14 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                             actual_wasm = expected_wasm
                         end
                     end
-                    # merge the arg (unless the phantom replaced it) BEFORE the bridging casts
+                    # merge the arg (unless the phantom replaced it) BEFORE the coercion
                     _ab_merged || (append_builder!(fb, _ab); _ab_merged = true)
 
-                    if expected_wasm isa ConcreteRef && actual_wasm isa ConcreteRef
-                        if expected_wasm.type_idx != actual_wasm.type_idx
-                            # Different ref types — insert ref.cast null to expected type
-                            local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                            ref_cast!(_cvb, Int64(expected_wasm.type_idx), true)
-                            append_builder!(fb, _cvb)
-                        end
-                    elseif expected_wasm isa ConcreteRef && (actual_wasm === StructRef || actual_wasm === ArrayRef || actual_wasm === AnyRef)
-                        # Abstract ref to concrete ref — insert ref.cast null
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        ref_cast!(_cvb, Int64(expected_wasm.type_idx), true)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm isa ConcreteRef && (actual_wasm === I32 || actual_wasm === I64 || actual_wasm === F32 || actual_wasm === F64)
-                        # PURE-6025: Numeric value to tagged union struct — wrap via emit_wrap_union_value.
-                        # This happens when a function expects a Union param (represented as tagged union struct)
-                        # but the actual value is a numeric type (e.g., NumType passed to Dict{WasmValType,...} key).
-                        # B4/M3: numeric → ref via THE single-source funnel (box arm; real
-                        # classId; loud trap on genuine mismatch). Dead tagged-union arm DELETED.
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        convert_type!(_cvb, actual_wasm, expected_wasm, ctx;
-                                      from_julia=(actual_julia_type isa Type && isconcretetype(actual_julia_type)) ? actual_julia_type : nothing)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm === I32 && actual_wasm === I64
-                        # i64 to i32 — insert i32.wrap_i64
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        num!(_cvb, Opcode.I32_WRAP_I64)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm === I64 && actual_wasm === I32
-                        # i32 to i64 — insert i64.extend_i32_s
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        num!(_cvb, Opcode.I64_EXTEND_I32_S)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm === F32 && actual_wasm === F64
-                        # f64 to f32 — insert f32.demote_f64
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        num!(_cvb, Opcode.F32_DEMOTE_F64)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm === F64 && actual_wasm === F32
-                        # f32 to f64 — insert f64.promote_f32
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        num!(_cvb, Opcode.F64_PROMOTE_F32)
-                        append_builder!(fb, _cvb)
-                    elseif (expected_wasm === I32 || expected_wasm === I64 || expected_wasm === F32 || expected_wasm === F64) &&
-                           (actual_wasm === AnyRef || actual_wasm === ExternRef)
-                        # P4-stdlib (Random hash_seed): boxed numeric in anyref/
-                        # externref consumed as a number — UNBOX via the numeric
-                        # box (was: drop + zero, silently wrong on live paths;
-                        # a null ref traps loud on the cast instead).
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        if actual_wasm === ExternRef
-                            any_convert_extern!(_cvb)
-                        end
-                        emit_classid_unbox!(_cvb, ctx, expected_wasm; nullable=true)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm === I32 && (actual_wasm isa ConcreteRef || actual_wasm === StructRef || actual_wasm === ArrayRef)
-                        # ref to i32 — drop and push 0 (type mismatch, likely dead code)
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        drop!(_cvb)
-                        i32_const!(_cvb, 0)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm === I64 && (actual_wasm isa ConcreteRef || actual_wasm === StructRef || actual_wasm === ArrayRef)
-                        # ref to i64 — drop and push 0 (type mismatch, likely dead code)
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        drop!(_cvb)
-                        i64_const!(_cvb, 0)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm === ExternRef && (actual_wasm isa ConcreteRef || actual_wasm === StructRef || actual_wasm === ArrayRef || actual_wasm === AnyRef)
-                        # Concrete or abstract ref to externref — insert extern.convert_any
-                        # extern.convert_any converts anyref → externref (concrete refs are subtypes of anyref)
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        extern_convert_any!(_cvb)
-                        append_builder!(fb, _cvb)
+                    convert_type!(fb, actual_wasm, expected_wasm, ctx;
+                                  from_julia=(actual_julia_type isa Type && isconcretetype(actual_julia_type)) ? actual_julia_type : nothing)
+                    # the tail target_info_early second-guess reads this flag
+                    if expected_wasm === ExternRef && actual_wasm !== ExternRef
                         extern_convert_emitted = true
-                    elseif expected_wasm === AnyRef && actual_wasm === ExternRef
-                        # PURE-9022: externref to anyref — insert any.convert_extern
-                        # Occurs when JS import returns externref but internal code expects anyref
-                        local _cvb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        any_convert_extern!(_cvb)
-                        append_builder!(fb, _cvb)
-                    elseif expected_wasm === AnyRef && (actual_wasm === I32 || actual_wasm === I64 || actual_wasm === F32 || actual_wasm === F64)
-                        # PURE-9022: Numeric value (on the stack) to anyref via THE single box emitter.
-                        # (The emitter saves the value to a local + rebuilds {classId, value}, so no
-                        # raw splice into `bytes` is needed — deletes the old insert-typeId hack.)
-                        local _bxa = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        emit_classid_box!(_bxa, ctx, actual_wasm, nothing)
-                        append_builder!(fb, _bxa)
-                    elseif expected_wasm === ExternRef && (actual_wasm === I32 || actual_wasm === I64 || actual_wasm === F32 || actual_wasm === F64)
-                        # PURE-6025: Numeric value to externref — box via the one emitter, then extern.convert_any.
-                        local _bxi = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                        emit_classid_box!(_bxi, ctx, actual_wasm, nothing)
-                        extern_convert_any!(_bxi)
-                        append_builder!(fb, _bxi)
-                        extern_convert_emitted = true
-                    elseif expected_wasm === ExternRef && actual_wasm === ExternRef
-                        # PURE-036z: Julia type inference says Any→ExternRef for both, but the actual
-                        # Wasm local might be a ConcreteRef — the emission's tracked type answers.
-                        if _ab_is_local
-                            actual_local_wasm = arg_ty
-                            if actual_local_wasm isa ConcreteRef || actual_local_wasm === StructRef || actual_local_wasm === ArrayRef || actual_local_wasm === AnyRef
-                                # Actual local is a ref type but not externref — insert conversion
-                                local _eca = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
-                                extern_convert_any!(_eca)
-                                append_builder!(fb, _eca)
-                                extern_convert_emitted = true
-                            end
-                        end
                     end
                 end
             end

--- a/src/codegen/selector_table.jl
+++ b/src/codegen/selector_table.jl
@@ -18,162 +18,10 @@
 # This file replaces the FNV-1a hash apparatus of dispatch.jl (per-function hash
 # tables + probe loops + whole-body replacement), which M8.4 DELETES.
 
-"""
-    SelectorInfo
-
-One dispatchable (generic function, arity) — dart's `SelectorInfo`
-(dispatch_table.dart:60). `targets` maps the DFS classId of the dispatch-axis
-argument to the wasm func index of the specialization compiled for it.
-"""
-mutable struct SelectorInfo
-    func_ref::Any                       # the generic function
-    arity::Int
-    axis::Int                           # 1-based dispatch-axis arg position
-    targets::Dict{Int32,UInt32}         # classId(axis arg) → wasm func idx
-    target_return_types::Dict{Int32,Type}
-    call_count::Int                     # call sites naming this selector
-    offset::Union{Nothing,Int}          # assigned by pack_selector_offsets! (M8.2)
-    multi_axis::Bool                    # >1 varying arg position (cascade, M8.3)
-end
-
-target_count(s::SelectorInfo) = length(s.targets)
-is_monomorphic(s::SelectorInfo) = target_count(s) == 1
-
-"""dart `needsDispatch` (dispatch_table.dart:401-403): used AND polymorphic."""
-needs_dispatch(s::SelectorInfo) = s.call_count > 0 && target_count(s) > 1
-
-"""
-    SelectorRegistry
-
-All selectors of a module compile + (M8.2) the one flat table layout.
-"""
-mutable struct SelectorRegistry
-    selectors::Dict{Tuple{Any,Int},SelectorInfo}   # (func_ref, arity) → info
-    table::Vector{Union{Nothing,UInt32}}           # the ONE flat table (M8.2)
-    wasm_table_idx::Union{Nothing,UInt32}
-end
-SelectorRegistry() = SelectorRegistry(Dict{Tuple{Any,Int},SelectorInfo}(), Union{Nothing,UInt32}[], nothing)
-
-"""
-    build_selectors(func_registry, type_registry) -> SelectorRegistry
-
-Group the module's registered specializations into selectors (dart
-dispatch_table.dart:380-399). For each (generic function, arity):
-
-- the DISPATCH AXIS = the first arg position whose specialization types vary
-  (Julia's dispatch column). Positions whose type is identical across all
-  specializations are not dispatch-relevant for this selector.
-- `targets[classId(axis type)] = func idx`. An axis type without a classId
-  (e.g. String until M9 — the documented exception) drops the specialization
-  from table dispatch; the selector records it via `multi_axis`-style honesty
-  only if it varies elsewhere.
-"""
-function build_selectors(func_registry, type_registry)::SelectorRegistry
-    reg = SelectorRegistry()
-    for (func_ref, infos) in func_registry.by_ref
-        length(infos) < 2 && continue   # monomorphic groups devirtualize trivially
-        by_arity = Dict{Int,Vector{Any}}()
-        for info in infos
-            push!(get!(Vector{Any}, by_arity, length(info.arg_types)), info)
-        end
-        for (arity, ainfos) in by_arity
-            length(ainfos) < 2 && continue
-            # varying positions
-            varying = Int[]
-            for pos in 1:arity
-                ts = Set{Any}(i.arg_types[pos] for i in ainfos)
-                length(ts) > 1 && push!(varying, pos)
-            end
-            isempty(varying) && continue          # duplicate registrations, not dispatch
-            axis = varying[1]
-            targets = Dict{Int32,UInt32}()
-            rets = Dict{Int32,Type}()
-            for i in ainfos
-                T = i.arg_types[axis]
-                (T isa DataType && isconcretetype(T)) || continue
-                cid = Int32(ensure_type_id!(type_registry, T))
-                # Julia specificity: last registration wins only if unseen — the
-                # func_registry registers most-specific methods once per tuple, so
-                # collisions here mean an axis tie (multi-axis case); keep the first.
-                haskey(targets, cid) || (targets[cid] = i.wasm_idx; rets[cid] = i.return_type)
-            end
-            isempty(targets) && continue
-            reg.selectors[(func_ref, arity)] = SelectorInfo(
-                func_ref, arity, axis, targets, rets, 0, nothing, length(varying) > 1)
-        end
-    end
-    return reg
-end
-
-"""
-    count_selector_calls!(reg, code_infos)
-
-dart's `callCount` (dispatch_table.dart:70): scan every compiled body's `:call`
-statements and count uses per selector. Selectors never called stay out of the
-table (needsDispatch).
-"""
-function count_selector_calls!(reg::SelectorRegistry, code_infos)
-    isempty(reg.selectors) && return reg
-    for ci in code_infos
-        ci isa Core.CodeInfo || continue
-        for stmt in ci.code
-            (stmt isa Expr && stmt.head === :call) || continue
-            callee = stmt.args[1]
-            callee isa GlobalRef || continue
-            f = try getfield(callee.mod, callee.name) catch; nothing end
-            f === nothing && continue
-            arity = length(stmt.args) - 1
-            s = get(reg.selectors, (f, arity), nothing)
-            s !== nothing && (s.call_count += 1)
-        end
-    end
-    return reg
-end
-
-"""
-    pack_selector_offsets!(reg) -> Int
-
-dart's first-fit offset packing (dispatch_table.dart:405-458): sort selectors by
-`classIds*10 + callCount` descending, then scan each from `firstAvailable -
-minClassId` until its row pattern fits the gaps. Returns the table length.
-"""
-function pack_selector_offsets!(reg::SelectorRegistry)::Int
-    sels = [s for s in values(reg.selectors) if needs_dispatch(s)]
-    sort!(sels; by=s -> -(target_count(s) * 10 + s.call_count))
-    table = reg.table
-    empty!(table)
-    first_available = 0
-    first = true
-    for s in sels
-        cids = sort!(collect(keys(s.targets)))
-        offset = first ? 0 : first_available - Int(cids[1])
-        first = false
-        while true
-            fits = true
-            for cid in cids
-                entry = offset + Int(cid)
-                entry < 0 && (fits = false; break)
-                entry >= length(table) && break          # extends the table — fits
-                table[entry + 1] !== nothing && (fits = false; break)
-            end
-            fits && break
-            offset += 1
-        end
-        s.offset = offset
-        for cid in cids
-            entry = offset + Int(cid)
-            while length(table) <= entry
-                push!(table, nothing)
-            end
-            @assert table[entry + 1] === nothing
-            table[entry + 1] = s.targets[cid]
-        end
-        while first_available < length(table) && table[first_available + 1] !== nothing
-            first_available += 1
-        end
-    end
-    return length(table)
-end
+# census F5 (march5): the M8.1 SelectorInfo/SelectorRegistry transcription
+# (a faithful dispatch_table.dart:27-77 port) was DEAD CODE — zero callers; the
+# LIVE packer is pack_dispatch_selectors! below, keyed on DispatchTableRegistry.
+# Deleted rather than kept as reference: the dart source IS the reference.
 
 # ============================================================================
 # M8.2 — route single-axis dispatch through the ONE dart table
@@ -187,8 +35,8 @@ dispatch axis; SINGLE-AXIS tables (exactly one varying typeId position — keyin
 on that axis alone is provably equivalent to the full-tuple key) get first-fit
 packed into ONE flat funcref table (dart dispatch_table.dart:405-458). Offsets +
 positions land on `dt_registry`; elements are filled after wrapper emission by
-[`fill_selector_table_elements!`](@ref). Multi-axis tables keep the FNV probe
-(the M8.3 cascade replaces it).
+[`fill_selector_table_elements!`](@ref). Multi-axis tables dispatch via the
+M8.3 CASCADE (composed single-axis hops through the SAME table; FNV is deleted).
 """
 const _ST_BASE_IDX = Base.RefValue{UInt32}(0)
 _st_base_idx(_) = _ST_BASE_IDX[]

--- a/src/codegen/strings.jl
+++ b/src/codegen/strings.jl
@@ -212,41 +212,8 @@ end
 # Stack Trace Support — JS new Error().stack Import
 # ============================================================================
 
-"""
-    add_stack_trace_import!(mod) -> func_idx
-
-Add a `capture_stack` import that returns an externref containing the JS
-stack trace string from `new Error().stack`. Used for backtrace support
-in exception handling.
-
-Returns the import function index.
-"""
-function add_stack_trace_import!(mod::WasmModule)
-    # capture_stack: () → externref
-    func_idx = add_import!(mod, "env", "capture_stack",
-        WasmValType[],
-        WasmValType[ExternRef])
-    return func_idx
-end
-
-"""
-    ensure_stack_trace_global!(mod) -> global_idx
-
-Ensure a module-level `\$current_stack_trace (mut externref)` global exists.
-Returns the global index.
-"""
-function ensure_stack_trace_global!(mod::WasmModule)
-    # Check if already added
-    for (i, g) in enumerate(mod.globals)
-        if g.valtype === ExternRef && g.mutable
-            return UInt32(i - 1)
-        end
-    end
-    # Add new global: (global $current_stack_trace (mut externref) ref.null extern)
-    init_expr = UInt8[0xD0, 0x6F, 0x0B]  # ref.null extern, end
-    idx = add_global!(mod, ExternRef, true, init_expr)
-    return idx
-end
+# census F7 (march5): add_stack_trace_import!/ensure_stack_trace_global! deleted
+# with the dormant PURE-9036 cluster (see generate.jl note; rebuild = D9.1 typed tag).
 
 # ============================================================================
 # IO Bridge — println/print via JS Imports

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -182,7 +182,7 @@ so that `isa(x, AbstractType)` becomes an O(1) range check:
 
 IDs start at 1 (0 is reserved for unknown/unassigned).
 """
-function assign_type_ids!(registry::TypeRegistry)
+function assign_type_ids!(registry::TypeRegistry; extra_concrete_types::Union{Nothing,Set{DataType}}=nothing)
     # Collect all concrete types from the registry that have typeId (field_offset > 0)
     concrete_types = Set{DataType}()
     for (T, info) in registry.structs
@@ -190,6 +190,10 @@ function assign_type_ids!(registry::TypeRegistry)
             push!(concrete_types, T)
         end
     end
+    # census F2 (march5): the closed world — IR-reachable types enter the numbering
+    # even before (or without) struct registration; their ids/ranges are what isa
+    # and the checked cast read, and lazy registration later reuses the same id.
+    extra_concrete_types !== nothing && union!(concrete_types, extra_concrete_types)
 
     # Also include primitive numeric types that may need boxing/dispatch
     # PURE-9028: Include Nothing for BoxedNothing typeId

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -371,30 +371,9 @@ function emit_type_id!(bytes::Vector{UInt8}, registry::TypeRegistry, T::Type)
     append!(bytes, builder_code(b))
 end
 
-"""
-    emit_box_type_id!(bytes::Vector{UInt8}, registry::TypeRegistry, wasm_type::WasmValType)
-
-PURE-9028: Emit `i32.const <typeId>` for a boxed primitive value.
-Maps WasmValType → default Julia type → DFS typeId.
-INTERNAL: the sole caller is now `emit_classid_box!`'s `julia_type === nothing` fallback (the
-site sweep routed every former direct caller through that one producer). Because it maps to the
-*default* Julia type per width (every i64→Int64), it only distinguishes by width — a box that
-carries the value's real classId must pass `julia_type` to `emit_classid_box!` instead.
-"""
-function emit_box_type_id!(bytes::Vector{UInt8}, registry::TypeRegistry, wasm_type::WasmValType)
-    julia_type = if wasm_type === I32
-        Int32
-    elseif wasm_type === I64
-        Int64
-    elseif wasm_type === F32
-        Float32
-    elseif wasm_type === F64
-        Float64
-    else
-        Any
-    end
-    emit_type_id!(bytes, registry, julia_type)
-end
+# census F5 (march5): emit_box_type_id! DELETED — zero callers (the docstring's
+# "sole caller is emit_classid_box!'s fallback" was stale: that fallback inlines
+# emit_type_id! with the width-default type directly, values.jl:513).
 
 # (B4: the i31 boxing helpers emit_box_i31! / emit_unbox_i31_s! / emit_unbox_i31_u! /
 # should_use_i31 were DELETED — dart2wasm uses no i31, and B4 routed every former i31 site
@@ -1110,7 +1089,14 @@ function get_numeric_box_type!(mod::WasmModule, registry::TypeRegistry, wasm_typ
     end
     # PURE-9024: Prepend typeId:i32 as field 0 (universal object layout)
     fields = [FieldType(I32, false), FieldType(wasm_type, false)]  # typeId + value
-    type_idx = add_struct_type!(mod, fields)
+    # census F1 (march5): declare `sub $JlBase` AT CREATION (dart class_info.dart:288 —
+    # every class struct subtypes its super at definition). The finalization retrofit
+    # (set_struct_supertypes!) already made this true in the EMITTED module; creating it
+    # true lets the strict builder use the subtype relation DURING emission (a box-typed
+    # ref validates where a $JlBase ref is expected — the typed-channel prerequisite).
+    base = registry.base_struct_idx
+    type_idx = base === nothing ? add_struct_type!(mod, fields) :
+               add_type!(mod, StructType(fields, base))
     registry.numeric_boxes[wasm_type] = type_idx
     return type_idx
 end

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -81,6 +81,10 @@ mutable struct TypeRegistry
     # Populated by a pre-pass over an enclosing fn's IR (populate_box_field_types!); consulted by
     # register_closure_type! to type the captured-box field as a typed Box{contents} (else anyref).
     box_contents_types::Union{Nothing, Dict{Type, WasmValType}}
+    # census F3 (march5, dart constants.dart:427-443): interned string-constant globals —
+    # every use of an equal short string literal reads ONE deduplicated global
+    # (code size + `===` identity like dart). Keyed by the string value.
+    string_constant_globals::Union{Nothing, Dict{String, UInt32}}
 end
 
 TypeRegistry() = TypeRegistry(
@@ -92,7 +96,8 @@ TypeRegistry() = TypeRegistry(
     nothing, nothing, nothing, nothing, nothing, nothing, nothing,
     nothing,  # string_hash_func_idx
     Dict{WasmValType, UInt32}(),  # box_types (F3)
-    Dict{Type, WasmValType}()     # box_contents_types (F3 L2)
+    Dict{Type, WasmValType}(),    # box_contents_types (F3 L2)
+    Dict{String, UInt32}()        # string_constant_globals (census F3)
 )
 
 # TRUE-INT-002: Dict-free constructor for WASM self-hosting.
@@ -107,8 +112,45 @@ TypeRegistry(::Val{:minimal}) = TypeRegistry(
     nothing, nothing, nothing, nothing, nothing, nothing, nothing,
     nothing,  # string_hash_func_idx
     nothing,  # box_types (F3)
-    nothing   # box_contents_types (F3 L2)
+    nothing,  # box_contents_types (F3 L2)
+    nothing   # string_constant_globals (census F3)
 )
+
+"""
+    get_string_constant_global!(mod, registry, s) -> Union{UInt32, Nothing}
+
+census F3 (march5) — INTERNED string constants, dart's constant→deduplicated-global
+architecture (constants.dart:427-443 ensureConstant; small strings eager via
+array_new_fixed, :512-564). Every use of an equal short literal reads ONE global,
+matching dart's code-size and `===`-identity semantics. Strings longer than the
+eager threshold return `nothing` (they keep the inline data-segment path — dart
+handles those with LAZY init functions, deferred here because init functions
+cannot be added during body compilation without shifting function indices).
+"""
+function get_string_constant_global!(mod::WasmModule, registry::TypeRegistry, s::String)::Union{UInt32, Nothing}
+    registry.string_constant_globals === nothing && return nothing
+    ncodeunits(s) > 64 && return nothing   # eager threshold (dart lazies large constants)
+    haskey(registry.string_constant_globals, s) && return registry.string_constant_globals[s]
+    struct_idx = get_string_struct_type!(mod, registry)
+    arr_idx = get_string_array_type!(mod, registry)
+    # constant initializer: i32.const classId; per-byte i32.const; array.new_fixed; struct.new
+    init = UInt8[]
+    push!(init, Opcode.I32_CONST)
+    append!(init, encode_leb128_signed(Int64(ensure_type_id!(registry, String))))
+    bytes = codeunits(s)
+    for b in bytes
+        push!(init, Opcode.I32_CONST)
+        append!(init, encode_leb128_signed(Int64(b)))
+    end
+    push!(init, Opcode.GC_PREFIX, Opcode.ARRAY_NEW_FIXED)
+    append!(init, encode_leb128_unsigned(UInt64(arr_idx)))
+    append!(init, encode_leb128_unsigned(UInt64(length(bytes))))
+    push!(init, Opcode.GC_PREFIX, Opcode.STRUCT_NEW)
+    append!(init, encode_leb128_unsigned(UInt64(struct_idx)))
+    g = add_global_ref!(mod, struct_idx, false, init; nullable=false)
+    registry.string_constant_globals[s] = g
+    return g
+end
 
 """
     get_datatype_type_idx(registry::TypeRegistry) → UInt32

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -488,7 +488,7 @@ convert_type!(b::InstrBuilder, ::WasmValType, ::Nothing, ::AbstractCompilationCo
 # ONE producer + ONE consumer that ALL boxing/discrimination routes through. The former ~41
 # scattered emit_box_type_id!+struct_new ladders (flow/conditionals/statements return boxes,
 # stackified phi-edge boxes, calls/invoke arg+ret boxes, tuple-field boxes) have ALL been
-# collapsed onto this producer; emit_box_type_id! survives only as this producer's private
+# collapsed onto this producer; the old emit_box_type_id! helper is DELETED (census F5) — its
 # wasm-rep classId fallback (values.jl below). Added DORMANT in F-i (byte-identical); wired via
 # convert_type!'s box/unbox arms + the isa sites in F-ii; the site sweep finished in Loop C.
 # ============================================================================
@@ -498,7 +498,7 @@ convert_type!(b::InstrBuilder, ::WasmValType, ::Nothing, ::AbstractCompilationCo
 
 Box the numeric value on the stack into a `{classId:i32, value:wasm_type}` struct (the
 canonical numeric box, which subtypes `\$JlBase`). Stores the REAL Julia-type classId when
-`julia_type` is given; otherwise the wasm-rep id fallback (`emit_box_type_id!`) for sites
+`julia_type` is given; otherwise the inline wasm-rep-id fallback (width-default type) for sites
 that don't yet carry the Julia type — those distinguish only by width until they migrate.
 Pushes the box ref. This is THE single boxing producer (dart `convertType` box arm).
 """

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -398,6 +398,9 @@ function convert_type!(b::InstrBuilder, from::WasmValType, to::WasmValType,
         return b
     elseif _wt_is_ref(from) && !_wt_is_ref(to)
         # ref→numeric: UNBOX (F-ii). Narrow to the `to` numeric box, read its value field.
+        # march5 F8: an externref source crosses the boundary first (the box lives
+        # under anyref; ref.cast from externref is not wasm-valid).
+        from === ExternRef && any_convert_extern!(b)
         emit_classid_unbox!(b, ctx, to)
         return b
     elseif _wt_is_ref(from) && _wt_is_ref(to)
@@ -470,6 +473,12 @@ function convert_type!(b::InstrBuilder, from::WasmValType, to::WasmValType,
             num!(b, Opcode.F32_CONVERT_I64_S)
         elseif from === I32 && to === F32
             num!(b, Opcode.F32_CONVERT_I32_S)
+        # march5 F8: the NARROWING arms (dart throws here; Julia call boundaries
+        # genuinely narrow — e.g. an Int64 value meeting an Int32 param)
+        elseif from === I64 && to === I32
+            num!(b, Opcode.I32_WRAP_I64)
+        elseif from === F64 && to === F32
+            num!(b, Opcode.F32_DEMOTE_F64)
         end
     end
     return b

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -1087,6 +1087,14 @@ function _compile_value_b(val, ctx::AbstractCompilationContext)::InstrBuilder
         f64_const!(b, val)
 
     elseif val isa String
+        # census F3 (march5): short literals read the ONE interned global (dart
+        # constants.dart dedup — code size + `===` identity); the inline
+        # data-segment path remains for long strings (dart lazies those).
+        local _sg = get_string_constant_global!(ctx.mod, ctx.type_registry, val)
+        if _sg !== nothing
+            global_get!(b, _sg, ConcreteRef(get_string_struct_type!(ctx.mod, ctx.type_registry), false))
+            return b
+        end
         # PURE-9013: String constant via passive data segment + array.new_data
         # parity(M9): then WRAPPED as the classed string {classId, data} (the ONE producer).
         type_idx = get_string_array_type!(ctx.mod, ctx.type_registry)

--- a/test/m8_selector_table.jl
+++ b/test/m8_selector_table.jl
@@ -1,46 +1,6 @@
-# parity(M8.1): the dart-shaped selector registry (dispatch_table.dart:380-458).
-# Locks: axis detection · monomorphic classification · needsDispatch gating ·
-# first-fit offset packing with gap reuse across selectors.
-module M8SelectorShapes
-struct B1 end; struct B2 end; struct B3 end; struct B4 end; struct B5 end
-struct B6 end; struct B7 end; struct B8 end; struct B9 end; struct B10 end
-end
-@testset "M8.1 selector registry (dart dispatch_table shape)" begin
-    using .M8SelectorShapes: B1,B2,B3,B4,B5,B6,B7,B8,B9,B10
-    kinds = (B1,B2,B3,B4,B5,B6,B7,B8,B9,B10)
-    poly(x) = 0
-    duo(x) = 1
-    mono(x) = 2
-    freg = WasmTarget.FunctionRegistry()
-    treg = WasmTarget.TypeRegistry()
-    for (i, T) in enumerate(kinds)
-        WasmTarget.register_function!(freg, "poly_$i", poly, (T,), UInt32(100 + i), Int64)
-    end
-    WasmTarget.register_function!(freg, "duo_1", duo, (B1,), UInt32(300), Int64)
-    WasmTarget.register_function!(freg, "duo_2", duo, (B2,), UInt32(301), Int64)
-    WasmTarget.register_function!(freg, "mono_1", mono, (B1,), UInt32(400), Int64)
-
-    reg = WasmTarget.build_selectors(freg, treg)
-    @test haskey(reg.selectors, (poly, 1))
-    @test haskey(reg.selectors, (duo, 1))
-    @test !haskey(reg.selectors, (mono, 1))          # 1 registration ⇒ no selector
-    s = reg.selectors[(poly, 1)]
-    d = reg.selectors[(duo, 1)]
-    @test s.axis == 1 && !s.multi_axis
-    @test WasmTarget.target_count(s) == 10
-    @test !WasmTarget.needs_dispatch(s)              # dart: callCount==0 ⇒ no table entry
-    s.call_count = 5; d.call_count = 1
-    @test WasmTarget.needs_dispatch(s) && WasmTarget.needs_dispatch(d)
-
-    n = WasmTarget.pack_selector_offsets!(reg)
-    @test n >= 10
-    # every row resolves for BOTH selectors (no collisions in the one table)
-    for sel in (s, d), (cid, fidx) in sel.targets
-        @test reg.table[sel.offset + Int(cid) + 1] == fidx
-    end
-    # dart sort weight: poly (10 targets) packs before duo (2 targets)
-    @test s.offset == 0
-end
+# census F5 (march5): the M8.1 SelectorInfo-transcription unit test is DELETED with
+# its subject — the transcription was dead production code (zero callers; the live
+# packer is pack_dispatch_selectors!, covered end-to-end by the M8.2 testset below).
 
 # M8.2: the dart virtual call end-to-end — classId + offset + call_indirect through
 # the ONE flat table, replacing the FNV probe for single-axis selectors.

--- a/test/march3_try_backfills.jl
+++ b/test/march3_try_backfills.jl
@@ -64,3 +64,40 @@ _m5_cast_box(b::Bool)::Int64 = (x = b ? Any[Int64(9)] : Any["s"];
     @test compare_julia_wasm(_m5_cast_box, true).pass
     @test compare_julia_wasm(_m5_cast_box, false).pass
 end
+
+# march5 (census D9.4): the try/finally differential battery — Julia inlines the
+# finalizer on each exit path; each shape verified native-vs-wasm. f_fin4's shape
+# (nested finally inside catch, non-throwing arm) caught a REAL wrong-value bug:
+# the normal path fell through the outer landing end INTO the handler, whose
+# fall-through phi-edge store overwrote the merge value with the catch edge's
+# (51→57). Fixed with the outer-merge skip machinery in generate_nested_try_catch_2.
+_m5_fin1(x::Int64)::Int64 = (acc = 0; try; try; x > 5 && error("big"); acc += 1
+    finally; acc += 100; end; catch; acc += 7; end; acc)
+_m5_fin2(x::Int64)::Int64 = (acc = 0; try; x > 5 && return acc + 1000; acc += 1
+    finally; acc += 100; end; acc)
+_m5_fin3(n::Int64)::Int64 = (t = 0; for i in 1:n; try; i > 3 && break; t += i
+    finally; t += 10; end; end; t)
+_m5_fin4(x::Int64)::Int64 = (r = 0; try; try; x > 2 && error("inner"); r += 1
+    finally; r += 50; end; catch; r += 7; end; r)
+
+@testset "march5: try/finally battery (D9.4)" begin
+    for (f, xs) in ((_m5_fin1, (3, 9)), (_m5_fin2, (3, 9)), (_m5_fin3, (2, 8)), (_m5_fin4, (1, 5)))
+        for x in xs
+            @test compare_julia_wasm(f, Int64(x)).pass
+        end
+    end
+end
+
+# march5 (census D10.1): async is OUT-OF-SCOPE BY DESIGN — this locks the
+# "sound loud-reject" guarantee (a Task/@async entry must REJECT at compile,
+# never silently miscompile).
+_m5_task(x::Int64)::Int64 = fetch(Threads.@spawn x + 1)
+@testset "march5: async loud-reject conformance (D10.1)" begin
+    rejected = try
+        WasmTarget.compile_multi(Any[(_m5_task, (Int64,), "m5_task")]; strict=true, validate=true)
+        false
+    catch
+        true
+    end
+    @test rejected
+end

--- a/test/march3_try_backfills.jl
+++ b/test/march3_try_backfills.jl
@@ -27,18 +27,40 @@ _m3_try_rethrow(x::Int64)::Int64 = try; x == 3 ? error("boom") : x; catch e; x +
     @test compare_julia_wasm(_m3_try_rethrow, Int64(7)).pass
 end
 
-# march3 FINDING (pre-existing, silent wrong value — NOT introduced by the march;
-# verified identical on parent 67b09a5^): `isa` over Any[] against a LOCALLY-defined
-# abstract hierarchy returns false for struct members (exp 21, act 3 — each `e isa _AZ`
-# yields false). The registered-at-compile DFS range apparently misses Main-defined
-# hierarchies in the single-entry compile. Track until the isa/classId dimension revisits.
+# march3 FINDING → FIXED by march5's census-F2 closed-world numbering (the
+# _register_reachable_ir_types! pre-pass): Main-defined hierarchies now enter the
+# one whole-world DFS before codegen, so `isa` gets a real [low, high] range.
+# HARD-LOCKED (was @test_broken while the classId universe was open).
 abstract type _M3AZ end
 struct _M3B1 <: _M3AZ; x::Int64; end
 struct _M3B2 <: _M3AZ; y::Float64; end
 _m3_isa_local_hier(x::Int64)::Int64 =
     (v = Any[_M3B1(x), _M3B2(2.5), "s"]; c = 0; for e in v; c += e isa _M3AZ ? 10 : 1; end; c)
 
-@testset "march3: isa over Any[] w/ local abstract hierarchy (documented gap)" begin
+@testset "march5: isa over Any[] w/ local abstract hierarchy (FIXED — closed-world DFS)" begin
     r = try compare_julia_wasm(_m3_isa_local_hier, Int64(1)) catch; (pass=false,) end
-    @test_broken r.pass
+    @test r.pass
+end
+
+# march5 (census F2+F4): the closed-world classId universe + the checked cast.
+# Multi-level Main-defined hierarchies (mid-abstract ranges), typeassert throw-parity
+# over structs and boxed numerics — all through the ONE whole-world DFS.
+abstract type _M5Z end
+abstract type _M5Mid <: _M5Z end
+struct _M5A <: _M5Mid; a::Int64; end
+struct _M5B <: _M5Mid; b::Float64; end
+struct _M5C <: _M5Z; c::Int64; end
+_m5_hier(x::Int64)::Int64 = (v = Any[_M5A(x), _M5B(1.5), _M5C(x), 7]; c = 0;
+    for e in v; c += (e isa _M5Mid ? 100 : 0) + (e isa _M5Z ? 10 : 0) + (e isa Integer ? 1 : 0); end; c)
+_m5_cast_struct(b::Bool)::Int64 = (x = b ? Any[_M5A(3)] : Any[_M5C(4)];
+    try; (x[1]::_M5A).a; catch; -5; end)
+_m5_cast_box(b::Bool)::Int64 = (x = b ? Any[Int64(9)] : Any["s"];
+    try; x[1]::Int64 + 1; catch; -7; end)
+
+@testset "march5: closed-world isa + checked casts" begin
+    @test compare_julia_wasm(_m5_hier, Int64(2)).pass
+    @test compare_julia_wasm(_m5_cast_struct, true).pass
+    @test compare_julia_wasm(_m5_cast_struct, false).pass
+    @test compare_julia_wasm(_m5_cast_box, true).pass
+    @test compare_julia_wasm(_m5_cast_box, false).pass
 end

--- a/test/parity_ratchet.jl
+++ b/test/parity_ratchet.jl
@@ -101,6 +101,23 @@ const METRICS = [
     "R7_raw_coercion_ops" => ("numeric-coercion opcodes outside values.jl's convert_type! funnel (M2 → intrinsic floor)",
         () -> count_sites(r"I32_WRAP_I64|I64_EXTEND_I32_S|I64_EXTEND_I32_U|I64_TRUNC_F|I32_TRUNC_F|F64_CONVERT_I|F32_CONVERT_I|F32_DEMOTE_F64|F64_PROMOTE_F32";
                           roots=[CODEGEN], exclude_files=["values.jl"])),
+    # ── marches 6-9 progress ratchets (mapped 2026-07-05, discovery-grounded;
+    # see dev/PARITY_MASTER.md § MARCHES 6-10 for each metric's anchor census) ──
+    "R12_try_drivers" => ("shape-specialized try/catch drivers (march 6 → 1: dart's ONE visitTryCatch)",
+        () -> count_sites(r"^function (generate_(try_catch|branch_split_try|catch_arm|catch_try_chain|sequential_try_catch|nested_try_catch)|_compile_(catch_region|try_body))";
+                          exclude_line=nothing)),
+    "R13_catch_all_clauses" => ("catch_all_clause emissions (march 6 → 0: the typed (exn,stackTrace) tag catches; catch_all reserved for host exns)",
+        () -> count_sites(r"catch_all_clause"; exclude_line=r"function |catch_all_clause`")),
+    "R14_fresh_constant_structs" => ("struct_new!(b in values.jl — fresh heap-constant materializations (march 7 → 2: the ONE ensureConstant funnel dedups; 2 = the wrap/box helper sites)",
+        () -> count_sites(r"struct_new!\(b"; roots=[joinpath(SRC, "codegen")], exclude_files=setdiff(readdir(joinpath(SRC, "codegen")), ["values.jl"]))),
+    "R15_constant_data_segments" => ("add_passive_data_segment! in values.jl (march 7 → 0: interned/shared segments, dart constants.dart:541)",
+        () -> count_sites(r"add_passive_data_segment!"; exclude_files=["builder/instructions.jl", "codegen/strings.jl", "codegen/compile.jl", "codegen/interpreter.jl"])),
+    "R16_external_convert_ladders" => ("convert_type! callers outside values.jl (march 8 → 0: fold into the 4-arg wrap)",
+        () -> count_sites(r"convert_type!\("; exclude_files=["codegen/values.jl"], exclude_line=r"function convert_type!")),
+    "R17_unwrapped_value_emissions" => ("3-arg emit_value! sites — no expectedType (march 8 → ~40 floor: dart wraps 100%)",
+        () -> count_sites(r"emit_value!\([^()]*, ctx\)"; exclude_line=r"function emit_value!")),
+    "R18_anyref_dispatch_sigs" => ("fill(AnyRef dispatch signatures (march 9 → 0: dart per-param LUB, dispatch_table.dart:86-205)",
+        () -> count_sites(r"fill\(AnyRef"; exclude_line=nothing)),
     "R11_patch_markers" => ("patch-tag comment sediment PURE-/WBUILD-/CG-/TRUE-PARSE-/E2E- (monotone down via root-fixes)",
         () -> begin  # markers live IN comments, so count comment lines too
             n = 0


### PR DESCRIPTION
# March 5: the certification-census queue executed to its floor

The post-census parity march — every item from the 2026-07-04 census's ranked queue except the two deep next-phase projects. Same rules: dart-anchored, shard-gated per commit, batteries committed. Record: `dev/PARITY_MASTER.md` § "MARCH 5".

## The closed-world classId universe (F2 — the census's #1)

`_register_reachable_ir_types!` walks every function's typed-IR ssa/arg/return types, decomposes Unions, and registers every eligible concrete struct BEFORE the one DFS — dart's whole-component numbering (`class_info.dart:583-690`). `ensure_type_id!` is now the rare range-less fallback instead of the systematic escape hatch. **The pinned isa-over-`Any[]` `@test_broken` flipped to `@test`.**

## The checked cast (F4 — dart `emitAsCheck`)

`Core.typeassert` was a silent pass-through; a failing cast surfaced as a downstream **uncatchable** `ref.cast` trap where native threw a catchable `TypeError`. Now: tee → `ref.test $JlBase` → typeof → classId range → tag-0 throw on mismatch (throw-parity as the contract; statically-proven casts pass through; non-discriminable refs under-check, never wrong-throw). Battery covers structs and boxed numerics, both arms.

## Universal wrap (F8 — dart's defining invariant)

Both argument-marshalling ladders — `compile_invoke`'s (10.9KB, 14 arms) and `compile_call`'s twin (8.2KB, 12 arms), each a hand-rolled re-implementation of `convertType`'s quadrants — are now **one `convert_type!` call each**, with the emission's tracked type refining `actual` (dart carries the type with the value). THE funnel gained its missing quadrants (i64→i32, f64→f32, externref-source unbox). The ladders' silent drop-and-push-zero arms became loud traps, per dart's semantics and the M5 ethos.

## Interned string constants (F3 — dart `constants.dart`)

Short literals (≤64B) each read ONE immutable global (constant `array.new_fixed` initializer) — dart's dedup-into-globals shape. `"hello" === "hello"` is now true in wasm (previously two fresh allocations compared unequal). Long strings keep the inline path (dart lazies those; init functions can't be added mid-compile — documented).

## A real wrong-value miscompile, caught by the census's own battery (D9.4)

The try/finally differential battery the census demanded caught a live bug on its first run: nested finally inside catch, **non-throwing arm** — native 51, wasm 57. The normal path fell through the outer landing-block end INTO the handler, whose fall-through phi-edge store overwrote the merge value with the catch edge's. Fixed with outer-merge skip machinery in `generate_nested_try_catch_2` (mirroring the inner-merge machinery). Exhibit N for D9.5's ONE-lowering direction.

## Boxes, dead code, conformance locks

- **F1**: numeric boxes declare `sub $JlBase` at CREATION (the census over-claimed — the finalization retrofit existed; the real gap was emission-time subtype reasoning; census corrected).
- **F5**: the dead M8.1 SelectorInfo transcription (6.3KB + its unit test), `emit_box_type_id!`, and the stale FNV comments — deleted.
- **F7**: the dormant PURE-9036 stack-trace cluster deleted (zero callers); the rebuild is D9.1's typed tag payload.
- **D10.1**: the async loud-reject conformance lock (a `@spawn` entry must REJECT at compile).

## Remaining (next phase)

D9.1/D9.2 typed exception tag `(exn, stackTrace)` + catch_all reserved for host exceptions; D9.5 the try-driver family → ONE lowering. Minor floors listed in the record.
