### PR TITLE
parity: marches 8+9 — the wrap chokepoint's decide-before-emit + structurally-sound multi-range isa

### DIFF
--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -682,3 +682,14 @@ instr-inspection surgeries are now foldable). The R17 tail (3-arg sites with der
 expectations) is CONSOLIDATION-FLOOR material (R5/R11 class): individually sound today
 (sinks coerce), monotone ratchet holds the line, ground down opportunistically —
 NOT a blocker for the tag. march 9-10 take the night.
+
+## MARCH 9 — CLOSED WITH REMAINDER (2026-07-06, overnight)
+LANDED: **multi-range classId checks** — drift ids record onto abstract ancestors at
+ensure_type_id!; isa/typeassert check the DFS range PLUS extras (dart 3862-3883); the
+F2 drift class is now closed STRUCTURALLY, not just empirically. **Closures: defer
+RECORDED** (§MARCH 9 mapping — 100% static, call_ref built+unused, nothing needs it).
+REMAINDER (scoped, next session — NOT blind-overnight material): **LUB fast lane +
+threshold** — the coordinated change spans FOUR sites (metadata sig, wrapper prologues,
+caller body, AND the dispatch fn's own signature → ripples to every call site of every
+dispatched generic); requires the full fuzz corpus per change. The multi-axis-2-8
+unreachable hole closes WITH the threshold work (they're the same change).

--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -671,3 +671,14 @@ singleton/closure/Module/Tuple/Int128) · Symbols join the intern registry ·
 content-addressed passive segments (dart :541). REMAINING: the literal pre-pass + LAZY
 constants (init-fns before the compile.jl:1641 index freeze) · boxed-scalar dedup
 (post-march-8: needs expectedType at the scalar arms).
