### PR TITLE
parity: march 13 — two-arg megamorphic dispatch fixed (the six-link chain)

### DIFF
--- a/dev/MARCH6_PLAN.md
+++ b/dev/MARCH6_PLAN.md
@@ -60,3 +60,11 @@ THE FIX = the phi-store funnel reads the RE-EMISSION's tracked type (the _pv_vb
 builder's stack top — it already exists at flow.jl's emit_phi_local_set! path!) instead
 of get_phi_edge_wasm_type's guess. THEN link 6: the phi-INIT null (t=0 entry edge).
 GATING LAW: exit codes only.
+
+## LINK-5 SURGICAL POINTER: compile_phi_value's SSA arm (stackified.jl ~650-770) —
+the += SSA's phi-edge store: it reads ssa_local_type/get_phi_edge_wasm_type (guesses)
+where the RE-EMISSION path exists; the non-SSA arm (770+) already has the tracked
+_ne_vty pattern — MIRROR IT in the SSA arm: recompute via _compile_value_b, use its
+stack-top as the actual, _emit_phi_edge_convert! to the phi local type. The 0x981
+store ([unbox,unbox,add,set anyref-110]) comes from the SSA recompute path emitting
+the RAW add without the convert.

--- a/dev/MARCH6_PLAN.md
+++ b/dev/MARCH6_PLAN.md
@@ -49,3 +49,14 @@ pre-pass + LAZY constants (init-fns before the compile.jl:1641 index freeze —
 the one big M7 piece) · boxed-scalar dedup (dart 361-376, needs expectedType
 at the scalar arms = post-march-8 material). R14/R15 prose revised to the
 honest mutable floor.
+
+## MARCH-13 CHAIN STATE (the two-arg megamorphic bug, links verified forward):
+1-3 ✓ (discovery cliff / export dedup / forwarder gate — committed 0a05dd3).
+4 ✓ safe (intrinsic-binop rebox when the SSA local is ref-typed — keyed on the REAL
+local type). NEXT LINK (the failing store at 0x981): the value flows through the PHI
+machinery — compile_phi_value / set_phi_locals_for_edge! re-emits the add at the edge
+and its store-convert re-guesses (Any→anyref ≡ anyref) while raw i64 sits on the stack.
+THE FIX = the phi-store funnel reads the RE-EMISSION's tracked type (the _pv_vb
+builder's stack top — it already exists at flow.jl's emit_phi_local_set! path!) instead
+of get_phi_edge_wasm_type's guess. THEN link 6: the phi-INIT null (t=0 entry edge).
+GATING LAW: exit codes only.

--- a/dev/MARCH6_PLAN.md
+++ b/dev/MARCH6_PLAN.md
@@ -68,3 +68,12 @@ _ne_vty pattern — MIRROR IT in the SSA arm: recompute via _compile_value_b, us
 stack-top as the actual, _emit_phi_edge_convert! to the phi local type. The 0x981
 store ([unbox,unbox,add,set anyref-110]) comes from the SSA recompute path emitting
 the RAW add without the convert.
+
+## LINK 5b STATE: the tail rebox RESURRECTED (was dead-by-scoping). Two-arg still red —
+the box now emits at the CALL tail but the wat earlier showed the failing add inside a
+RECOMPUTED phi-edge sequence ([unbox,unbox,add,set]) — the phi-edge RECOMPUTE path
+(compile_phi_value on the += SSA re-EMITS the call via compile_statement? or the
+fall-through store at stackified ~1083) bypasses compile_call's tail. NEXT: dump the
+CURRENT wat, locate the (possibly moved) failing site, identify WHICH emitter owns it
+(the boxes now emitted at tail may have MOVED the mismatch), iterate. The chain is
+long but every link is a real pre-existing hole on new coverage.

--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -751,3 +751,12 @@ fill(AnyRef) is GONE from dispatch (R18→0). Full gate: 10 shards + 9 fuzz gree
 PINNED (pre-existing, @test_broken battery): two-arg megamorphic dispatch traps — the
 next dispatch slice (threshold/multi-axis) owns it. Remaining there: threshold=9 cliff,
 multi-axis 2-8 → unreachable, full struct-LUB (non-primitive joins via the hierarchy DAG).
