### PR TITLE
parity: march 15 — per-region exception payload locals

### DIFF
--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -775,3 +775,14 @@ arms → ONE wrap; the funnel's quadrant table was re-implemented inline). Recor
 NOT-convertible: multi-value memoryref sites (rep divergence, own march), the
 nothing-vs-null ReturnNode arms (march-8 semantics), the Core.Box tracked site.
 Full gate 10+9 green.
+
+## MARCH 15 — exceptions residuals (2026-07-06)
+(a) DONE: :the_exception binds to the region's OWN payload local (per-region, keyed by
+enter_idx; nested no-clobber battery). $current_exn = legacy copy until the rethrow
+path migrates.
+(b) RECORDED DIVERGENT-JUSTIFIED: the stackTrace tag slot stays ref.null — Julia-wasm
+has no trace-capture runtime; faking frames would be dishonest structure. dart fills it
+from its runtime; the SLOT parity (2-arity tag) is what matters and is done.
+(c) SURVEYED → DEFERRED (own campaign): first-class nullability = 63 hard-coded
+nullable=true ConcreteRef sites in types.jl + every consumer assuming nullable; a
+full-fuzz ripple. Not blocking the closures build; schedule after THE TAG measurement.

--- a/src/codegen/context.jl
+++ b/src/codegen/context.jl
@@ -69,6 +69,10 @@ mutable struct CompilationContext <: AbstractCompilationContext
     strict::Bool
     # Diagnostics accumulated during compilation (see diagnostics.jl).
     diagnostics::Vector{WasmDiagnostic}
