### PR TITLE
parity: step 5 — THE CLASS-DAG + census-3 (70.2 raw / 77.7 actionable)

### DIFF
--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -861,3 +861,47 @@ unreachable hole: CLOSED (tables exist for every polymorphic selector).
 R17 205→186 (invoke obvious-expected + the index idiom + codepoint sites). The remaining
 186: mega-arm restructures + the memoryref multi-value class (recorded) — resumable
 mechanically; superseded in priority by step 5 (the CLASS-DAG's census value is higher).
+
+## STEP 5 — THE CLASS-DAG: gate-certified (2026-07-07, 10 shards + 9 fuzz under the strict builder)
+Per-class wasm subtype hierarchy (dart class_info.dart:278-330): abstract synthetics
+{classId:i32} sub their parent's synthetic; concretes sub their nearest abstract parent
+at creation (7 sites) + the lookup-only retrofit; supertype joined struct identity
+(types_equal). Emitted proof: sub-chains 6→5→0, wasm-tools valid.
+
+# ═══════════════════════════════════════════════════════════════════
+# CENSUS-3 — THE GO-FOR-BROKE CLOSE (2026-07-07)
+# ═══════════════════════════════════════════════════════════════════
+Same instrument (parallel auditors, verify-in-code strict bar, dart oracle cross-checks,
+empirical probes). Dims 7/14 ESTIMATED from three other auditors' verified citations
+(the closures auditor's summary did not deliver; its subject matter was independently
+verified: march-16 end-to-end by the dispatch+residual audits, march-17 by the gate).
+
+## THE NUMBER: raw-15 55.6 → 66.0 → **70.2** · actionable-13 72.8 → **77.7**
+
+| # | dim | c2 | NOW | movement |
+|---|-----|----|-----|----------|
+| 1 | visitors | 82 | **84** | PiNode collapse (exactly 11 arms→1 wrap, verified); 61 fragment-ctors deleted; the wrap = dart's wrap→ONE convertType where wired (34% coverage, ~86% achievable) |
+| 2 | translator | 81 | **85** | THE CLASS-DAG verified end-to-end incl. emitted wasm; nullability = exactly-63 sites, zero derived (the residual) |
+| 3 | class metadata | 68 | **74** | the per-class chain EMITTED+VALID; sibling-abstract collapse = wasm-inherent (isa correctly stays classId-ranged); identityHash absent; the LUB unlock latent |
+| 4 | runtime types | 65 | **65** | holds — isa/typeassert correctly classId-ranged (per the collapse finding) |
+| 5 | dispatch | 63 | **76** | threshold=2 LIVE (needsDispatch-equivalent) + the two-arg six-link fix + all machinery + the LUB fast lane; REFUTED: struct-LUB via the DAG (dart's _upperBound climb absent — THE unlocked follow-up) |
+| 6 | dynamic calls | 78 | **78** | the call_ref path real but DIM-7-attributed (no double count) |
+| 7 | closures | 35 | **68 (EST)** | march-16 end-to-end: the object/vtable/trampolines/call_ref/typed entries — verified via citations; dual static rep + identityHash/runtimeType slots remain |
+| 8 | constants | 78 | **78** | holds; boxed-scalar dedup definitively absent; 5-registry federation + threshold-64 nuances |
+| 9 | exceptions | 82 | **82** | march-15 verified live; $current_exn legacy copy per plan |
+| 10 | async | 5 | **5** | permanent (ratified) |
+| 11 | records | 75 | **75** | the DAG tuple-neutral (verified) |
+| 12 | boxes/strings | 82 | **82** | box sub-base at creation ✓ oracle-corroborated (dart puts bool/num under Top); width-default classId = precision caveat |
+| 13 | interop | 38 | **38** | permanent-ish |
+| 14 | builder | 88 | **93 (EST)** | THE ENFORCING BUILDER strict-by-default, gate-certified; the L-strict lock; underflows throw at the emit site |
+| 15 | driver | 70 | **70** | trimcollect = worklist seeding, NOT allocation-gating (the opposite axis; verified) |
+
+## THE RANKED REMAINDER (to ~85 actionable)
+1. **struct-LUB in dispatch** — dart's _upperBound superType! climb; the DAG's join
+   targets exist NOW (latent) — a contained follow-up in dispatch.jl's slot loop.
+2. **The typed-channel campaign** — zero the collected type-mismatches → full-strict
+   (the enforcer's stage 2); subsumes the wrap tail's ~150 semi-convertible sites.
+3. **Nullability** (exactly 63 + consumers) · 4. **identityHash campaign** (the header
+   slot; String offsets) · 5. **boxed-scalar constant dedup** · 6. **closure-rep
+   unification** (the dual static rep) · 7. **allocation-gating** (driver) ·
+   8. $current_exn death · tuple-per-arity.

--- a/dev/STEP5_CLASSDAG.md
+++ b/dev/STEP5_CLASSDAG.md
@@ -1,0 +1,27 @@
+# STEP 5 — THE CLASS-DAG (dart class_info.dart:278-330)
+
+dart: each class's wasm struct subtypes its SUPERCLASS's struct (Top → Object → … →
+leaf, depth-tracked). WT today: every struct `sub $JlBase` (flat — census DIM-3's
+main residual).
+
+## THE WT SHAPE
+- ABSTRACT Julia types get SYNTHETIC wasm structs ({classId:i32} only), each `sub` its
+  parent's synthetic; the chain roots at $JlBase (=Any).
+- CONCRETE structs/boxes/closure-base subtype their NEAREST abstract parent's synthetic
+  instead of $JlBase directly. Field-prefix validity: synthetics carry only field 0
+  (i32 classId) = the universal header ✓ every child extends it.
+- Everything still transitively subtypes $JlBase → all existing ref.test/cast gates
+  keep working; the DAG adds wasm-level hierarchy tests (isa Number = ref.test on the
+  synthetic — a follow-up bonus) + real struct-LUB join targets for dispatch.
+
+## ORDERING CONSTRAINT (wasm: supertypes precede subtypes in the type section)
+ensure_abstract_struct! recurses parent-first (low indices); lazily-registered types
+ensure their parent chain AT REGISTRATION (never a forward ref). The post-body
+retrofit re-parents per-class (same recursion).
+
+## SLICES
+A. ensure_abstract_struct! + registration wiring (register_struct_type!,
+   get_numeric_box_type!, the closure base) — parent synthetics at creation.
+B. set_struct_supertypes! per-class re-parenting (the retrofit).
+C. consumers audit (anything reading supertype_idx === base_struct_idx).
+Full gate per slice.

--- a/src/builder/instructions.jl
+++ b/src/builder/instructions.jl
@@ -455,6 +455,11 @@ function types_equal(a::FuncType, b::FuncType)
 end
 
 function types_equal(a::StructType, b::StructType)
+    # step5: the SUPERTYPE is part of a struct type's identity — the class-DAG's
+    # synthetic {classId} structs differ ONLY by their parent (dedup collapsed the
+    # whole hierarchy into $JlBase otherwise). Matches wasm's nominal-ish subtyping:
+    # (sub A (struct i32)) and (sub B (struct i32)) are distinct types.
+    a.supertype_idx == b.supertype_idx &&
     length(a.fields) == length(b.fields) &&
     all(fields_equal(af, bf) for (af, bf) in zip(a.fields, b.fields))
 end

--- a/src/codegen/dispatch.jl
+++ b/src/codegen/dispatch.jl
@@ -78,14 +78,9 @@ get_dispatch_table(reg::DispatchTableRegistry, func_ref) = get(reg.tables, func_
 function build_dispatch_tables(func_registry::FunctionRegistry,
                                 type_registry::TypeRegistry;
                                 threshold::Int=2)::DispatchTableRegistry
-    # march13b: the 2-8 TABLE MACHINERY is now PROVEN (threshold=2 exercised the
-    # wrapper void-drop, the target-signature cast fallback, the class-axis
-    # requirement, and tuple dedup — all landed below; M8+two-arg+smoke green at 2).
-    # The DEFAULT flip 9→2 (dart: every targetCount>1, dispatch_table.dart:401-403)
-    # is SEQUENCED AFTER the closures march: the remaining holes at 2 live in the
-    # closure/invoke wrapper interplay that march rebuilds (Dates parse internals
-    # unbalanced at fn#35 was the stopper). One-line flip when that lands.
-    dt_registry = DispatchTableRegistry()
+    # step3 (LANDED): threshold=2 — dart tables EVERY used targetCount>1 selector
+    # (dispatch_table.dart:401-403 needsDispatch). The 2-8 machinery was proven at
+    # march13b (void-drop + mirror arm, target-signature casts, class-axis, dedup).
 
     for (func_ref, infos) in func_registry.by_ref
         length(infos) < threshold && continue

--- a/src/codegen/dispatch.jl
+++ b/src/codegen/dispatch.jl
@@ -81,6 +81,7 @@ function build_dispatch_tables(func_registry::FunctionRegistry,
     # step3 (LANDED): threshold=2 — dart tables EVERY used targetCount>1 selector
     # (dispatch_table.dart:401-403 needsDispatch). The 2-8 machinery was proven at
     # march13b (void-drop + mirror arm, target-signature casts, class-axis, dedup).
+    dt_registry = DispatchTableRegistry()
 
     for (func_ref, infos) in func_registry.by_ref
         length(infos) < threshold && continue

--- a/src/codegen/structs.jl
+++ b/src/codegen/structs.jl
@@ -126,7 +126,9 @@ function register_closure_type!(mod::WasmModule, registry::TypeRegistry, T::Data
     # Add struct type to module
     # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
     # synthetic (dart class_info.dart:288), created parent-first at registration.
-    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
+    local _dagp = dag_supertype_idx!(mod, registry, T)
+    type_idx = _dagp === nothing ? add_struct_type!(mod, wasm_fields) :
+               UInt32(add_type!(mod, StructType(wasm_fields, _dagp)))
 
     # Record mapping (field_offset=1 for typeId prefix)
     info = StructInfo(T, type_idx, field_names, field_types, UInt32(1))
@@ -555,7 +557,8 @@ function _register_struct_type_impl_with_reserved!(mod::WasmModule, registry::Ty
     end
 
     # Update the placeholder struct with the correct fields
-    mod.types[reserved_idx + 1] = StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))   # step5
+    local _dagp2 = dag_supertype_idx!(mod, registry, T)
+    mod.types[reserved_idx + 1] = _dagp2 === nothing ? StructType(wasm_fields) : StructType(wasm_fields, _dagp2)   # step5
 
     # Record mapping (rec groups already set up by register_struct_type!)
     # PURE-9024: field_offset=1 for typeId prefix
@@ -756,7 +759,9 @@ function _register_struct_type_impl!(mod::WasmModule, registry::TypeRegistry, T:
     # Add struct type to module
     # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
     # synthetic (dart class_info.dart:288), created parent-first at registration.
-    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
+    local _dagp = dag_supertype_idx!(mod, registry, T)
+    type_idx = _dagp === nothing ? add_struct_type!(mod, wasm_fields) :
+               UInt32(add_type!(mod, StructType(wasm_fields, _dagp)))
 
     # Record mapping (PURE-9024: field_offset=1 for typeId prefix)
     info = StructInfo(T, type_idx, field_names, field_types, UInt32(1))
@@ -885,7 +890,9 @@ function register_tuple_type!(mod::WasmModule, registry::TypeRegistry, T::Type{<
     # Add struct type to module
     # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
     # synthetic (dart class_info.dart:288), created parent-first at registration.
-    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
+    local _dagp = dag_supertype_idx!(mod, registry, T)
+    type_idx = _dagp === nothing ? add_struct_type!(mod, wasm_fields) :
+               UInt32(add_type!(mod, StructType(wasm_fields, _dagp)))
 
     # Record mapping (PURE-9024: field_offset=1 for typeId prefix)
     info = StructInfo(T, type_idx, field_names, field_types_vec, UInt32(1))
@@ -939,7 +946,9 @@ function register_matrix_type!(mod::WasmModule, registry::TypeRegistry, T::Type)
     # Add struct type to module
     # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
     # synthetic (dart class_info.dart:288), created parent-first at registration.
-    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
+    local _dagp = dag_supertype_idx!(mod, registry, T)
+    type_idx = _dagp === nothing ? add_struct_type!(mod, wasm_fields) :
+               UInt32(add_type!(mod, StructType(wasm_fields, _dagp)))
 
     # Record mapping with field info (PURE-9024: field_offset=1)
     field_names = [:ref, :size]  # Julia field names
@@ -997,7 +1006,9 @@ function register_vector_type!(mod::WasmModule, registry::TypeRegistry, T::Type)
     # Add struct type to module
     # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
     # synthetic (dart class_info.dart:288), created parent-first at registration.
-    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
+    local _dagp = dag_supertype_idx!(mod, registry, T)
+    type_idx = _dagp === nothing ? add_struct_type!(mod, wasm_fields) :
+               UInt32(add_type!(mod, StructType(wasm_fields, _dagp)))
 
     # Record mapping with field info (PURE-9024: field_offset=1)
     field_names = [:ref, :size]  # Julia field names
@@ -1033,7 +1044,9 @@ function register_int128_type!(mod::WasmModule, registry::TypeRegistry, T::Type)
     # Add struct type to module
     # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
     # synthetic (dart class_info.dart:288), created parent-first at registration.
-    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
+    local _dagp = dag_supertype_idx!(mod, registry, T)
+    type_idx = _dagp === nothing ? add_struct_type!(mod, wasm_fields) :
+               UInt32(add_type!(mod, StructType(wasm_fields, _dagp)))
 
     # Record mapping with field info (PURE-9024: field_offset=1)
     field_names = [:lo, :hi]

--- a/src/codegen/structs.jl
+++ b/src/codegen/structs.jl
@@ -124,7 +124,9 @@ function register_closure_type!(mod::WasmModule, registry::TypeRegistry, T::Data
     end
 
     # Add struct type to module
-    type_idx = add_struct_type!(mod, wasm_fields)
+    # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
+    # synthetic (dart class_info.dart:288), created parent-first at registration.
+    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
 
     # Record mapping (field_offset=1 for typeId prefix)
     info = StructInfo(T, type_idx, field_names, field_types, UInt32(1))
@@ -553,7 +555,7 @@ function _register_struct_type_impl_with_reserved!(mod::WasmModule, registry::Ty
     end
 
     # Update the placeholder struct with the correct fields
-    mod.types[reserved_idx + 1] = StructType(wasm_fields)
+    mod.types[reserved_idx + 1] = StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))   # step5
 
     # Record mapping (rec groups already set up by register_struct_type!)
     # PURE-9024: field_offset=1 for typeId prefix
@@ -752,7 +754,9 @@ function _register_struct_type_impl!(mod::WasmModule, registry::TypeRegistry, T:
     end
 
     # Add struct type to module
-    type_idx = add_struct_type!(mod, wasm_fields)
+    # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
+    # synthetic (dart class_info.dart:288), created parent-first at registration.
+    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
 
     # Record mapping (PURE-9024: field_offset=1 for typeId prefix)
     info = StructInfo(T, type_idx, field_names, field_types, UInt32(1))
@@ -879,7 +883,9 @@ function register_tuple_type!(mod::WasmModule, registry::TypeRegistry, T::Type{<
     end
 
     # Add struct type to module
-    type_idx = add_struct_type!(mod, wasm_fields)
+    # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
+    # synthetic (dart class_info.dart:288), created parent-first at registration.
+    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
 
     # Record mapping (PURE-9024: field_offset=1 for typeId prefix)
     info = StructInfo(T, type_idx, field_names, field_types_vec, UInt32(1))
@@ -931,7 +937,9 @@ function register_matrix_type!(mod::WasmModule, registry::TypeRegistry, T::Type)
     ]
 
     # Add struct type to module
-    type_idx = add_struct_type!(mod, wasm_fields)
+    # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
+    # synthetic (dart class_info.dart:288), created parent-first at registration.
+    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
 
     # Record mapping with field info (PURE-9024: field_offset=1)
     field_names = [:ref, :size]  # Julia field names
@@ -987,7 +995,9 @@ function register_vector_type!(mod::WasmModule, registry::TypeRegistry, T::Type)
     ]
 
     # Add struct type to module
-    type_idx = add_struct_type!(mod, wasm_fields)
+    # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
+    # synthetic (dart class_info.dart:288), created parent-first at registration.
+    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
 
     # Record mapping with field info (PURE-9024: field_offset=1)
     field_names = [:ref, :size]  # Julia field names
@@ -1021,7 +1031,9 @@ function register_int128_type!(mod::WasmModule, registry::TypeRegistry, T::Type)
     ]
 
     # Add struct type to module
-    type_idx = add_struct_type!(mod, wasm_fields)
+    # step5 THE CLASS-DAG: the struct subtypes its nearest abstract parent's
+    # synthetic (dart class_info.dart:288), created parent-first at registration.
+    type_idx = UInt32(add_type!(mod, StructType(wasm_fields, dag_supertype_idx!(mod, registry, T))))
 
     # Record mapping with field info (PURE-9024: field_offset=1)
     field_names = [:lo, :hi]

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -2302,7 +2302,7 @@ The synthetic {classId:i32} struct for an ABSTRACT Julia type, `sub` its parent'
 synthetic (recursion roots at \$JlBase = Any). Parents recurse FIRST → their indices
 precede the child's (the wasm ordering rule).
 """
-function ensure_abstract_struct!(mod::WasmModule, registry::TypeRegistry, A::Type)::UInt32
+function ensure_abstract_struct!(mod::WasmModule, registry::TypeRegistry, A::Type)
     (A === Any || !(A isa DataType)) && return registry.base_struct_idx
     d = registry.abstract_struct_idxs
     d === nothing && return registry.base_struct_idx
@@ -2319,7 +2319,8 @@ end
 The wasm supertype for a CONCRETE type's struct: its nearest abstract parent's
 synthetic (the class-DAG), falling back to \$JlBase.
 """
-function dag_supertype_idx!(mod::WasmModule, registry::TypeRegistry, T::Type)::UInt32
+function dag_supertype_idx!(mod::WasmModule, registry::TypeRegistry, T::Type)::Union{UInt32, Nothing}
+    registry.base_struct_idx === nothing && return nothing   # bare registries (probes)
     (T isa DataType && registry.abstract_struct_idxs !== nothing) || return registry.base_struct_idx
     local P = supertype(T)
     (P === Any || !(P isa DataType)) && return registry.base_struct_idx

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -105,6 +105,10 @@ mutable struct TypeRegistry
     closure_base_idx::Union{Nothing, UInt32}
     closure_vtable_struct_idxs::Union{Nothing, Dict{Int, UInt32}}      # max_arity -> vtable struct
     closure_vtable_globals::Union{Nothing, Dict{Any, UInt32}}          # closure body key -> global
+    # step5 THE CLASS-DAG (dart class_info.dart:278-330): synthetic {classId:i32}
+    # wasm structs per ABSTRACT Julia type, each sub its parent's synthetic; concrete
+    # structs subtype their nearest abstract parent instead of flat $JlBase.
+    abstract_struct_idxs::Union{Nothing, Dict{Type, UInt32}}
 end
 
 TypeRegistry() = TypeRegistry(
@@ -121,7 +125,8 @@ TypeRegistry() = TypeRegistry(
     Dict{String, UInt32}(),       # string_constant_globals (census F3)
     Dict{String, Tuple{UInt32, UInt32}}(),  # lazy_string_globals (march7)
     Dict{Type, Vector{Int32}}(),            # type_extra_ids (march9)
-    nothing, Dict{Int, UInt32}(), Dict{Any, UInt32}()   # march16 closure layouter
+    nothing, Dict{Int, UInt32}(), Dict{Any, UInt32}(),  # march16 closure layouter
+    Dict{Type, UInt32}()                                # step5 class-DAG synthetics
 )
 
 # TRUE-INT-002: Dict-free constructor for WASM self-hosting.
@@ -141,7 +146,8 @@ TypeRegistry(::Val{:minimal}) = TypeRegistry(
     nothing,  # string_constant_globals (census F3)
     nothing,  # lazy_string_globals (march7)
     nothing,  # type_extra_ids (march9)
-    nothing, nothing, nothing   # march16 closure layouter
+    nothing, nothing, nothing,  # march16 closure layouter
+    nothing                     # step5 class-DAG synthetics
 )
 
 """
@@ -796,8 +802,22 @@ function set_struct_supertypes!(mod::WasmModule, base_idx::UInt32; registry::Uni
     for (i, ct) in enumerate(mod.types)
         ti = UInt32(i - 1)
         if ct isa StructType && ti != base_idx && ct.supertype_idx === nothing && !(ti in jl_exclude)
-            # Replace with version that declares base as supertype
-            mod.types[i] = StructType(ct.fields, base_idx)
+            # step5: per-class re-parenting where a synthetic ALREADY exists (post-body
+            # creation would forward-reference — lookup only); else the flat base.
+            local _dag_parent = base_idx
+            if registry !== nothing && registry.abstract_struct_idxs !== nothing && registry.structs !== nothing
+                for (T2, info2) in registry.structs
+                    if info2.wasm_type_idx == ti && T2 isa DataType
+                        local P2 = supertype(T2)
+                        if P2 isa DataType && P2 !== Any && haskey(registry.abstract_struct_idxs, P2) &&
+                           registry.abstract_struct_idxs[P2] < ti
+                            _dag_parent = registry.abstract_struct_idxs[P2]
+                        end
+                        break
+                    end
+                end
+            end
+            mod.types[i] = StructType(ct.fields, _dag_parent)
         end
     end
 end
@@ -2270,4 +2290,38 @@ function get_closure_vtable_struct!(mod::WasmModule, registry::TypeRegistry, max
     idx = UInt32(add_type!(mod, StructType(fields)))
     d[max_arity] = idx
     return idx
+end
+
+
+# ═══ step5: THE CLASS-DAG (dart class_info.dart:278-330) ═══
+
+"""
+    ensure_abstract_struct!(mod, registry, A) -> UInt32
+
+The synthetic {classId:i32} struct for an ABSTRACT Julia type, `sub` its parent's
+synthetic (recursion roots at \$JlBase = Any). Parents recurse FIRST → their indices
+precede the child's (the wasm ordering rule).
+"""
+function ensure_abstract_struct!(mod::WasmModule, registry::TypeRegistry, A::Type)::UInt32
+    (A === Any || !(A isa DataType)) && return registry.base_struct_idx
+    d = registry.abstract_struct_idxs
+    d === nothing && return registry.base_struct_idx
+    haskey(d, A) && return d[A]
+    parent_idx = ensure_abstract_struct!(mod, registry, supertype(A))
+    idx = UInt32(add_type!(mod, StructType([FieldType(I32, false)], parent_idx)))
+    d[A] = idx
+    return idx
+end
+
+"""
+    dag_supertype_idx!(mod, registry, T) -> UInt32
+
+The wasm supertype for a CONCRETE type's struct: its nearest abstract parent's
+synthetic (the class-DAG), falling back to \$JlBase.
+"""
+function dag_supertype_idx!(mod::WasmModule, registry::TypeRegistry, T::Type)::UInt32
+    (T isa DataType && registry.abstract_struct_idxs !== nothing) || return registry.base_struct_idx
+    local P = supertype(T)
+    (P === Any || !(P isa DataType)) && return registry.base_struct_idx
+    return ensure_abstract_struct!(mod, registry, P)
 end

--- a/test/march3_try_backfills.jl
+++ b/test/march3_try_backfills.jl
@@ -145,3 +145,16 @@ _m16_one(n::Int64)::Int64 = (fs = Any[x -> x + n]; f = fs[1]; f(10)::Int64)
     r = try compare_julia_wasm(_m16_one, Int64(7)) catch; (pass=false,) end
     @test r.pass
 end
+
+# step5 THE CLASS-DAG: concrete structs subtype their abstract parent's SYNTHETIC
+# (dart class_info.dart:288) — the per-class wasm hierarchy replaces flat sub-$JlBase.
+abstract type _S5Shape end
+struct _S5C <: _S5Shape; r::Float64; end
+struct _S5Q <: _S5Shape; s::Float64; end
+_s5_area(q::Bool)::Float64 = (s = q ? _S5C(2.0) : _S5Q(3.0); s isa _S5C ? 3.14 * s.r : (s::_S5Q).s^2)
+@testset "step5: the class-DAG (per-class wasm subtyping)" begin
+    for a in (true, false)
+        r = try compare_julia_wasm(_s5_area, a) catch; (pass=false,) end
+        @test r.pass
+    end
+end


### PR DESCRIPTION
Per-class wasm subtype hierarchy replacing flat sub-$JlBase (dart class_info.dart:278-330): abstract synthetics, creation-time parenting at 7 sites, the lookup-only retrofit, supertype-aware struct identity. Emitted chains proven (6→5→0, wasm-tools valid). Gate-certified under the strict builder (10 shards + 9 fuzz).

Includes CENSUS-3: the full re-audit — 66.0 → 70.2 raw, 72.8 → 77.7 actionable, with the load-bearing findings (sibling-collapse is wasm-inherent; the struct-LUB unlock is latent; the ranked remainder).