+
+## MARCH 13 — two-arg megamorphic dispatch FIXED (2026-07-06)
+The six-link chain (each a real pre-existing hole exposed by new coverage): discovery's
+circular-abandonment cliff (≤8 cap fed nothing to the table it deferred to) · export-name
+dedup at THE chokepoint (add_export!) · forwarder-only whole-body replacement (was
+hijacking loop bodies) + the ::T-annotation phi chase (M8.3 gate catch) · the intrinsic-
+table rebox · the tail rebox arm RESURRECTED (dead-by-scoping since introduction,
+debug-proven 1224/1224 skips) · the function-top scope fix. Tuple dedup guards candidate
+copies. @test_broken FLIPPED. Full gate 10+9 green ×2 (the M8.3 catch in between).

--- a/src/builder/instructions.jl
+++ b/src/builder/instructions.jl
@@ -601,7 +601,18 @@ Add an export entry to the module.
 - kind: 0=func, 1=table, 2=memory, 3=global
 """
 function add_export!(mod::WasmModule, name::String, kind::Integer, idx::Integer)
-    push!(mod.exports, WasmExport(name, UInt8(kind), UInt32(idx)))
+    # march13: export-name dedup at THE one chokepoint — wasm requires unique export
+    # names, and two independent minting paths (megamorphic wrappers + discovery
+    # candidates) collided. Suffix _dN until unique.
+    final = name
+    if any(e -> e.name == final, mod.exports)
+        local k = 2
+        while any(e -> e.name == string(name, "_d", k), mod.exports)
+            k += 1
+        end
+        final = string(name, "_d", k)
+    end
+    push!(mod.exports, WasmExport(final, UInt8(kind), UInt32(idx)))
     return mod
 end
 

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -4364,6 +4364,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # Union{Nothing, UInt64}-style SSAs live in AnyRef locals; consuming
         # them raw in i64 arithmetic failed validation. Mirror of the
         # externref unbox below, minus any_convert_extern. Gated on the
+    _boxed_operand_unboxed = false   # march13: survives the arg loop (the old flag was loop-scoped → the tail rebox was DEAD)
         # ACTUAL local type (type-derived guesses say I64 for these unions).
         local _arg_anyref = false
         if !_is_externref_value(arg, ctx) && arg isa Core.SSAValue
@@ -4391,6 +4392,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             local _ub = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
             emit_classid_unbox!(_ub, ctx, _aa_target; nullable=true)
             append_builder!(fb, _ub)
+            _boxed_operand_unboxed = true   # march13: function-scoped (the tail rebox keys on this)
         end
         # PURE-904: Unbox externref args for numeric intrinsics.
         # When a param/SSA has Wasm type externref but Julia IR uses it as
@@ -6424,8 +6426,9 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
     # parity(M6/F3): the symmetric RESULT side of the anyref-OPERAND unbox above — a numeric
     # arith result flowing into a ref-typed SSA local boxes through THE one producer (the
     # scalar-replaced Core.Box accumulator cycle: unbox → op → BOX → store; dart convertType).
-    if (@isdefined _arg_anyref) && (@isdefined is_numeric_intrinsic) && (@isdefined _generic_arith) &&
-       (is_numeric_intrinsic || _generic_arith) && _arg_anyref && !ctx.last_stmt_was_stub
+    # march13: keyed on the FUNCTION-scoped flag — the old @isdefined-guarded read of a
+    # LOOP-scoped variable made this arm silently dead for every call since introduction.
+    if (@isdefined _boxed_operand_unboxed) && _boxed_operand_unboxed && !ctx.last_stmt_was_stub
         local _dl = get(ctx.ssa_locals, idx, nothing)
         if _dl !== nothing
             local _doff = _dl - ctx.n_params

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -1727,6 +1727,7 @@ same discard semantics: arms that clear/replace it re-init; exits merge typed).
 """
 function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompilationContext)
     fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod)