+
+## MARCH 8 — RESCOPED HONESTLY (2026-07-06, overnight): substantially adopted through 5-7
+The discovery's own verdict held: R3/R5 are surviving getStaticType surface, and the
+march-5/6/7 restructurings made the "13 external ladders" wrap-shaped (emit → tracked
+actual → THE funnel = wrap's literal body; the census anchors predate them). LANDED this
+march: the 4-arg chokepoint gained DECIDE-BEFORE-EMIT for the Nothing phantom (a Nothing
+value meeting a ref expectation emits ref.null directly — the callers' post-hoc
+instr-inspection surgeries are now foldable). The R17 tail (3-arg sites with derivable
+expectations) is CONSOLIDATION-FLOOR material (R5/R11 class): individually sound today
+(sinks coerce), monotone ratchet holds the line, ground down opportunistically —
+NOT a blocker for the tag. march 9-10 take the night.

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -1543,7 +1543,9 @@ function _compile_call_isa(args, fb::InstrBuilder, ctx::AbstractCompilationConte
                 emit_typeof!(bld, _base_idx)
                 # dart's 3-instruction unsigned window via THE single range discriminator
                 # (was tee + ge_s/le_s/and with a temp local).
-                emit_classid_range_check!(bld, _low, _high)
+                emit_classid_ranges!(bld, ctx, _low, _high,
+                    ctx.type_registry.type_extra_ids === nothing ? Int32[] :
+                    get(ctx.type_registry.type_extra_ids, check_type isa DataType && !isempty(check_type.parameters) ? check_type.name.wrapper : check_type, Int32[]))
                 end_block!(bld)
             else
                 # No DFS range for this abstract type — return false
@@ -3734,7 +3736,9 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                     if_!(fb)                                   # discriminable ($JlBase struct)
                     local_get!(fb, UInt32(_ta_tmp))
                     emit_typeof!(fb, _ta_base)
-                    emit_classid_range_check!(fb, _ta_low, _ta_high)
+                    emit_classid_ranges!(fb, ctx, _ta_low, _ta_high,
+                        ctx.type_registry.type_extra_ids === nothing ? Int32[] :
+                        get(ctx.type_registry.type_extra_ids, _ta_target isa DataType && !isempty(_ta_target.parameters) ? _ta_target.name.wrapper : _ta_target, Int32[]))
                     num!(fb, Opcode.I32_EQZ)
                     if_!(fb)                                   # out of range → THROW
                     # null-payload throw (the union_bottom_throw_stub shape): TypeError

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -94,6 +94,11 @@ mutable struct TypeRegistry
     # uninitialized global + a pre-created init function; use = global.get + br_on_non_null
     # + call init. Keyed by value → (global_idx, init_fn_idx).
     lazy_string_globals::Union{Nothing, Dict{String, Tuple{UInt32, UInt32}}}
+    # march9: post-DFS drift ids — a concrete type numbered AFTER the closed-world DFS
+    # (ensure_type_id! max+1) lies outside every abstract's [low,high]; each abstract
+    # ancestor records it here so isa checks the range PLUS these (dart's multi-range,
+    # code_generator.dart:3862-3883). Makes isa sound INDEPENDENT of numbering order.
+    type_extra_ids::Union{Nothing, Dict{Type, Vector{Int32}}}
 end
 
 TypeRegistry() = TypeRegistry(
@@ -108,7 +113,8 @@ TypeRegistry() = TypeRegistry(
     Dict{Type, WasmValType}(),    # box_contents_types (F3 L2)
     Dict{Any, UInt32}(),          # constant_globals (march7 ensureConstant)
     Dict{String, UInt32}(),       # string_constant_globals (census F3)
-    Dict{String, Tuple{UInt32, UInt32}}()   # lazy_string_globals (march7)
+    Dict{String, Tuple{UInt32, UInt32}}(),  # lazy_string_globals (march7)
+    Dict{Type, Vector{Int32}}()             # type_extra_ids (march9)
 )
 
 # TRUE-INT-002: Dict-free constructor for WASM self-hosting.
@@ -126,7 +132,8 @@ TypeRegistry(::Val{:minimal}) = TypeRegistry(
     nothing,  # box_contents_types (F3 L2)
     nothing,  # constant_globals (march7)
     nothing,  # string_constant_globals (census F3)
-    nothing   # lazy_string_globals (march7)
+    nothing,  # lazy_string_globals (march7)
+    nothing   # type_extra_ids (march9)
 )
 
 """
@@ -452,6 +459,16 @@ function ensure_type_id!(registry::TypeRegistry, T::Type)::Int32
     end
     new_id = max_id + Int32(1)
     registry.type_ids[T] = new_id
+    # march9: record the drift id on every abstract ancestor — isa checks the DFS
+    # range PLUS these extras (dart's multi-range), so numbering order can't break it.
+    if registry.type_extra_ids !== nothing && T isa DataType && isconcretetype(T)
+        anc = supertype(T)
+        while anc !== Any && anc isa DataType
+            base = isempty(anc.parameters) ? anc : anc.name.wrapper
+            base isa DataType && push!(get!(Vector{Int32}, registry.type_extra_ids, base), new_id)
+            anc = supertype(anc)
+        end
+    end
     return new_id
 end
 

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -622,6 +622,25 @@ function emit_classid_range_check!(b::InstrBuilder, low::Integer, high::Integer)
     return b
 end
 
+"""march9 — dart's MULTI-range check (code_generator.dart:3862-3883): the DFS range
+plus the post-DFS drift ids. typeId is on the stack; result i32. Uses a scratch local
+when extras exist."""
+function emit_classid_ranges!(b::InstrBuilder, ctx::AbstractCompilationContext,
+                              low::Integer, high::Integer, extras::Vector{Int32})
+    isempty(extras) && return emit_classid_range_check!(b, low, high)
+    sc = allocate_local!(ctx, I32)
+    local_tee!(b, sc)
+    emit_classid_range_check!(b, low, high)
+    for x in extras
+        (low <= x <= high) && continue
+        local_get!(b, UInt32(sc))
+        i32_const!(b, Int64(x))
+        num!(b, Opcode.I32_EQ)
+        num!(b, Opcode.I32_OR)
+    end
+    return b
+end
+
 """
     emit_isa_classid!(b, ctx, box_idx, check_type)
 

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -821,6 +821,23 @@ shape stays consistent, matching dart's posture that unreachable code still vali
 """
 function emit_value!(b::InstrBuilder, val, ctx::AbstractCompilationContext,
                      expected::WasmValType; from_julia::Union{Type,Nothing}=nothing)::WasmValType
+    # march8: DECIDE-BEFORE-EMIT for the Nothing phantom — a Nothing value meeting a
+    # ref-typed expectation emits ref.null DIRECTLY (the callers' post-hoc _ab.instrs
+    # i32.const-inspection surgeries die; this was THE blocker for folding the arg
+    # weaves into this one chokepoint).
+    local _is_nothing_val = val === nothing || (val isa GlobalRef && val.name === :nothing) ||
+        (val isa Core.SSAValue && (begin
+            local _st = ctx.code_info.code[val.id]
+            (_st isa GlobalRef && _st.name === :nothing) || (_st isa Core.PiNode && _st.typ === Nothing)
+        end)) || from_julia === Nothing
+    if _is_nothing_val && _wt_is_ref(expected)
+        if expected isa ConcreteRef
+            ref_null!(b, Int64(expected.type_idx), ConcreteRef(expected.type_idx, true))
+        else
+            ref_null!(b, expected)
+        end
+        return expected
+    end
     ty = emit_value!(b, val, ctx)
     ty === nothing && return expected
     ty === expected || convert_type!(b, ty, expected, ctx; from_julia=from_julia)


### PR DESCRIPTION
March 8 (honestly rescoped — the census's ladder anchors predated marches 5-7's restructuring, which already made the external ladders wrap-shaped): the 4-arg chokepoint gains DECIDE-BEFORE-EMIT for the Nothing phantom (ref.null before emission, killing the post-hoc instr-inspection class). The R17 tail is consolidation-floor material, ratchet-held.

March 9: **multi-range classId checks** (dart code_generator.dart:3862-3883) — post-DFS drift ids record onto every abstract ancestor at ensure_type_id!; isa/typeassert check the DFS range PLUS extras. The F2 drift class closes STRUCTURALLY. Closures defer recorded; LUB/threshold ripple-mapped (four coordinated sites incl. the dispatch fn's own signature) for a dedicated session with full fuzz per change.