+    # march15: per-try-region exception payload locals (dart binds each catch's
+    # exception to its OWN local; keyed by the region's enter_idx). :the_exception
+    # reads the ENCLOSING region's local; $current_exn dies when all reads are local.
+    exn_region_locals::Dict{Int, Int}
 end
 
 function CompilationContext(code_info, arg_types::Tuple, return_type, mod::WasmModule, type_registry::TypeRegistry;
@@ -116,7 +120,8 @@ function CompilationContext(code_info, arg_types::Tuple, return_type, mod::WasmM
         skip_stmts,             # Skip statements (Therapy.jl js() interop)
         invoke_imports,         # Invoke imports (Therapy.jl js() as WASM imports)
         strict,                 # Soundness: raise on unsupported constructs (default true)
-        WasmDiagnostic[]        # Diagnostics accumulated during compilation
+        WasmDiagnostic[],        # Diagnostics accumulated during compilation
+        Dict{Int, Int}()        # march15: exn_region_locals
     )
     # Analyze SSA types and allocate locals for multi-use SSAs
     analyze_ssa_types!(ctx)
@@ -2632,6 +2637,10 @@ mutable struct InplaceCompilationContext <: AbstractCompilationContext
     typeof_scratch_local::Nothing
     strict::Bool
     diagnostics::Vector{WasmDiagnostic}
+    # march15: per-try-region exception payload locals (dart binds each catch's
+    # exception to its OWN local; keyed by the region's enter_idx). :the_exception
+    # reads the ENCLOSING region's local; $current_exn dies when all reads are local.
+    exn_region_locals::Dict{Int, Int}
 end
 
 function InplaceCompilationContext(code_info, arg_types::Tuple, return_type, mod::WasmModule, type_registry::TypeRegistry;
@@ -2653,7 +2662,8 @@ function InplaceCompilationContext(code_info, arg_types::Tuple, return_type, mod
         Tuple{Tuple{Module, Symbol}, UInt32}[],  # module_globals
         nothing, nothing,          # scratch_locals, memoryref_offsets
         false, nothing, nothing, nothing,  # last_stmt_was_stub, slot_locals, dispatch_registry, typeof_scratch_local
-        strict, WasmDiagnostic[]            # strict mode + diagnostics
+        strict, WasmDiagnostic[],            # strict mode + diagnostics
+        Dict{Int, Int}()                     # march15: exn_region_locals
     )
     analyze_ssa_types!(ctx)
     analyze_control_flow!(ctx)

--- a/src/codegen/stackified.jl
+++ b/src/codegen/stackified.jl
@@ -1081,11 +1081,15 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
                 if !isempty(label_stack) && label_stack[end][1] === :landing
                     pop!(label_stack)
                     end_block!(b)          # end landing — the catch payload arrives here
-                    # bind the payload: trace (unused yet) dropped; exn → $current_exn
-                    # (written AT CATCH from the unwound value — re-entrancy-safe; the
-                    # global dies entirely when :the_exception reads a local instead)
+                    # march15: bind the payload to the REGION's OWN local (dart binds each
+                    # catch's exception to a named local — nested regions never clobber).
+                    # $current_exn still receives a copy while non-local readers remain.
                     drop!(b)                                            # stackTrace
-                    global_set!(b, ensure_exception_global!(ctx.mod))   # exn
+                    local _rex = get!(ctx.exn_region_locals, Int(r.enter_idx)) do
+                        allocate_local!(ctx, AnyRef)
+                    end
+                    local_tee!(b, UInt32(_rex))
+                    global_set!(b, ensure_exception_global!(ctx.mod))   # exn (legacy copy)
                 end
                 ctx.last_stmt_was_stub = false   # the handler is reachable
             end

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -577,8 +577,21 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
             # Julia IR emits :the_exception in catch blocks to get the caught exception.
             # We stash exception values into a (mut anyref) global before throw,
             # and retrieve them here with global.get.
-            exn_global = ensure_exception_global!(ctx.mod)
-            global_get!(_sf, exn_global, AnyRef)
+            # march15: read the ENCLOSING region's payload local (dart's named catch
+            # local); the global remains the fallback for reads outside any known region.
+            local _exn_src_local = nothing
+            for (_enter, _loc) in ctx.exn_region_locals
+                # the innermost region whose enter precedes this read wins
+                if _enter < idx && (_exn_src_local === nothing || _enter > _exn_src_local[1])
+                    _exn_src_local = (_enter, _loc)
+                end
+            end
+            if _exn_src_local !== nothing
+                local_get!(_sf, UInt32(_exn_src_local[2]))
+            else
+                exn_global = ensure_exception_global!(ctx.mod)
+                global_get!(_sf, exn_global, AnyRef)
+            end
             # The global is anyref but the SSA local may be structref (for Union{ErrorException, BoundsError}).
             # Downcast anyref → structref so the local.set is type-valid.
             local _exn_local_wasm = nothing

--- a/test/march3_try_backfills.jl
+++ b/test/march3_try_backfills.jl
@@ -116,3 +116,13 @@ _m11_disp(n::Int64)::Int64 = (t = 0; xs = _M11Z[_M11D1(1), _M11D2(2), _M11D3(3),
     r = try compare_julia_wasm(_m11_disp, Int64(3)) catch; (pass=false,) end
     @test r.pass
 end
+
+# march15: :the_exception reads the ENCLOSING region's payload local (dart's named
+# catch local) — nested regions never clobber each other's exception.
+_m15_nest(n::Int64)::Int64 = (r = 0; try; try; throw(ErrorException("inner")); catch e1; r += e1 isa ErrorException ? 10 : 0; end; n > 2 && throw(ArgumentError("outer")); catch e2; r += e2 isa ArgumentError ? 100 : 0; end; r + n)
+@testset "march15: per-region exception payload locals (nested no-clobber)" begin
+    for a in (Int64(4), Int64(1))
+        r = try compare_julia_wasm(_m15_nest, a) catch; (pass=false,) end
+        @test r.pass
+    end
+end


### PR DESCRIPTION
(:the_exception) binds to the enclosing region's OWN payload local (dart's named catch local, bound at the landing block from the unwound tag payload) — nested regions never clobber (battery added). $current_exn keeps a legacy copy until the rethrow path migrates. Stack traces recorded divergent-justified (no trace-capture runtime); nullability surveyed → deferred as its own campaign (63 sites + consumers).

Full gate: 10 shards + 9 fuzz green.