+    _boxed_operand_unboxed = false   # march13: FUNCTION-TOP scope (a mid-function init sat in a closed scope — the tail arm read @isdefined=false on every call)
     _seed_builder_locals!(fb, ctx)
     func = expr.args[1]
     args = expr.args[2:end]
@@ -4364,7 +4365,6 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # Union{Nothing, UInt64}-style SSAs live in AnyRef locals; consuming
         # them raw in i64 arithmetic failed validation. Mirror of the
         # externref unbox below, minus any_convert_extern. Gated on the
-    _boxed_operand_unboxed = false   # march13: survives the arg loop (the old flag was loop-scoped → the tail rebox was DEAD)
         # ACTUAL local type (type-derived guesses say I64 for these unions).
         local _arg_anyref = false
         if !_is_externref_value(arg, ctx) && arg isa Core.SSAValue

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -4461,6 +4461,19 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 _emit_normalise_narrow_pair!(fb, ctx, false, _julia_int_width(arg_type, is_32bit))
             end
             _op1!(_it_e.opcode)
+            # march13 (the rebox link): a numeric intrinsic whose SSA LOCAL is
+            # ref-typed (the boxed accumulator: Any-joined phi) must REBOX its
+            # result — keyed on the REAL local type, never inference (the sink's
+            # re-guess said anyref≡anyref while raw i64 sat on the stack).
+            local _rbx_li = get(ctx.ssa_locals, idx, nothing)
+            if _rbx_li !== nothing
+                local _rbx_off = _rbx_li - ctx.n_params
+                if _rbx_off >= 0 && _rbx_off < length(ctx.locals) && _wt_is_ref(ctx.locals[_rbx_off + 1]) &&
+                   _it_e.result in (I32, I64, F32, F64)
+                    emit_classid_box!(fb, ctx, _it_e.result,
+                                      arg_type isa Type && isconcretetype(arg_type) ? arg_type : nothing)
+                end
+            end
             return append_builder!(b, fb)
         end
     end

--- a/src/codegen/dispatch.jl
+++ b/src/codegen/dispatch.jl
@@ -120,6 +120,9 @@ function build_dispatch_tables(func_registry::FunctionRegistry,
             all_valid || continue
 
             h = UInt32(0)   # parity(M8.4): hashing DELETED — the selector table keys on classId
+            # march13: dedup by tuple — the un-capped discovery can register a candidate
+            # COPY of an explicit specialization; first registration wins (M8.4 rule).
+            any(e -> e.type_ids == type_ids, entries) && continue
             push!(entries, DispatchEntry(type_ids, h, info.wasm_idx, UInt32(0), info.return_type))
         end
 
@@ -326,13 +329,33 @@ function find_dispatch_call(code_info::Core.CodeInfo,
             call_args = stmt.args[2:end]
             length(call_args) == dt.arity || continue
             all(k -> call_args[k] isa Core.Argument && call_args[k].n == k + 1, 1:length(call_args)) || continue
-            # and the call's value is what the function returns
+            # and the call's value is what the function returns — possibly through the
+            # ::T-annotation lowering (convert/typeassert/PiNode and the φ(call, converted)
+            # join; M8.3's caller2 taught us the phi)
+            local chases_to_call = function(vid::Int, depth::Int)
+                vid == i && return true
+                depth <= 0 && return false
+                local st = code[vid]
+                if st isa Core.PiNode && st.val isa Core.SSAValue
+                    return chases_to_call(st.val.id, depth - 1)
+                elseif st isa Core.PhiNode
+                    for k in 1:length(st.values)
+                        isassigned(st.values, k) || continue
+                        local ev = st.values[k]
+                        ev isa Core.SSAValue && chases_to_call(ev.id, depth - 1) && return true
+                    end
+                    return false
+                elseif st isa Expr && st.head === :call && length(st.args) >= 2
+                    local pay = (st.args[1] isa GlobalRef && st.args[1].name === :typeassert) ?
+                                st.args[2] : st.args[end]
+                    pay isa Core.SSAValue && return chases_to_call(pay.id, depth - 1)
+                end
+                return false
+            end
             local returned = false
             for st2 in code
-                if st2 isa Core.ReturnNode && isdefined(st2, :val) &&
-                   st2.val isa Core.SSAValue && st2.val.id == i
-                    returned = true
-                    break
+                if st2 isa Core.ReturnNode && isdefined(st2, :val) && st2.val isa Core.SSAValue
+                    chases_to_call(st2.val.id, 4) && (returned = true; break)
                 end
             end
             returned || continue

--- a/src/codegen/dispatch.jl
+++ b/src/codegen/dispatch.jl
@@ -302,20 +302,41 @@ Returns the dispatch table if found, nothing otherwise.
 """
 function find_dispatch_call(code_info::Core.CodeInfo,
                              dt_registry::DispatchTableRegistry)
-    for stmt in code_info.code
+    # march13: this feeds the WHOLE-BODY dispatch replacement — it must fire ONLY
+    # for pure FORWARDERS (a body that IS the dispatch call: the call's args are
+    # exactly the function's params in order, and the call's result is returned).
+    # It used to fire on ANY body containing a megamorphic call (f2-the-loop got
+    # its entire body replaced by a 2-param trampoline — validation failure once
+    # discovery started registering ≥9-method candidates). In-body megamorphic
+    # call SITES are the inline-switch / call-site path's job.
+    code = code_info.code
+    for (i, stmt) in enumerate(code)
         if stmt isa Expr && stmt.head === :call
             callee = stmt.args[1]
-            if callee isa GlobalRef
-                callee_func = try
-                    getfield(callee.mod, callee.name)
-                catch
-                    nothing
-                end
-                if callee_func !== nothing
-                    dt = get_dispatch_table(dt_registry, callee_func)
-                    dt !== nothing && return dt
+            callee isa GlobalRef || continue
+            callee_func = try
+                getfield(callee.mod, callee.name)
+            catch
+                nothing
+            end
+            callee_func === nothing && continue
+            dt = get_dispatch_table(dt_registry, callee_func)
+            dt === nothing && continue
+            # forwarder shape: args are exactly the params, in order
+            call_args = stmt.args[2:end]
+            length(call_args) == dt.arity || continue
+            all(k -> call_args[k] isa Core.Argument && call_args[k].n == k + 1, 1:length(call_args)) || continue
+            # and the call's value is what the function returns
+            local returned = false
+            for st2 in code
+                if st2 isa Core.ReturnNode && isdefined(st2, :val) &&
+                   st2.val isa Core.SSAValue && st2.val.id == i
+                    returned = true
+                    break
                 end
             end
+            returned || continue
+            return dt
         end
     end
     return nothing

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -1273,7 +1273,13 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
                 # DROP the value and emit a type-safe default instead of causing validation error.
                 # PURE-4151: If extern_convert_any was already appended above (line ~15272),
                 # the stack type is now ExternRef regardless of the original value_wasm_type.
-                value_wasm_type = needs_extern_convert_any ? ExternRef : get_concrete_wasm_type(stmt_type, ctx.mod, ctx.type_registry)
+                # march13: the TRACKED emission type rules the store sink (dart: the value
+                # carries its type) — the inference re-guess said anyref for a generic-+
+                # on Any operands while the actual emission left RAW i64 (unbox·op with
+                # no rebox), so the M10 box arm never fired and the store was invalid.
+                value_wasm_type = needs_extern_convert_any ? ExternRef :
+                    (!isempty(_sf.v.stack) ? _sf.v.stack[end] :
+                     get_concrete_wasm_type(stmt_type, ctx.mod, ctx.type_registry))
                 if local_type !== nothing && !wasm_types_compatible(local_type, value_wasm_type)
                     # PURE-908: externref↔anyref conversion instead of drop+default
                     if value_wasm_type === ExternRef && local_type === AnyRef

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -1273,13 +1273,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
                 # DROP the value and emit a type-safe default instead of causing validation error.
                 # PURE-4151: If extern_convert_any was already appended above (line ~15272),
                 # the stack type is now ExternRef regardless of the original value_wasm_type.
-                # march13: the TRACKED emission type rules the store sink (dart: the value
-                # carries its type) — the inference re-guess said anyref for a generic-+
-                # on Any operands while the actual emission left RAW i64 (unbox·op with
-                # no rebox), so the M10 box arm never fired and the store was invalid.
-                value_wasm_type = needs_extern_convert_any ? ExternRef :
-                    (!isempty(_sf.v.stack) ? _sf.v.stack[end] :
-                     get_concrete_wasm_type(stmt_type, ctx.mod, ctx.type_registry))
+                value_wasm_type = needs_extern_convert_any ? ExternRef : get_concrete_wasm_type(stmt_type, ctx.mod, ctx.type_registry)
                 if local_type !== nothing && !wasm_types_compatible(local_type, value_wasm_type)
                     # PURE-908: externref↔anyref conversion instead of drop+default
                     if value_wasm_type === ExternRef && local_type === AnyRef

--- a/src/codegen/trimcollect.jl
+++ b/src/codegen/trimcollect.jl
@@ -83,13 +83,15 @@ function _dynamic_dispatch_candidate_mis(codeinfos::Vector{Any}, seen::Set{Any})
             length(absp) == 1 || continue
             p = absp[1]
             ms = try collect(methods(g, Tuple{atypes...})) catch; Method[] end
-            # Reconcile with PURE-9060: a function with ≥9 applicable methods is
-            # MEGAMORPHIC and handled by the existing call_indirect dispatch table
-            # (build_dispatch_tables threshold=9). Leave those to PURE-9060 — adding
-            # inline-typeId candidates for them both double-handles the call AND pulls
-            # in unreachable specializations that collide with the megamorphic export
-            # naming (duplicate-export). Discovery owns only the ≤8-method case.
-            (0 < length(ms) <= 8) || continue
+            # march13 (dart: ALL targetCount>1 dispatch through the table,
+            # dispatch_table.dart:401-403): the old ≤8 cap CIRCULARLY ABANDONED
+            # ≥9-method dynamic sites — it "left them to the dispatch table", but the
+            # table only builds from registered specializations, which only register
+            # through THIS discovery → nothing registered, no table, unreachable stub
+            # (the pinned two-arg megamorphic bug). Discovery now feeds BOTH mechanisms;
+            # the inline-vs-table split happens downstream by count (threshold=9).
+            # 64 = an explosion sanity guard, not a mechanism cliff.
+            (0 < length(ms) <= 64) || continue
             for m in ms
                 msig = try collect(Base.unwrap_unionall(m.sig).parameters) catch; continue end
                 length(msig) == length(atypes) + 1 || continue

--- a/test/march3_try_backfills.jl
+++ b/test/march3_try_backfills.jl
@@ -112,7 +112,7 @@ for i in 1:10
     @eval _m11dv(x::$(Symbol("_M11D", i)), k::Int64)::Int64 = x.v * $i + k
 end
 _m11_disp(n::Int64)::Int64 = (t = 0; xs = _M11Z[_M11D1(1), _M11D2(2), _M11D3(3), _M11D4(4), _M11D5(5), _M11D6(6), _M11D7(7), _M11D8(8), _M11D9(9), _M11D10(10)]; for x in xs; t += _m11dv(x, n); end; t)
-@testset "march11: two-arg megamorphic dispatch (pinned pre-existing gap)" begin
+@testset "march13: two-arg megamorphic dispatch (FIXED — the six-link chain)" begin
     r = try compare_julia_wasm(_m11_disp, Int64(3)) catch; (pass=false,) end
-    @test_broken r.pass
+    @test r.pass
 end


### PR DESCRIPTION
Fixes the pinned two-arg megamorphic dispatch bug end-to-end. Six links, each a real pre-existing hole: the discovery ≤8-cap circular abandonment, export-name collisions, whole-body dispatch hijacking non-forwarders (+ the ::T phi chase), a missing rebox in the intrinsics-table route, the RESURRECTED dead-by-scoping tail rebox arm, and its closed-scope init. The pinned @test_broken flips to @test.

Full gate: 10 shards + 9 fuzz green twice (the M8.3 multi-axis catch fixed in between).
