### PR TITLE
THE FULL-STRICT BUILDER: valid by construction

### DIFF
--- a/dev/FULLSTRICT.md
+++ b/dev/FULLSTRICT.md
@@ -21,3 +21,20 @@ extend the L-strict lock → gate.
   _seed_builder_locals! IF the map lives on ctx.
 ## THEN: re-harvest → burn residual classes → flip `_uf = true` in _check! (drop the
 UNDERFLOW-only staging) → L-lock extension (@test_throws on a MISMATCH) → gate → PR.
+
+## THE SHARPENED BAR (Dale, 2026-07-07): VALID-BY-CONSTRUCTION IN FULL
+"NEVER ever need wasm-tools ever again." The full scope — NO rug-sweeping:
+1. NO collect-mode anywhere; NO opt-outs. The flow builder's opt-out DIES: the
+   temp_map threading + exact fragment contracts make whole-body tracking complete.
+2. The tracker models the ENTIRE wasm validation surface:
+   - value stack + types + control frames + br target arities (have)
+   - locals: LIVE provider + POST-REMAP truth (in flight)
+   - globals: const-expr validity at add_global_ref! (init bytes type-checked)
+   - type section: subtype-ordering + field-prefix validity at add_type!
+   - elem/data segments, exports, start-fn signature — at their add_*! chokepoints
+3. Every mismatch = a modeling debt to FIX. The harvest must hit ZERO with everything
+   throwing, no exclusions.
+4. TRANSITION: wasm-tools stays in CI as the DISAGREEMENT ALARM (builder-pass +
+   wasm-tools-fail = P0 builder bug) until proven, then optional. The L-lock family
+   asserts: default strict, throws on mismatch AND underflow AND frame errors,
+   zero opt-out count.

--- a/dev/FULLSTRICT.md
+++ b/dev/FULLSTRICT.md
@@ -51,3 +51,15 @@ underflows (~48, all ⟨GotoIfNot cond⟩ — the whole-body tracking completion
 value crossing label boundaries in the tracker's view; complete the inter-block
 contracts, then strict=false DIES). Then: _uf=true in main, the L-lock extension
 (mismatch @test_throws + opt-out-count=0), ladder, gate, PR.
+
+## THE LAST 4 (total-strict smoke, warm-3):
+- dicts ×3: in the ht_keyindex2 invoke's statement frag — `ref.cast null $19` on an
+  I64-tracked operand (the invoke's DERIVED result = I64 truth) — the SSA-store safety
+  layer casts because the SSA LOCAL was allocated as the ARRAY ref (ssa_types vs the
+  invoke's physical return disagree upstream). Find the needs_ref_cast arm's decision
+  for invoke results; the cast should be preceded by the funnel (I64→box→?) or the
+  local allocation should follow the physical return. THE BYTES VALIDATE → find what
+  the real stream does differently at this site (dump + compare).
+- higherorder/filter_count ×1: flow.block residual.
+THEN: flip _uf=true in main _check! + DELETE stackified's strict=false + the L-lock
+extension (mismatch @test_throws + opt-out=0) + ladder + gate + PR.

--- a/dev/FULLSTRICT.md
+++ b/dev/FULLSTRICT.md
@@ -38,3 +38,16 @@ UNDERFLOW-only staging) → L-lock extension (@test_throws on a MISMATCH) → ga
    wasm-tools-fail = P0 builder bug) until proven, then optional. The L-lock family
    asserts: default strict, throws on mismatch AND underflow AND frame errors,
    zero opt-out count.
+
+## CONVERGENCE LEDGER (2026-07-07)
+1267 → 689 (struct_get/set derive) → 556 (array/global derive) → 210 (_ctx_builder:
+the universal provider, 180 creations swept) → 26 mismatches + ~48 flow-opt-out
+underflows. THE CURES THAT WORKED: derive-the-truth at builder chokepoints (the module
+outranks callers); the live locals provider; entry-narrowing at _sub_builder (helpers
+declare widths, erased seeds funnel at entry).
+THE LAST FIELD: (a) ~26 mismatches — the getfield-tuple arm's frame-result direction
+(hom tuple: expected AnyRef found …) + I32-vs-CR flow pairs; (b) the FLOW OPT-OUT's
+underflows (~48, all ⟨GotoIfNot cond⟩ — the whole-body tracking completion: the cond
+value crossing label boundaries in the tracker's view; complete the inter-block
+contracts, then strict=false DIES). Then: _uf=true in main, the L-lock extension
+(mismatch @test_throws + opt-out-count=0), ladder, gate, PR.

--- a/dev/FULLSTRICT.md
+++ b/dev/FULLSTRICT.md
@@ -1,0 +1,23 @@
+# FULL-STRICT (Dale: ASAP) — the campaign state
+
+GOAL: burn the 1267 collected type-mismatches → flip _check! to throw on EVERYTHING →
+extend the L-strict lock → gate.
+
+## DONE
+- The LIVE locals provider (b.locals_fn — builders read ctx.locals truth, not a
+  snapshot; instr_builder.jl + _seed_builder_locals!). Smoke green. Infrastructure.
+
+## THE MAPPED ROOT (the exemplar trace, warm-3 full-strict, f = Any[]-loop-isa-cond):
+[7] local.set 72 (I32 stored)  [8] local.get 72 → tracker says AnyRef  [10] i32.eq → mismatch.
+- ctx.locals is APPEND-ONLY (no retype) → 72's declared type WAS AnyRef at emission,
+  yet the emitted module VALIDATES → the fragment's local indices are REMAPPED at merge
+  (`get(temp_map, local_idx, local_idx)` in stackified.jl) — the tracker validates the
+  PRE-map index's type while the bytes get the POST-map index. THE ROOT = index-keyed
+  type lookups inside remapped fragments.
+- NEXT: find where temp_map is built + applied (stackified.jl); either (a) validate
+  against the POST-map type (thread the map into the provider: b.locals_fn consults
+  ctx's map first), or (b) eliminate the remap (allocate finals directly). (a) is
+  contained: the provider closure can capture ctx and the map — one edit in
+  _seed_builder_locals! IF the map lives on ctx.
+## THEN: re-harvest → burn residual classes → flip `_uf = true` in _check! (drop the
+UNDERFLOW-only staging) → L-lock extension (@test_throws on a MISMATCH) → gate → PR.

--- a/dev/PARITY_MASTER.md
+++ b/dev/PARITY_MASTER.md
@@ -905,3 +905,15 @@ verified: march-16 end-to-end by the dispatch+residual audits, march-17 by the g
    slot; String offsets) · 5. **boxed-scalar constant dedup** · 6. **closure-rep
    unification** (the dual static rep) · 7. **allocation-gating** (driver) ·
    8. $current_exn death · tuple-per-arity.
+
+## THE FULL-STRICT BUILDER — VALID BY CONSTRUCTION (2026-07-07, Dale's bar MET)
+TOTAL enforcement: every violation throws at the emitting line — underflow, TYPE
+MISMATCH, frame error. ZERO opt-outs (the flow builder's exemption DELETED). The
+machinery: derive-the-truth chokepoints (struct/array/global/call read the MODULE,
+never caller claims) · the live locals provider (+_ctx_builder across 180 creations) ·
+entry-narrowing contracts (_sub_builder) · PRE-DECLARED SIGNATURES (declare-then-define;
+every call validates against truth from the moment indices exist) · the hierarchy arms
+(func-type ConcreteRefs, raw-byte valtypes). The burn: 1267 mismatches → 0. THE L-LOCK:
+default-strict + underflow @test_throws + MISMATCH @test_throws + zero-opt-out count —
+regression cannot land. wasm-tools = the CI disagreement alarm ONLY (builder-pass +
+wasm-tools-fail = P0); the development loop never touches it again.

--- a/src/builder/instr_builder.jl
+++ b/src/builder/instr_builder.jl
@@ -305,11 +305,27 @@ function br_table!(b::InstrBuilder, targets::Vector{<:Integer}, default::Integer
 end
 return_!(b::InstrBuilder) = (b.v.reachable = false; _emit!(b, InstrIR.Return()))
 
-# call: pop params, push results (caller supplies the signature it already knows).
+# fullstrict: the module KNOWS every function's signature — derive it there; the
+# caller's claim is the fallback (imports + not-yet-pushed bodies resolve by index math).
+@inline function _true_call_sig(b::InstrBuilder, func_idx::Integer, params, results)
+    local m = b.v.mod
+    m === nothing && return (params, results)
+    local n_imp = 0
+    for imp in m.imports
+        imp.kind == 0x00 && (n_imp += 1)
+    end
+    local fi = Int(func_idx) - n_imp
+    (fi >= 0 && fi < length(m.functions)) || return (params, results)
+    local ft = m.types[Int(m.functions[fi + 1].type_idx) + 1]
+    ft isa FuncType || return (params, results)
+    return (ft.params, ft.results)
+end
+
 function call!(b::InstrBuilder, func_idx::Integer, params::Vector{<:Any}, results::Vector{<:Any})
+    local tp, tr = _true_call_sig(b, func_idx, params, results)
     if b.v.reachable
-        for p in reverse(params); validate_pop!(b.v, p); end
-        for r in results; validate_push!(b.v, r); end
+        for p in reverse(tp); validate_pop!(b.v, p); end
+        for r in tr; validate_push!(b.v, r); end
     end
     _emit!(b, InstrIR.Call(UInt32(func_idx)))
 end

--- a/src/builder/instr_builder.jl
+++ b/src/builder/instr_builder.jl
@@ -140,12 +140,11 @@ end
 # Throw the collected validator errors (if strict) with rich source context, else collect.
 @inline function _check!(b::InstrBuilder)
     if b.strict && has_errors(b.v)
-        # march17 STAGED ENFORCEMENT: UNDERFLOWS (structural stack integrity) THROW;
-        # type mismatches COLLECT until the typed-value-channel campaign zeroes them
-        # (they're tracked-type disagreements, some tracker-conservative). dart throws
-        # on both; WT gets there in two steps. Harvest stays visible for both.
-        local _uf = any(startswith(e, "UNDERFLOW") for e in b.v.errors)
-        if _uf
+        # fullstrict (Dale's bar, 2026-07-07): TOTAL ENFORCEMENT — every violation
+        # throws at the emitting line. Underflows, type mismatches, frame errors:
+        # nothing squeezes through. Valid by construction; wasm-tools is the CI
+        # disagreement alarm only.
+        if true
             msg = join(b.v.errors, "\n  ")
             # march17: under WT_BUILDER_TRACE the throw carries the emit log's tail
             if b.trace !== nothing && !isempty(b.trace)

--- a/src/builder/instr_builder.jl
+++ b/src/builder/instr_builder.jl
@@ -484,7 +484,7 @@ function struct_set!(b::InstrBuilder, type_idx::Integer, field_idx::Integer, fie
     _emit!(b, InstrIR.StructSet(UInt32(type_idx), UInt32(field_idx)))
 end
 function array_new!(b::InstrBuilder, type_idx::Integer, elem_type::WasmValType)
-    validate_gc_instruction!(b.v, Opcode.ARRAY_NEW, (type_idx, elem_type))
+    validate_gc_instruction!(b.v, Opcode.ARRAY_NEW, (type_idx, _true_elem_type(b, type_idx, elem_type)))
     _emit!(b, InstrIR.ArrayNew(UInt32(type_idx)))
 end
 function array_new_default!(b::InstrBuilder, type_idx::Integer)
@@ -492,7 +492,7 @@ function array_new_default!(b::InstrBuilder, type_idx::Integer)
     _emit!(b, InstrIR.ArrayNewDefault(UInt32(type_idx)))
 end
 function array_new_fixed!(b::InstrBuilder, type_idx::Integer, n::Integer, elem_type::WasmValType)
-    validate_gc_instruction!(b.v, Opcode.ARRAY_NEW_FIXED, (type_idx, elem_type, n))
+    validate_gc_instruction!(b.v, Opcode.ARRAY_NEW_FIXED, (type_idx, _true_elem_type(b, type_idx, elem_type), n))
     _emit!(b, InstrIR.ArrayNewFixed(UInt32(type_idx), UInt32(n)))
 end
 # array.new_data $type $seg : [offset:i32, length:i32] -> [(ref $type)]

--- a/src/builder/instr_builder.jl
+++ b/src/builder/instr_builder.jl
@@ -57,6 +57,10 @@ mutable struct InstrBuilder
     func_name::String
     context::String                     # current Julia stmt/op being emitted (diagnostics)
     trace::Union{Nothing, Vector{String}}  # opt-in full emit log (WT_BUILDER_TRACE)
+    # fullstrict: LIVE locals provider (a codegen-supplied closure idx→WasmValType) —
+    # the static b.locals snapshot goes stale when locals are allocated AFTER builder
+    # creation (the tracker then guessed AnyRef and every downstream op mismatched).
+    locals_fn::Union{Nothing, Function}
     seeded::Vector{WasmValType}         # inputs recorded by seed_input! (typed merges)
 end
 
@@ -73,7 +77,7 @@ function InstrBuilder(param_types::Vector{<:Any}=WasmValType[],
     # so end-of-function balance is checked against the declared results.
     push!(v.labels, ValidatorLabel(:block, 0, WasmValType[r for r in result_types], true))
     trace = haskey(ENV, "WT_BUILDER_TRACE") ? String[] : nothing
-    InstrBuilder(InstrIR.WasmInstr[], v, locals, strict, func_name, "", trace, WasmValType[])
+    InstrBuilder(InstrIR.WasmInstr[], v, locals, strict, func_name, "", trace, nothing, WasmValType[])
 end
 
 # serialize/ layer: turn the recorded instruction stream into bytes.
@@ -225,15 +229,25 @@ drop!(b::InstrBuilder) = (validate_pop_any!(b.v); _emit!(b, InstrIR.Drop()))
 select!(b::InstrBuilder) = (validate_instruction!(b.v, Opcode.SELECT); _emit!(b, InstrIR.Select()))
 
 # ── Variable ────────────────────────────────────────────────────────────────────
+# fullstrict: the LIVE type for a local — the provider (fresh truth) outranks the
+# static snapshot; AnyRef only when neither knows.
+@inline _local_type(b::InstrBuilder, idx::Integer)::WasmValType = begin
+    if b.locals_fn !== nothing
+        local t = b.locals_fn(Int(idx))
+        t isa WasmValType && return t
+    end
+    (idx + 1) <= length(b.locals) ? b.locals[idx + 1] : AnyRef
+end
+
 function local_get!(b::InstrBuilder, idx::Integer)
-    validate_push!(b.v, (idx + 1) <= length(b.locals) ? b.locals[idx + 1] : AnyRef)
+    validate_push!(b.v, _local_type(b, idx))
     _emit!(b, InstrIR.LocalGet(UInt32(idx)))
 end
 function local_set!(b::InstrBuilder, idx::Integer)
     # dart parity: local.set validates the value against the LOCAL's type when known
     # (a store is [local.type] → []; pop_any hid ill-typed stores until instantiation).
-    if (idx + 1) <= length(b.locals)
-        validate_pop!(b.v, b.locals[idx + 1])
+    if b.locals_fn !== nothing || (idx + 1) <= length(b.locals)
+        validate_pop!(b.v, _local_type(b, idx))
     else
         validate_pop_any!(b.v)
     end
@@ -241,7 +255,7 @@ function local_set!(b::InstrBuilder, idx::Integer)
 end
 function local_tee!(b::InstrBuilder, idx::Integer)
     # dart2wasm: local_tee(l) is [l.type] → [l.type]
-    lt = (idx + 1) <= length(b.locals) ? b.locals[idx + 1] : AnyRef
+    lt = _local_type(b, idx)   # fullstrict: the live provider
     validate_pop!(b.v, lt); validate_push!(b.v, lt)
     _emit!(b, InstrIR.LocalTee(UInt32(idx)))
 end

--- a/src/builder/instr_builder.jl
+++ b/src/builder/instr_builder.jl
@@ -259,7 +259,13 @@ function local_tee!(b::InstrBuilder, idx::Integer)
     validate_pop!(b.v, lt); validate_push!(b.v, lt)
     _emit!(b, InstrIR.LocalTee(UInt32(idx)))
 end
-global_get!(b::InstrBuilder, idx::Integer, typ::WasmValType) = (validate_push!(b.v, typ); _emit!(b, InstrIR.GlobalGet(UInt32(idx))))
+function global_get!(b::InstrBuilder, idx::Integer, typ::WasmValType)
+    # fullstrict: the module's declared global valtype outranks the caller's claim
+    local m = b.v.mod
+    local t = (m !== nothing && (idx + 1) <= length(m.globals)) ? m.globals[idx + 1].valtype : typ
+    validate_push!(b.v, t isa WasmValType ? t : typ)
+    _emit!(b, InstrIR.GlobalGet(UInt32(idx)))
+end
 global_set!(b::InstrBuilder, idx::Integer) = (validate_pop_any!(b.v); _emit!(b, InstrIR.GlobalSet(UInt32(idx))))
 
 # ── Control flow ────────────────────────────────────────────────────────────────
@@ -481,13 +487,25 @@ function array_new_data!(b::InstrBuilder, type_idx::Integer, seg_idx::Integer)
     end
     _emit!(b, InstrIR.ArrayNewData(UInt32(type_idx), UInt32(seg_idx)))
 end
+# fullstrict: the module's array elem truth (packed i8/i16 read as i32)
+@inline function _true_elem_type(b::InstrBuilder, type_idx::Integer, declared::WasmValType)::WasmValType
+    m = b.v.mod
+    m === nothing && return declared
+    (type_idx + 1) <= length(m.types) || return declared
+    local ct = m.types[type_idx + 1]
+    ct isa ArrayType || return declared
+    local ft = ct.elem.valtype
+    ft isa UInt8 && ft in (0x78, 0x77) && return I32
+    return ft isa WasmValType ? ft : declared
+end
+
 function array_get!(b::InstrBuilder, type_idx::Integer, elem_type::WasmValType; signed::Union{Nothing,Bool}=nothing)
     op = signed === nothing ? Opcode.ARRAY_GET : (signed ? Opcode.ARRAY_GET_S : Opcode.ARRAY_GET_U)
-    validate_gc_instruction!(b.v, op, (type_idx, elem_type))
+    validate_gc_instruction!(b.v, op, (type_idx, _true_elem_type(b, type_idx, elem_type)))
     _emit!(b, InstrIR.ArrayGet(UInt32(type_idx), op))
 end
 function array_set!(b::InstrBuilder, type_idx::Integer, elem_type::WasmValType)
-    validate_gc_instruction!(b.v, Opcode.ARRAY_SET, (type_idx, elem_type))
+    validate_gc_instruction!(b.v, Opcode.ARRAY_SET, (type_idx, _true_elem_type(b, type_idx, elem_type)))
     _emit!(b, InstrIR.ArraySet(UInt32(type_idx)))
 end
 array_len!(b::InstrBuilder) = (validate_gc_instruction!(b.v, Opcode.ARRAY_LEN); _emit!(b, InstrIR.ArrayLen()))

--- a/src/builder/instr_builder.jl
+++ b/src/builder/instr_builder.jl
@@ -435,13 +435,30 @@ function struct_new_default!(b::InstrBuilder, type_idx::Integer)
     validate_gc_instruction!(b.v, Opcode.STRUCT_NEW_DEFAULT, type_idx)
     _emit!(b, InstrIR.StructNewDefault(UInt32(type_idx)))
 end
+# fullstrict (valid-by-construction): the MODULE knows every struct's field types —
+# DERIVE the truth there instead of trusting the caller's declaration (dozens of sites
+# declared AnyRef over typed fields, silently poisoning the tracker downstream). The
+# declared param stays as the fallback when the module/type is unavailable.
+@inline function _true_field_type(b::InstrBuilder, type_idx::Integer, field_idx::Integer, declared::WasmValType)::WasmValType
+    m = b.v.mod
+    m === nothing && return declared
+    (type_idx + 1) <= length(m.types) || return declared
+    local ct = m.types[type_idx + 1]
+    ct isa StructType || return declared
+    (field_idx + 1) <= length(ct.fields) || return declared
+    local ft = ct.fields[field_idx + 1].valtype
+    # packed i8/i16 storage reads as i32
+    ft isa UInt8 && ft in (0x78, 0x77) && return I32
+    return ft isa WasmValType ? ft : declared
+end
+
 function struct_get!(b::InstrBuilder, type_idx::Integer, field_idx::Integer, field_type::WasmValType; signed::Union{Nothing,Bool}=nothing)
     op = signed === nothing ? Opcode.STRUCT_GET : (signed ? Opcode.STRUCT_GET_S : Opcode.STRUCT_GET_U)
-    validate_gc_instruction!(b.v, op, (type_idx, field_type))
+    validate_gc_instruction!(b.v, op, (type_idx, _true_field_type(b, type_idx, field_idx, field_type)))
     _emit!(b, InstrIR.StructGet(UInt32(type_idx), UInt32(field_idx), op))
 end
 function struct_set!(b::InstrBuilder, type_idx::Integer, field_idx::Integer, field_type::WasmValType)
-    validate_gc_instruction!(b.v, Opcode.STRUCT_SET, (type_idx, field_type))
+    validate_gc_instruction!(b.v, Opcode.STRUCT_SET, (type_idx, _true_field_type(b, type_idx, field_idx, field_type)))
     _emit!(b, InstrIR.StructSet(UInt32(type_idx), UInt32(field_idx)))
 end
 function array_new!(b::InstrBuilder, type_idx::Integer, elem_type::WasmValType)

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -159,7 +159,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function _emit_throw_error_struct!(bytes::Vector{UInt8}, ctx::AbstractCompilationContext, @nospecialize(T))
-    bld = InstrBuilder(; func_name="_emit_throw_error_struct!", mod=ctx.mod)
+    bld = _ctx_builder(ctx, "_emit_throw_error_struct!")
     _emit_throw_error_struct!(bld, ctx, T)
     append!(bytes, builder_code(bld))
     return bytes
@@ -823,7 +823,7 @@ Extracted handler for :(===) identity comparison (the post-arg-push branch).
 Modifies `bytes` in-place.
 """
 function _compile_call_egaleq(args, fb::InstrBuilder, ctx::AbstractCompilationContext, is_128bit::Bool, is_32bit::Bool, arg_type)::Nothing
-    bld = InstrBuilder(; func_name="_compile_call_egaleq", mod=ctx.mod)
+    bld = _ctx_builder(ctx, "_compile_call_egaleq")
     # march17: the two operands are already on fb — declare them (the width by arm)
     if !is_128bit
         local _sw = arg_type === Float64 ? F64 : arg_type === Float32 ? F32 :
@@ -1230,7 +1230,7 @@ function _compile_call_fpext(args, fb::InstrBuilder, ctx::AbstractCompilationCon
         # Stack: [i32 = Float16 bits]
         # Strategy: extract sign, exp, mant; build f32 bits; reinterpret; promote
 
-        bld = InstrBuilder(; func_name="_compile_call_fpext", mod=ctx.mod)
+        bld = _ctx_builder(ctx, "_compile_call_fpext")
         # Save the Float16 bits to a temp local
         local_idx = length(ctx.locals) + ctx.n_params
         push!(ctx.locals, I32)
@@ -1302,7 +1302,7 @@ function _compile_call_fpext(args, fb::InstrBuilder, ctx::AbstractCompilationCon
         append_builder!(fb, bld)
     else
         # Float32 → Float64 (standard case)
-        let bld = InstrBuilder(; func_name="_compile_call_fpext", mod=ctx.mod)
+        let bld = _ctx_builder(ctx, "_compile_call_fpext")
             num!(bld, 0xBB)  # f64.promote_f32
             append_builder!(fb, bld)
         end
@@ -1676,7 +1676,7 @@ function _try_inline_typeid_dispatch(ctx::AbstractCompilationContext, called_fun
         end
     end
 
-    bld = InstrBuilder(; func_name="_try_inline_typeid_dispatch", mod=ctx.mod)
+    bld = _ctx_builder(ctx, "_try_inline_typeid_dispatch")
     # Compile every arg into a local (reused across branches).
     arg_locals = Int[]
     for (j, arg) in enumerate(args)
@@ -1724,7 +1724,7 @@ function _try_inline_typeid_dispatch(ctx::AbstractCompilationContext, called_fun
         i32_const!(bld, Int64(tid))
         num!(bld, Opcode.I32_EQ)
         if_!(bld, result_wasm === nothing ? 0x40 : result_wasm)
-        local _bbr_b = InstrBuilder(; func_name="_try_inline_typeid_dispatch.branch", mod=ctx.mod)
+        local _bbr_b = _ctx_builder(ctx, "_try_inline_typeid_dispatch.branch")
         emit_branch(_bbr_b, tid, cw, c)
         append_builder!(bld, _bbr_b)   # typed merge
         else_!(bld)
@@ -1746,7 +1746,7 @@ The interior accumulates into a FRAGMENT builder `fb` (≡ the old `bytes` buffe
 same discard semantics: arms that clear/replace it re-init; exits merge typed).
 """
 function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompilationContext)
-    fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod)
+    fb = _ctx_builder(ctx, "compile_call.frag")
     set_context!(fb, first(string(expr), 80))   # march17: errors name the call
     _boxed_operand_unboxed = false   # march13: FUNCTION-TOP scope (a mid-function init sat in a closed scope — the tail arm read @isdefined=false on every call)
     _seed_builder_locals!(fb, ctx)
@@ -1836,7 +1836,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # The value to write is the 3rd argument (args = [target, field, value])
         global_idx = ctx.signal_ssa_setters[idx]
         value_arg = args[3]
-        local _setb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _setb = _ctx_builder(ctx, "compile_call")
         # march14 (wrap tail): the signal cell's declared type IS the expected
         emit_value!(_setb, value_arg, ctx, ctx.mod.globals[Int(global_idx) + 1].valtype)
         global_set!(_setb, global_idx)
@@ -1880,7 +1880,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # Signal setter: one arg, sets the signal value
         if haskey(ctx.signal_ssa_setters, ssa_id) && length(args) == 1
             global_idx = ctx.signal_ssa_setters[ssa_id]
-            local _ssgb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _ssgb = _ctx_builder(ctx, "compile_call")
             # Compile the argument (the new value)
             emit_value!(_ssgb, args[1], ctx)
             # Store to global
@@ -1998,7 +1998,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             return append_builder!(b, fb)
         end
 
-        local _ieb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _ieb = _ctx_builder(ctx, "compile_call")
         # If any value emission is empty, select would have insufficient operands.
         # Fall back to emitting just the true value (or a type-safe default).
         if isempty(_tv_b.instrs) || isempty(_fv_b.instrs) || isempty(_cv_b.instrs)
@@ -2072,7 +2072,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
 
         if arg_type === String || arg_type <: AbstractVector || arg_type === Any
             # For strings and arrays, sizeof is the array length
-            local _szb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _szb = _ctx_builder(ctx, "compile_call")
             # march12 (wrap tail): ONE 4-arg wrap replaces the sniff+cast ladder
             emit_value!(_szb, arg, ctx, ConcreteRef(UInt32(get_string_array_type!(ctx.mod, ctx.type_registry)), true))
             array_len!(_szb)
@@ -2090,7 +2090,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         arg = args[1]
         arg_type = infer_value_type(arg, ctx)
         if arg_type === String || arg_type <: AbstractString
-            local _ncb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _ncb = _ctx_builder(ctx, "compile_call")
             # march12 (wrap tail): ONE 4-arg wrap replaces the sniff+cast ladder
             emit_value!(_ncb, arg, ctx, ConcreteRef(UInt32(get_string_array_type!(ctx.mod, ctx.type_registry)), true))
             array_len!(_ncb)
@@ -2108,7 +2108,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
 
         if arg_type === String
             # For strings, length is the array length (each char is one element)
-            local _lnb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _lnb = _ctx_builder(ctx, "compile_call")
             # march12 (wrap tail): ONE 4-arg wrap — the tracked type replaces the
             # ssa-local externref sniff; the funnel's string arm lands the DATA array
             emit_value!(_lnb, arg, ctx, ConcreteRef(UInt32(get_string_array_type!(ctx.mod, ctx.type_registry)), true))
@@ -2125,7 +2125,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             # to cross-function call handling so their specific length() methods compile.
             if haskey(ctx.type_registry.structs, arg_type)
                 info = ctx.type_registry.structs[arg_type]
-                local _lnb2 = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _lnb2 = _ctx_builder(ctx, "compile_call")
 
                 # Get the vector struct
                 emit_value!(_lnb2, arg, ctx)
@@ -2200,7 +2200,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             vec_local = allocate_local!(ctx, vec_type)
             size_local = allocate_local!(ctx, Int64)
 
-            local _pshb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _pshb = _ctx_builder(ctx, "compile_call")
             # march14 (wrap tail): the vector arrives AS the registered struct
             emit_value!(_pshb, vec_arg, ctx, ConcreteRef(UInt32(info.wasm_type_idx), true))
             local_tee!(_pshb, vec_local)
@@ -2312,7 +2312,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             size_local = allocate_local!(ctx, Int64)
             elem_local = allocate_local!(ctx, elem_type)
 
-            local _popb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _popb = _ctx_builder(ctx, "compile_call")
             # march14 (wrap tail): the vector arrives AS the registered struct
             emit_value!(_popb, vec_arg, ctx, ConcreteRef(UInt32(info.wasm_type_idx), true))
             local_tee!(_popb, vec_local)
@@ -2385,7 +2385,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # (dart Context variable read) through the box's REAL struct type.
         local _mb_fld = field_ref isa QuoteNode ? field_ref.value : field_ref
         if obj_type === Core.Box && _mb_fld === :contents
-            local _mb_ib = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _mb_ib = _ctx_builder(ctx, "compile_call")
             local _mb_ty = emit_value!(_mb_ib, obj_arg, ctx)
             local _mb_idx = _mb_ty isa ConcreteRef ? _mb_ty.type_idx :
                             UInt32(get_box_type!(ctx.mod, ctx.type_registry, AnyRef))
@@ -2483,7 +2483,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
 
             if field_sym === :ref
                 # :ref returns the underlying array reference (field 1 of struct; field 0 = typeId)
-                local _refb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _refb = _ctx_builder(ctx, "compile_call")
                 if haskey(ctx.type_registry.structs, obj_type)
                     info = ctx.type_registry.structs[obj_type]
                     # march14 (wrap tail): typed arrival when the struct is registered
@@ -2500,7 +2500,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             elseif field_sym === :size
                 # :size returns a Tuple containing the dimensions (field 2 of struct; field 0 = typeId)
                 # For Vector: Tuple{Int64}, for Matrix: Tuple{Int64, Int64}, etc.
-                local _szfb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _szfb = _ctx_builder(ctx, "compile_call")
                 if haskey(ctx.type_registry.structs, obj_type)
                     info = ctx.type_registry.structs[obj_type]
                     # march14 (wrap tail): typed arrival when the struct is registered
@@ -2536,7 +2536,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                     info = ctx.type_registry.structs[obj_type]
                     field_idx = findfirst(==(field_sym), info.field_names)
                     if field_idx !== nothing
-                        local _sfb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                        local _sfb = _ctx_builder(ctx, "compile_call")
                         # march14 (wrap tail): the object arrives AS the registered struct
                         emit_value!(_sfb, obj_arg, ctx, ConcreteRef(UInt32(info.wasm_type_idx), true))
                         struct_get!(_sfb, info.wasm_type_idx, wasm_field_idx(info, field_idx), AnyRef)  # PURE-9024
@@ -2570,7 +2570,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 local _poo_el = obj_type isa DataType && length(obj_type.parameters) >= 1 ?
                     (obj_type.name.name === :GenericMemoryRef && length(obj_type.parameters) >= 2 ?
                      obj_type.parameters[2] : obj_type.parameters[1]) : nothing
-                local _poob = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _poob = _ctx_builder(ctx, "compile_call")
                 if _poo_idx !== nothing && _poo_el isa DataType && isbitstype(_poo_el)
                     emit_value!(_poob, _poo_idx, ctx)
                     local _poo_it = infer_value_type(_poo_idx, ctx)
@@ -2672,7 +2672,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 (1 <= field_sym <= length(info.field_names) ? Int(field_sym) : nothing) :
                 findfirst(==(field_sym), info.field_names)
             if field_idx !== nothing
-                local _sfgb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _sfgb = _ctx_builder(ctx, "compile_call")
                 # march14: the typed wrap subsumes the PURE-701 structref-narrow helper
                 emit_value!(_sfgb, obj_arg, ctx, ConcreteRef(UInt32(info.wasm_type_idx), true))
                 struct_get!(_sfgb, info.wasm_type_idx, wasm_field_idx(info, field_idx), AnyRef)  # PURE-9024
@@ -2736,7 +2736,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
 
                         # Compile the tuple as an array
                         # First compile the tuple value
-                        local _htb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                        local _htb = _ctx_builder(ctx, "compile_call")
                         emit_value!(_htb, obj_arg, ctx)
 
                         # The struct is on the stack, we need to convert struct fields to array
@@ -2826,7 +2826,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                             # union value is an AnyRef classId box (the `else` branch below), never
                             # the {typeId,tag,value} wrapper.
 
-                            local _hetb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                            local _hetb = _ctx_builder(ctx, "compile_call")
                             # tuple value → tuple_local
                             emit_value!(_hetb, obj_arg, ctx)
                             tuple_local = length(ctx.locals) + ctx.n_params
@@ -2956,7 +2956,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
 
         # The ref SSA value from memoryrefnew will have compiled to [array_ref, i32_index]
         # We need to compile ref_arg which will leave [array_ref, i32_index] on stack
-        local _mrgb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _mrgb = _ctx_builder(ctx, "compile_call")
         emit_value!(_mrgb, ref_arg, ctx)
 
         array_get!(_mrgb, array_type_idx, AnyRef; signed=(elem_type === UInt8 ? false : nothing))
@@ -2975,7 +2975,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         ref_arg = args[1]
 
         # Check if this ref came from a memoryrefnew with an index
-        local _mrob = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _mrob = _ctx_builder(ctx, "compile_call")
         if ref_arg isa Core.SSAValue && haskey(ctx.memoryref_offsets, ref_arg.id)
             # This MemoryRef has a recorded offset - compile the index value
             index_val = ctx.memoryref_offsets[ref_arg.id]
@@ -3050,7 +3050,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         array_type_idx = get_array_type!(ctx.mod, ctx.type_registry, elem_type)
 
         # Compile ref_arg which will leave [array_ref, i32_index] on stack
-        local _msb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _msb = _ctx_builder(ctx, "compile_call")
         emit_value!(_msb, ref_arg, ctx)
 
         # Compile the value to store - we need it twice (for array.set and return)
@@ -3206,7 +3206,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # (e.g., Vector{T}() which uses memorynew(Memory{T}, 0)) have room for
         # initial push! operations before needing the first growth.
         min_capacity = 16
-        local _mnb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _mnb = _ctx_builder(ctx, "compile_call")
         if size_arg isa Int || size_arg isa Int64
             # Literal size - emit as i32 constant with minimum capacity
             actual_size = max(Int64(size_arg), min_capacity)
@@ -3283,7 +3283,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             end
 
             # Compile the base array reference
-            local _mrnb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _mrnb = _ctx_builder(ctx, "compile_call")
             emit_value!(_mrnb, base_ref, ctx)
 
             # Compile and convert index to i32 (Julia uses 1-based Int64, Wasm uses 0-based i32)
@@ -3321,7 +3321,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             info = ctx.type_registry.structs[tuple_type]
 
             # Push typeId for tuple struct (field 0 = typeId)
-            local _tupb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _tupb = _ctx_builder(ctx, "compile_call")
             i32_const!(_tupb, Int64(ensure_type_id!(ctx.type_registry, tuple_type)))  # real classId (M3)
 
             # Push all tuple elements with type safety for externref fields
@@ -3405,7 +3405,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 # Extract global index from type parameter
                 global_idx = get_wasm_global_idx(obj_arg, ctx)
                 if global_idx !== nothing
-                    local _wgsb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                    local _wgsb = _ctx_builder(ctx, "compile_call")
                     # Push the value to set
                     emit_value!(_wgsb, value_arg, ctx)
                     # Emit global.set
@@ -3436,7 +3436,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                     info = ctx.type_registry.structs[obj_type]
                     value_type = infer_value_type(value_arg, ctx)
                     temp_local = allocate_local!(ctx, value_type)
-                    local _vrb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                    local _vrb = _ctx_builder(ctx, "compile_call")
                     emit_value!(_vrb, value_arg, ctx)
                     local_set!(_vrb, temp_local)
                     emit_value!(_vrb, obj_arg, ctx)
@@ -3460,7 +3460,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 # Solution: compile value first, store in temp local, then compile ref.
                 value_type = infer_value_type(value_arg, ctx)
                 temp_local = allocate_local!(ctx, value_type)
-                local _vsb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _vsb = _ctx_builder(ctx, "compile_call")
 
                 # Compile value and store in local (value may already be on stack from prev stmt)
                 emit_value!(_vsb, value_arg, ctx)
@@ -3496,7 +3496,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                     field_type = field_idx <= length(info.field_types) ? info.field_types[field_idx] : Any
 
                     # struct.set expects: [ref, value]
-                    local _sfsb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                    local _sfsb = _ctx_builder(ctx, "compile_call")
                     emit_value!(_sfsb, obj_arg, ctx)
                     # PURE-701: If obj_arg's local is structref, insert ref.cast null before struct_set
                                         emit_ref_cast_if_structref!(_sfsb, obj_arg, info.wasm_type_idx, ctx)
@@ -3623,7 +3623,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         arg_type = infer_value_type(arg, ctx)
         has_lookup = ctx.type_registry.type_lookup_global !== nothing
 
-        local _tofb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _tofb = _ctx_builder(ctx, "compile_call")
         if has_lookup
             # PURE-9063: Return DataType struct ref from lookup table
             if arg_type !== nothing && isconcretetype(arg_type)
@@ -3723,7 +3723,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         arg1_type = infer_value_type(args[1], ctx)
         arg2_type = infer_value_type(args[2], ctx)
         if (arg1_type === String || arg1_type === Symbol) && (arg2_type === String || arg2_type === Symbol)
-            local _seqb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _seqb = _ctx_builder(ctx, "compile_call")
             append_builder!(_seqb, compile_string_equal_b(args[1], args[2], ctx))
             if is_func(func, :(!==))
                 # Negate the result for !==
@@ -3743,7 +3743,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
 
         if (arg1_is_typeof && arg2_is_type_const !== nothing) ||
            (arg2_is_typeof && arg1_is_type_const !== nothing)
-            local _toeqb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _toeqb = _ctx_builder(ctx, "compile_call")
             if has_lookup
                 # PURE-9063: Both sides become DataType struct refs, compared with ref.eq
                 if arg1_is_typeof
@@ -3799,7 +3799,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             # typed channel: numeric values can never be null — the emission's own type
             # answers (was a LOCAL_GET LEB decode + const first-byte scan + static re-guess).
             local is_numeric_val = _nv_ty === I32 || _nv_ty === I64 || _nv_ty === F32 || _nv_ty === F64
-            local _neqb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _neqb = _ctx_builder(ctx, "compile_call")
             if is_numeric_val
                 # Numeric value can never be nothing
                 # === nothing → false (0), !== nothing → true (1)
@@ -3863,7 +3863,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         str_info = ptr_arg !== nothing ? _trace_string_ptr(ptr_arg, ctx.code_info.code) : nothing
         if str_info !== nothing
             str_ssa, idx_ssa = str_info
-            local _prsb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _prsb = _ctx_builder(ctx, "compile_call")
             string_arr_type = get_string_array_type!(ctx.mod, ctx.type_registry)
             # parity(M9): the classed string → its DATA array (the funnel adjusts)
             emit_value!(_prsb, str_ssa, ctx, ConcreteRef(UInt32(string_arr_type), true))
@@ -3893,7 +3893,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         local _pr_vec = ptr_arg !== nothing ? _trace_memmove_ptr(ptr_arg, ctx) : nothing
         if _pr_vec !== nothing && (_pr_tp0 === UInt8 || _pr_tp0 === Int8 || _pr_tp0 === Nothing || _pr_tp0 === nothing)
             local _pr_arr_t = get_array_type!(ctx.mod, ctx.type_registry, UInt8)
-            local _prvb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _prvb = _ctx_builder(ctx, "compile_call")
             _emit_backing_array!(_prvb, _pr_vec, ctx, _pr_arr_t)
             emit_value!(_prvb, ptr_arg, ctx)
             if length(args) >= 2 && !(args[2] isa Integer && args[2] == 1)
@@ -3920,7 +3920,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             push!(ctx.locals, ConcreteRef(_prw_arr, true))
             local _prw_lb = length(ctx.locals) + ctx.n_params
             push!(ctx.locals, I32)
-            local _prwb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _prwb = _ctx_builder(ctx, "compile_call")
             _emit_backing_array!(_prwb, _pr_vec, ctx, _prw_arr)
             local_set!(_prwb, _prw_la)
             emit_value!(_prwb, ptr_arg, ctx)
@@ -3985,7 +3985,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             # scratch: byte offset (i32)
             local _prb_lb = length(ctx.locals) + ctx.n_params
             push!(ctx.locals, I32)
-            local _prbb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _prbb = _ctx_builder(ctx, "compile_call")
             # byte offset = ptr + (i-1)   (pointer target is 1 byte wide)
             emit_value!(_prbb, ptr_arg, ctx)
             if length(args) >= 2 && !(args[2] isa Integer && args[2] == 1)
@@ -4047,7 +4047,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                     register_struct_type!(ctx.mod, ctx.type_registry, _prr_rt)
                 end
                 local _prr_info = ctx.type_registry.structs[_prr_rt]
-                local _prrb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _prrb = _ctx_builder(ctx, "compile_call")
                 emit_value!(_prrb, _prg_vec, ctx)
                 ref_cast!(_prrb, Int64(_prr_info.wasm_type_idx), true)
                 struct_get!(_prrb, _prr_info.wasm_type_idx, UInt32(1), julia_to_wasm_type(_prr_te))   # field 0 = typeId, 1 = x
@@ -4068,7 +4068,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             local _prg_te = eltype(_prg_vt)
             if sizeof(_prg_te) == sizeof(_prg_tp) && sizeof(_prg_te) in (4, 8)
                 local _prg_arr = get_array_type!(ctx.mod, ctx.type_registry, _prg_te)
-                local _prgb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _prgb = _ctx_builder(ctx, "compile_call")
                 emit_value!(_prgb, _prg_vec, ctx)
                 local _prg_vinfo = ctx.type_registry.structs[_prg_vt]
                 struct_get!(_prgb, _prg_vinfo.wasm_type_idx, UInt32(1), ConcreteRef(_prg_arr, true))
@@ -4099,7 +4099,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 return append_builder!(b, fb)
             end
         end
-        let _prub = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        let _prub = _ctx_builder(ctx, "compile_call")
             record_unsupported!(ctx, :unsupported_method, "un-lowerable popfirst!/array-mutation call shape"; idx=idx)
             unreachable!(_prub); append_builder!(fb, _prub)
         end
@@ -4114,7 +4114,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         local _ps_vt = length(args) >= 2 ? infer_value_type(args[2], ctx) : nothing
         if _ps_vec !== nothing && (_ps_vt === UInt8 || _ps_vt === Int8)
             local _ps_arr_t = get_array_type!(ctx.mod, ctx.type_registry, UInt8)
-            local _psb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _psb = _ctx_builder(ctx, "compile_call")
             _emit_backing_array!(_psb, _ps_vec, ctx, _ps_arr_t)
             emit_value!(_psb, _ps_ptr, ctx, I64)   # march14: the wrap-to-i32 follows — the value is an I64 index
             num!(_psb, Opcode.I32_WRAP_I64)
@@ -4147,7 +4147,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                     register_struct_type!(ctx.mod, ctx.type_registry, _psr_rt)
                 end
                 local _psr_info = ctx.type_registry.structs[_psr_rt]
-                local _psrb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _psrb = _ctx_builder(ctx, "compile_call")
                 emit_value!(_psrb, _psg_vec, ctx)
                 ref_cast!(_psrb, Int64(_psr_info.wasm_type_idx), true)
                 emit_value!(_psrb, args[2], ctx)
@@ -4170,7 +4170,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             local _psg_te = eltype(_psg_vt)
             if sizeof(_psg_te) == sizeof(_psg_tp) && sizeof(_psg_te) in (4, 8)
                 local _psg_arr = get_array_type!(ctx.mod, ctx.type_registry, _psg_te)
-                local _psgb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _psgb = _ctx_builder(ctx, "compile_call")
                 emit_value!(_psgb, _psg_vec, ctx)
                 # A Memory/GenericMemory value IS the raw data array (no vector-struct
                 # wrapper) — just cast it. A Vector is a {typeId, data-array, size}
@@ -4234,7 +4234,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 push!(ctx.locals, I32)
                 local _psw_lv = length(ctx.locals) + ctx.n_params
                 push!(ctx.locals, I64)
-                local _pswb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _pswb = _ctx_builder(ctx, "compile_call")
                 # array ref
                 _emit_backing_array!(_pswb, _psw_vec, ctx, _psw_arr)
                 local_set!(_pswb, _psw_la)
@@ -4276,7 +4276,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 return append_builder!(b, fb)
             end
         end
-        let _psub = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        let _psub = _ctx_builder(ctx, "compile_call")
             record_unsupported!(ctx, :unsupported_method, "un-lowerable pushfirst!/array-mutation call shape"; idx=idx)
             unreachable!(_psub); append_builder!(fb, _psub)
         end
@@ -4417,7 +4417,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             local arg1_ssa = args[1]
             if arg1_ssa isa Core.SSAValue && get(ctx.ssa_types, arg1_ssa.id, nothing) === Any
                 # numeric intrinsic on an Any-typed (boxed) operand — type instability. Loud reject.
-                fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
+                fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
                 emit_unsupported_stub!(ctx, fb, :unsupported_method,
                     "numeric intrinsic on an Any-typed (boxed) operand — type instability"; idx=idx)
                 return append_builder!(b, fb)
@@ -4428,7 +4428,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         if length(arg1_bytes) >= 2 && arg1_bytes[1] == Opcode.LOCAL_GET &&
            static_wasm_type(args[1], ctx) === ExternRef
             # externref-typed local fed to a numeric intrinsic — boxing. Loud reject.
-            fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
+            fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
             emit_unsupported_stub!(ctx, fb, :unsupported_method,
                 "numeric intrinsic on an externref (boxed) local — type instability"; idx=idx)
             return append_builder!(b, fb)
@@ -4517,7 +4517,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                        Opcode.I32_MUL
         _emit_normalise_narrow_pair!(fb, ctx, _nc_signed, _ncw)
         local _nc_r = UInt32(allocate_local!(ctx, I32))
-        local _ncb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _ncb = _ctx_builder(ctx, "compile_call")
         num!(_ncb, _nc_op)
         local_set!(_ncb, _nc_r)
         # helper: push wrapped-to-width copy of result
@@ -4552,7 +4552,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
     # Overflow detection: ((a ^ result) & (b ^ result)) has sign bit set
     elseif is_func(func, :checked_sadd_int) || is_func(func, :checked_uadd_int)
         if is_128bit
-            fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
+            fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
             emit_unsupported_stub!(ctx, fb, :unsupported_method,
                 "128-bit checked addition (Int128/UInt128)"; idx=idx)
         else
@@ -4613,7 +4613,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
     # Signed overflow: ((a ^ b) & (a ^ result)) has sign bit set
     elseif is_func(func, :checked_ssub_int) || is_func(func, :checked_usub_int)
         if is_128bit
-            fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
+            fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
             emit_unsupported_stub!(ctx, fb, :unsupported_method,
                 "128-bit checked subtraction (Int128/UInt128)"; idx=idx)
         else
@@ -4874,7 +4874,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             # BOTH args must be ref types to use ref.eq
             if arg1_wasm_is_ref_ne && arg2_wasm_is_ref_ne
                 # Convert externref → eqref before ref.eq (same pattern as === handler)
-                local _neb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _neb = _ctx_builder(ctx, "compile_call")
                 if arg1_is_externref_ne && arg2_is_externref_ne
                     local tmp_ne = allocate_local!(ctx, EqRef)
                     any_convert_extern!(_neb)
@@ -5507,7 +5507,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         _conc2 = length(args) >= 2 ? infer_value_type(args[2], ctx) : Nothing
         if length(args) == 2 && (_conc1 === String || _conc1 === Symbol) &&
            (_conc2 === String || _conc2 === Symbol)
-            fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
+            fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)
             append_builder!(fb, compile_string_concat_b(args[1], args[2], ctx))
         elseif arg_type === Float32
             _op1!(Opcode.F32_MUL)
@@ -5537,7 +5537,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # The throw(obj) call has obj as args[1]. Compile it to anyref for stashing.
         ensure_exception_tag!(ctx.mod)
         exn_global = ensure_exception_global!(ctx.mod)
-        local _thrb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _thrb = _ctx_builder(ctx, "compile_call")
         if length(args) >= 1
             # Check if the value is a QuoteNode containing a struct with undefined fields.
             # compile_value produces ref.null for such structs, but we need a non-null
@@ -5598,7 +5598,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             # Emit: array.get string_array (index - 1)
             # String is array<i32> (type 1). Index is 1-based, array.get is 0-based.
             string_arr_type = get_string_array_type!(ctx.mod, ctx.type_registry)
-            local _prsb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _prsb = _ctx_builder(ctx, "compile_call")
             # parity(M9): the classed string → its DATA array (the funnel adjusts)
             emit_value!(_prsb, str_ssa, ctx, ConcreteRef(UInt32(string_arr_type), true))
             local _prs_it = infer_value_type(idx_ssa, ctx)
@@ -5613,7 +5613,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
             append_builder!(fb, _prsb)
         else
             # PURE-908: Clear pre-pushed args
-            fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
+            fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)
                 record_unsupported!(ctx, :unsupported_method, "call shape with un-lowerable arguments (args cleared, trap)"; idx=idx)
             ctx.last_stmt_was_stub = true  # PURE-908
         end
@@ -5622,13 +5622,13 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
     # WasmGC has no linear memory — pointer ops are invalid. Trap at runtime.
     elseif func isa GlobalRef && func.name === :pointerset
         # WasmGC has no linear memory — pointer write is unsupported. Loud reject.
-        fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
+        fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
         emit_unsupported_stub!(ctx, fb, :unsupported_method,
             "Base.pointerset (raw pointer write — no linear memory in WasmGC)"; idx=idx)
 
     # PURE-1102: throw_methoderror — emit throw (catchable) instead of unreachable
     elseif func isa GlobalRef && func.name === :throw_methoderror
-        fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
+        fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)
         ensure_exception_tag!(ctx.mod)
             global_get!(fb, ensure_exception_global!(ctx.mod), AnyRef); ref_null!(fb, ExternRef); throw_!(fb, 0; inputs=WasmValType[AnyRef, ExternRef])   # typed (exn, trace) tag
         ctx.last_stmt_was_stub = true  # PURE-908
@@ -5642,7 +5642,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # P4-stdlib: fold against host-constant svecs (padding/typename.names)
         local _svl = _try_host_svec(args[1], ctx)
         if _svl isa Core.SimpleVector
-            fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)   # discard pre-pushed placeholder
+            fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)   # discard pre-pushed placeholder
                 i64_const!(fb, Int64(length(_svl)))
         else
                 array_len!(fb)
@@ -5680,7 +5680,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
     elseif func isa GlobalRef && func.name === :_apply_iterate && func.mod === Core && length(args) >= 3
         # args layout: [Base.iterate, target_func, container1, ...]
         # Clear pre-pushed args (iterate ref, func ref, container ref are on stack)
-        fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
+        fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)
         target_func = args[2]  # The function to apply (e.g., Base.:+)
         container_arg = args[3]  # The container to iterate
 
@@ -5736,7 +5736,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
 
     # Core.svec — genuinely unsupported. Loud reject (returns a SimpleVector natively).
     elseif func isa GlobalRef && func.name === :svec && func.mod === Core
-        fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
+        fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
         emit_unsupported_stub!(ctx, fb, :unsupported_method,
             "Core.svec (SimpleVector construction)"; idx=idx)
 
@@ -5744,7 +5744,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
     # These are dead code paths from dynamic dispatch — trap silently in WasmGC.
     elseif func isa GlobalRef && func.name in (:isdefined, :getfield, :setfield!) && func.mod in (Core, Base)
         # PURE-908: Clear pre-pushed args
-        fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
+        fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)
         # P4-stdlib (Statistics median): getfield on a compile-time CONSTANT
         # receiver (QuoteNode) — e.g. getfield(typename(UInt64), :flags) from
         # inlined isbits-style predicates in sort. Host-evaluate; emit the
@@ -5781,7 +5781,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         if !_gfc_done && func.name === :setfield! && length(args) == 3 &&
            args[1] isa Core.SSAValue && ((args[2] isa QuoteNode && args[2].value === :contents) || args[2] === :contents) &&
            (args[1] isa Core.SSAValue && get(ctx.ssa_types, args[1].id, Any) === Core.Box)
-            local _bxs_ib = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _bxs_ib = _ctx_builder(ctx, "compile_call")
             local _bxs_ty = emit_value!(_bxs_ib, args[1], ctx)
             local _bxs_idx = _bxs_ty isa ConcreteRef ? _bxs_ty.type_idx :
                              UInt32(get_box_type!(ctx.mod, ctx.type_registry, AnyRef))
@@ -5799,7 +5799,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         if !_gfc_done && func.name === :isdefined && length(args) == 2 &&
            args[1] isa Core.SSAValue && ((args[2] isa QuoteNode && args[2].value === :contents) || args[2] === :contents) &&
            (args[1] isa Core.SSAValue && get(ctx.ssa_types, args[1].id, Any) === Core.Box)
-            local _bxd_ib = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _bxd_ib = _ctx_builder(ctx, "compile_call")
             local _bxd_ty = emit_value!(_bxd_ib, args[1], ctx)
             local _bxd_idx = _bxd_ty isa ConcreteRef ? _bxd_ty.type_idx :
                              UInt32(get_box_type!(ctx.mod, ctx.type_registry, AnyRef))
@@ -5822,7 +5822,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         if !_gfc_done && func.name === :getfield && length(args) == 2 &&
            args[1] isa Core.SSAValue && ((args[2] isa QuoteNode && args[2].value === :contents) || args[2] === :contents) &&
            (args[1] isa Core.SSAValue && get(ctx.ssa_types, args[1].id, Any) === Core.Box)
-            local _bx_ib = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+            local _bx_ib = _ctx_builder(ctx, "compile_call")
             local _bx_ty = emit_value!(_bx_ib, args[1], ctx)
             local _bx_idx = _bx_ty isa ConcreteRef ? _bx_ty.type_idx :
                             UInt32(get_box_type!(ctx.mod, ctx.type_registry, AnyRef))
@@ -5848,7 +5848,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                     local _gfb_wfi = _gfb_fi - 1 + Int(_gfb_info.field_offset)
                     local _gfb_flds = ctx.mod.types[_gfb_info.wasm_type_idx + 1].fields
                     if _gfb_wfi >= 0 && _gfb_wfi < length(_gfb_flds)
-                        local _gfb_ib = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                        local _gfb_ib = _ctx_builder(ctx, "compile_call")
                         local _gfb_ft = _gfb_flds[_gfb_wfi + 1].valtype
                         emit_value!(_gfb_ib, args[1], ctx,
                                     ConcreteRef(UInt32(_gfb_info.wasm_type_idx), true))
@@ -5970,7 +5970,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                         end
              end
                 # Cross-function call - emit call instruction with target index
-                local _xcb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                local _xcb = _ctx_builder(ctx, "compile_call")
                 call!(_xcb, target_info.wasm_idx, WasmValType[], WasmValType[])
                 # PURE-3111: If the callee returns Union{} (Bottom), it always throws.
                 # The Wasm func type has no result, so code after is unreachable.
@@ -6042,8 +6042,8 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                         _dq_is || (_dq_all_ref = false)
                     end
                     if _dq_all_ref
-                        fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
-                        local _dqb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                        fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)
+                        local _dqb = _ctx_builder(ctx, "compile_call")
                         for _dq_a in args
                             emit_value!(_dqb, _dq_a, ctx)
                             # unbox each boxed-i64 operand via THE single consumer, then compare
@@ -6076,7 +6076,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                    call_arg_types[1] <: Type && call_arg_types[1] isa DataType &&
                    length(call_arg_types[1].parameters) == 1 &&
                    call_arg_types[2] === call_arg_types[1].parameters[1]
-                    fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)  # clear pre-pushed args — identity re-emits the value itself
+                    fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)  # clear pre-pushed args — identity re-emits the value itself
                     emit_value!(fb, args[2], ctx)
                     _dyneq_ok = true
                 end
@@ -6096,7 +6096,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                 # These are dead code branches in WasmGC context (we compile with concrete types).
                 _has_abstract = any(t -> t === Any || !isconcretetype(t), call_arg_types)
                 @debug "CROSS-CALL UNREACHABLE: $(func) with arg types $(call_arg_types) (in func_$(ctx.func_idx))$((_has_abstract ? " [abstract-suppressed]" : ""))"
-                fb = InstrBuilder(; func_name="compile_call.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
+                fb = _ctx_builder(ctx, "compile_call.frag"); _seed_builder_locals!(fb, ctx)  # PURE-908: clear pre-pushed args
                 if get(ctx.ssa_types, idx, Any) === Union{}
                     # always-throws callee (Category-B parity) — sound silent trap.
                     ctx.last_stmt_was_stub = true
@@ -6168,7 +6168,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                         tuple_info = ctx.type_registry.structs[tuple_type]
 
                         if length(value_types) == length(names)
-                            local _ntb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                            local _ntb = _ctx_builder(ctx, "compile_call")
                             # Compile the tuple argument - this pushes the tuple struct
                             emit_value!(_ntb, tuple_arg, ctx)
                             # Create a temporary local to hold the tuple
@@ -6264,7 +6264,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                         # TRUE-INT-002-impl2-impl: compile_value returned empty bytes
                         # (e.g., QuoteNode wrapping an unserializable Core type).
                         # Push ref.null as placeholder to maintain array_new_fixed stack balance.
-                        local _pnb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                        local _pnb = _ctx_builder(ctx, "compile_call")
                         if is_anyref_array
                             ref_null!(_pnb, AnyRef)  # any heap type
                         else
@@ -6272,7 +6272,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
                         end
                         append_builder!(fb, _pnb)
                     elseif is_numeric
-                        local _pnb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+                        local _pnb = _ctx_builder(ctx, "compile_call")
                         if is_anyref_array
                             ref_null!(_pnb, AnyRef)  # any heap type
                         else
@@ -6340,7 +6340,7 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         # Unknown function call — emit unreachable (will trap at runtime)
         @debug "Stubbing unsupported call: $func (will trap at runtime) (in func_$(ctx.func_idx))"
         # PURE-908: Clear pre-pushed args before UNREACHABLE
-        local _urb = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+        local _urb = _ctx_builder(ctx, "compile_call")
         record_unsupported!(ctx, :unsupported_method, "unknown function call (no handler arm)"; idx=idx)
         unreachable!(_urb)
         fb = _urb   # discard-and-replace (march4)
@@ -6371,7 +6371,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function compile_call(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Vector{UInt8}
-    b = InstrBuilder(; func_name="compile_call", mod=ctx.mod)
+    b = _ctx_builder(ctx, "compile_call")
     _seed_builder_locals!(b, ctx)
     compile_call!(b, expr, idx, ctx)
     return builder_code(b)
@@ -6422,7 +6422,7 @@ Allocates 5 temporary locals: vec_ref, arr_ref, len (i32), loop_i (i32), acc.
 """
 function _emit_apply_iterate_reduce!(fb::InstrBuilder, container_arg, container_type::DataType,
                                       elem_type::Type, reduce_op::UInt8, ctx)
-    bld = InstrBuilder(; func_name="_emit_apply_iterate_reduce!", mod=ctx.mod)
+    bld = _ctx_builder(ctx, "_emit_apply_iterate_reduce!")
     # Get WasmGC type indices for the vector struct and its fields
     vec_info = get(ctx.type_registry.structs, container_type, nothing)
     if vec_info === nothing
@@ -6556,7 +6556,7 @@ function _emit_apply_iterate_vect!(fb::InstrBuilder, container_arg, container_ty
     elem_type = eltype(container_type)
     arr_type_idx = get(ctx.type_registry.arrays, elem_type, nothing)
     size_info = get(ctx.type_registry.structs, Tuple{Int64}, nothing)
-    bld = InstrBuilder(; func_name="_emit_apply_iterate_vect!", mod=ctx.mod)
+    bld = _ctx_builder(ctx, "_emit_apply_iterate_vect!")
     if vec_info === nothing || arr_type_idx === nothing || size_info === nothing
         record_unsupported!(ctx, :unsupported_method, "apply-iterate reduce: vector layout unavailable")
         unreachable!(bld); append_builder!(fb, bld)

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -110,10 +110,17 @@ march17: a fragment that consumes the parent's top `n` stack values DECLARES the
 (seeded from fb's TRACKED stack; append_builder! settles the contract exactly).
 """
 function _sub_builder(fb::InstrBuilder, ctx::AbstractCompilationContext, name::String, n::Int;
-                      narrow_to::Union{Nothing, WasmValType}=nothing)
+                      narrow_to::Union{Nothing, WasmValType}=nothing,
+                      seed_types::Union{Nothing, Vector{WasmValType}}=nothing)
     local b = InstrBuilder(; func_name=name, mod=ctx.mod)
     _seed_builder_locals!(b, ctx)   # fullstrict: the live provider everywhere
     local h = length(fb.v.stack)
+    # fullstrict: when the parent's tracking is short, the caller's DECLARED types
+    # are the contract (the parent's shortfall surfaces at ITS merge, attributed there)
+    if n > 0 && h < n && seed_types !== nothing && length(seed_types) == n
+        seed_input!(b, copy(seed_types))
+        return b
+    end
     if n > 0 && h >= n
         local seeds = WasmValType[fb.v.stack[h - n + i] for i in 1:n]
         seed_input!(b, seeds)

--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -109,10 +109,40 @@ end
 march17: a fragment that consumes the parent's top `n` stack values DECLARES them
 (seeded from fb's TRACKED stack; append_builder! settles the contract exactly).
 """
-function _sub_builder(fb::InstrBuilder, ctx::AbstractCompilationContext, name::String, n::Int)
+function _sub_builder(fb::InstrBuilder, ctx::AbstractCompilationContext, name::String, n::Int;
+                      narrow_to::Union{Nothing, WasmValType}=nothing)
     local b = InstrBuilder(; func_name=name, mod=ctx.mod)
+    _seed_builder_locals!(b, ctx)   # fullstrict: the live provider everywhere
     local h = length(fb.v.stack)
-    n > 0 && h >= n && seed_input!(b, WasmValType[fb.v.stack[h - n + i] for i in 1:n])
+    if n > 0 && h >= n
+        local seeds = WasmValType[fb.v.stack[h - n + i] for i in 1:n]
+        seed_input!(b, seeds)
+        # fullstrict: a helper that declares its operand WIDTH narrows erased seeds
+        # AT ENTRY through the funnel (the erased-operand mismatches in the div/shift/
+        # flipsign guards). Deeper-than-top seeds shuffle through a scratch.
+        if narrow_to !== nothing
+            for k in n:-1:1
+                local st = seeds[k]
+                if _wt_is_ref(st)
+                    if k == n
+                        convert_type!(b, st, narrow_to, ctx)
+                    else
+                        # rotate: store the above values, convert, restore
+                        local _tmp = UInt32[]
+                        for _ in (k+1):n
+                            local t2 = UInt32(allocate_local!(ctx, narrow_to))
+                            local_set!(b, t2); pushfirst!(_tmp, t2)
+                        end
+                        convert_type!(b, st, narrow_to, ctx)
+                        for t2 in _tmp
+                            local_get!(b, t2)
+                        end
+                    end
+                    seeds[k] = narrow_to
+                end
+            end
+        end
+    end
     return b
 end
 
@@ -182,7 +212,7 @@ function _emit_div_guard!(fb::InstrBuilder, ctx::AbstractCompilationContext, is3
     weq    = is32 ? Opcode.I32_EQ : Opcode.I64_EQ
     la = UInt32(allocate_local!(ctx, lt))
     lb = UInt32(allocate_local!(ctx, lt))
-    bld = _sub_builder(fb, ctx, "_emit_div_guard!", 2)
+    bld = _sub_builder(fb, ctx, "_emit_div_guard!", 2; narrow_to=(is32 ? I32 : I64))
     local_set!(bld, lb)  # [a]
     local_set!(bld, la)  # []
     # b == 0 → throw DivideError
@@ -252,7 +282,7 @@ function _emit_shift_guarded!(fb::InstrBuilder, ctx::AbstractCompilationContext,
     shop   = kind === :shl  ? (is32 ? Opcode.I32_SHL : Opcode.I64_SHL) :
              kind === :lshr ? (is32 ? Opcode.I32_SHR_U : Opcode.I64_SHR_U) :
                               (is32 ? Opcode.I32_SHR_S : Opcode.I64_SHR_S)
-    bld = _sub_builder(fb, ctx, "_emit_shift_guarded!", 2)
+    bld = _sub_builder(fb, ctx, "_emit_shift_guarded!", 2; narrow_to=(is32 ? I32 : I64))
     _lset(op, i) = op === Opcode.LOCAL_SET ? local_set!(bld, i) :
                    op === Opcode.LOCAL_TEE ? local_tee!(bld, i) : local_get!(bld, i)
     _wc(v) = is32 ? i32_const!(bld, Int64(v)) : i64_const!(bld, Int64(v))
@@ -679,7 +709,7 @@ function _compile_call_flipsign(args, fb::InstrBuilder, ctx::AbstractCompilation
     # Formula: (x xor signbit) - signbit where signbit = y >> 63 (all 1s if negative)
     # We need both x and y on stack, but they've been pushed as: [x, y]
 
-    bld = _sub_builder(fb, ctx, "_compile_call_flipsign", 2)
+    bld = _sub_builder(fb, ctx, "_compile_call_flipsign", 2; narrow_to=(is_32bit ? I32 : I64))
     if is_128bit
         # For 128-bit, check if y's hi word is negative
         # flipsign_int(x, y) = y < 0 ? -x : x

--- a/src/codegen/closures.jl
+++ b/src/codegen/closures.jl
@@ -37,7 +37,11 @@ function ensure_closure_vtable!(mod::WasmModule, registry::TypeRegistry,
     # ── the trampoline: the UNIFORM DYNAMIC SIGNATURE (anyref^(1+arity)) → anyref
     # (dart's dynamic-call entries: args arrive boxed/erased; the trampoline
     # unboxes/casts per the body's REAL signature and re-boxes the result).
-    tb = InstrBuilder(; func_name="closure_trampoline", mod=mod)
+    # fullstrict: the trampoline builder declares its params + scratch local so the
+    # tracker reads truth (params anyref^(1+arity) → anyref; scratch = the body width)
+    tb = InstrBuilder(WasmValType[AnyRef for _ in 0:arity],
+                      isempty(body_results) ? WasmValType[] : WasmValType[AnyRef];
+                      func_name="closure_trampoline", mod=mod)
     local_get!(tb, UInt32(0))
     ref_cast!(tb, Int64(base_idx), false)
     struct_get!(tb, base_idx, UInt32(1), AnyRef)               # .context
@@ -57,6 +61,7 @@ function ensure_closure_vtable!(mod::WasmModule, registry::TypeRegistry,
         local rw = body_results[1]
         local box_idx = get_numeric_box_type!(mod, registry, rw)
         local scratch = UInt32(1 + arity)
+        builder_set_local_type!(tb, Int(scratch), rw)   # fullstrict: the scratch's truth
         local_set!(tb, scratch)
         i32_const!(tb, Int64(0))          # width-default classId (un-migrated callers discriminate by width)
         local_get!(tb, scratch)
@@ -128,9 +133,19 @@ function _closure_body_for(ctx, closure_type::Type)
         # PRECISE match only: the type-keyed registration (the arg_types[1]
         # heuristic once matched throw_boundserror taking the closure as arg 1)
         info.func_ref === closure_type || continue
-        # derive the wasm signature from the REGISTRATION (Julia types) — at wrap
-        # time the body may not be pushed into mod.functions yet (indices are
-        # assigned before bodies compile)
+        # fullstrict: the PLACEHOLDER (pre-declared signatures) is THE truth — the
+        # same source the call! deriver enforces; the julia re-derivation could
+        # disagree (the trampoline then mismatched at its own call).
+        local _m = ctx.mod
+        local _ni = count(imp -> imp.kind == 0x00, _m.imports)
+        local _fi = Int(info.wasm_idx) - _ni
+        if _fi >= 0 && _fi < length(_m.functions)
+            local _ft = _m.types[Int(_m.functions[_fi + 1].type_idx) + 1]
+            if _ft isa FuncType
+                return (info.wasm_idx, WasmValType[q for q in _ft.params], WasmValType[r for r in _ft.results])
+            end
+        end
+        # fallback: the julia derivation (bare registries)
         local ps = WasmValType[]
         for T in info.arg_types
             push!(ps, get_concrete_wasm_type(T, ctx.mod, ctx.type_registry))

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -1686,15 +1686,39 @@ function compile_module(functions::Vector;
         end
     end
 
+    # fullstrict PRE-DECLARED SIGNATURES: the one derivation both the placeholder
+    # (registration) and the body fill use — the builder's call! deriver then reads
+    # TRUTH for every function from the moment indices exist (the 19 empty-sig call
+    # sites + all cross-calls stop guessing; declare-then-define, like an assembler).
+    _fn_signature = function(arg_types, return_type, global_args)
+        local pts = WasmValType[]
+        for (j, T) in enumerate(arg_types)
+            if !(j in global_args)
+                if T isa Union && needs_anyref_boxing(T)
+                    push!(pts, AnyRef)
+                else
+                    push!(pts, get_concrete_wasm_type(T, mod, type_registry))
+                end
+            end
+        end
+        local rts = (return_type === Nothing || return_type === Union{}) ? WasmValType[] :
+                    WasmValType[get_concrete_wasm_type(return_type, mod, type_registry)]
+        return (pts, rts)
+    end
+
     n_existing = length(mod.functions)  # PURE-9065: includes pre-created helper functions
     # T1.1 step 2: discovery-added dynamic-dispatch candidates (beyond the base
     # collection) register as is_candidate=true → visible to the call-site typeId
     # switch (by_ref) but invisible to get_function cross-call resolution.
     _disp_cands = _TRIM_ISOLATED_FUNCS[]
-    for (i, (f, arg_types, name, _, return_type, _, _)) in enumerate(function_data)
+    for (i, (f, arg_types, name, _, return_type, global_args, _)) in enumerate(function_data)
         func_idx = UInt32(n_imports + n_existing + i - 1)
         register_function!(func_registry, name, f, arg_types, func_idx, return_type;
                            is_candidate = (!isempty(_disp_cands) && (f, arg_types) in _disp_cands))
+        # fullstrict: the PLACEHOLDER carries the true signature from birth
+        local _pp, _rr = _fn_signature(arg_types, return_type, global_args)
+        local _ft_idx = add_type!(mod, FuncType(WasmValType[p for p in _pp], WasmValType[r for r in _rr]))
+        push!(mod.functions, WasmFunction(UInt32(_ft_idx), WasmValType[], UInt8[Opcode.UNREACHABLE, Opcode.END]))
     end
 
     # PURE-9060: Build dispatch tables for megamorphic functions (>8 specializations)
@@ -1805,22 +1829,12 @@ function compile_module(functions::Vector;
             end
         end
 
-        # Get param/result types (skip WasmGlobal args)
-        param_types = WasmValType[]
-        for (j, T) in enumerate(arg_types)
-            if !(j in global_args)
-                # PURE-9030: Union params with mixed int/float need anyref for runtime dispatch
-                if T isa Union && needs_anyref_boxing(T)
-                    push!(param_types, AnyRef)
-                else
-                    push!(param_types, get_concrete_wasm_type(T, mod, type_registry))
-                end
-            end
-        end
-        result_types = (return_type === Nothing || return_type === Union{}) ? WasmValType[] : WasmValType[get_concrete_wasm_type(return_type, mod, type_registry)]
-
-        # Add function to module
-        actual_idx = add_function!(mod, param_types, result_types, locals, body)
+        # fullstrict: FILL the pre-declared placeholder (same signature derivation)
+        param_types, result_types = _fn_signature(arg_types, return_type, global_args)
+        local _slot = Int(func_idx) - n_imports + 1
+        local _ft_idx2 = add_type!(mod, FuncType(WasmValType[p for p in param_types], WasmValType[r for r in result_types]))
+        mod.functions[_slot] = WasmFunction(UInt32(_ft_idx2), WasmValType[l for l in locals], body)
+        actual_idx = func_idx
         _this_isolated && push!(isolated_indices, actual_idx)
 
         # Export the function with a unique name

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -1664,28 +1664,6 @@ function compile_module(functions::Vector;
     # Calculate function indices (accounting for imports + pre-created helper functions)
     # Functions are added in order, so index = n_imports + n_existing + position - 1
     n_imports = length(mod.imports)
-    # march16: THE CLOSURE VTABLE PRE-PASS (the index-freeze rule: nothing
-    # may add functions during body compilation). Trampolines + vtable globals for
-    # every type-keyed userland closure are created NOW; their bodies' FINAL indices
-    # are computable deterministically (bodies start after the K trampolines).
-    local _cvp = Tuple{Int, DataType}[]   # (function_data position, closure type)
-    for (i, (f, _, _, _, _, _, _)) in enumerate(function_data)
-        f isa DataType && is_closure_type(f) && push!(_cvp, (i, f))
-    end
-    if !isempty(_cvp)
-        local _n_now = length(mod.functions)
-        local _K = length(_cvp)   # trampolines to pre-create (one per closure body)
-        for (_slot, (_i, _T)) in enumerate(_cvp)
-            local _entry = function_data[_i]
-            local _ats, _rt = _entry[2], _entry[5]
-            local _body_idx = UInt32(n_imports + _n_now + _K + _i - 1)
-            local _bps = WasmValType[get_concrete_wasm_type(T2, mod, type_registry) for T2 in _ats]
-            local _brs = (_rt === Nothing || _rt === Union{}) ? WasmValType[] :
-                         WasmValType[get_concrete_wasm_type(_rt, mod, type_registry)]
-            ensure_closure_vtable!(mod, type_registry, _T, _body_idx, _bps, _brs)
-        end
-    end
-
     # fullstrict PRE-DECLARED SIGNATURES: the one derivation both the placeholder
     # (registration) and the body fill use — the builder's call! deriver then reads
     # TRUTH for every function from the moment indices exist (the 19 empty-sig call
@@ -1720,6 +1698,30 @@ function compile_module(functions::Vector;
         local _ft_idx = add_type!(mod, FuncType(WasmValType[p for p in _pp], WasmValType[r for r in _rr]))
         push!(mod.functions, WasmFunction(UInt32(_ft_idx), WasmValType[], UInt8[Opcode.UNREACHABLE, Opcode.END]))
     end
+
+    # march16: THE CLOSURE VTABLE PRE-PASS (the index-freeze rule: nothing
+    # may add functions during body compilation). Trampolines + vtable globals for
+    # every type-keyed userland closure are created NOW; their bodies' FINAL indices
+    # are computable deterministically (bodies start after the K trampolines).
+    local _cvp = Tuple{Int, DataType}[]   # (function_data position, closure type)
+    for (i, (f, _, _, _, _, _, _)) in enumerate(function_data)
+        f isa DataType && is_closure_type(f) && push!(_cvp, (i, f))
+    end
+    if !isempty(_cvp)
+        for (_slot, (_i, _T)) in enumerate(_cvp)
+            local _entry = function_data[_i]
+            local _ats, _rt = _entry[2], _entry[5]
+            # fullstrict reorder: the placeholders occupy the body indices ALREADY —
+            # the standard formula reads them; trampolines append after.
+            local _body_idx = UInt32(n_imports + n_existing + _i - 1)
+            local _bps = WasmValType[get_concrete_wasm_type(T2, mod, type_registry) for T2 in _ats]
+            local _brs = (_rt === Nothing || _rt === Union{}) ? WasmValType[] :
+                         WasmValType[get_concrete_wasm_type(_rt, mod, type_registry)]
+            ensure_closure_vtable!(mod, type_registry, _T, _body_idx, _bps, _brs)
+        end
+    end
+
+
 
     # PURE-9060: Build dispatch tables for megamorphic functions (>8 specializations)
     # Phase 1: metadata (signatures, globals, tables) — needed by emit_dispatch_call! during body compilation

--- a/src/codegen/context.jl
+++ b/src/codegen/context.jl
@@ -2228,7 +2228,7 @@ function _ref_cast_source_type(val, ctx::AbstractCompilationContext)
 end
 
 function emit_ref_cast_if_structref!(bytes::Vector{UInt8}, val, target_type_idx::Integer, ctx::AbstractCompilationContext)
-    b = InstrBuilder(; func_name="emit_ref_cast_if_structref!", mod=ctx.mod)
+    b = _ctx_builder(ctx, "emit_ref_cast_if_structref!")
     seed_input!(b, WasmValType[AnyRef])  # consumes the ref the caller left on the stack
     _emit_ref_cast_arm!(b, _ref_cast_source_type(val, ctx), target_type_idx)
     append!(bytes, builder_code(b))

--- a/src/codegen/dispatch.jl
+++ b/src/codegen/dispatch.jl
@@ -238,7 +238,9 @@ function emit_dispatch_wrappers!(mod::WasmModule,
 
         wrapper_indices = UInt32[]
         for (entry_i, entry) in enumerate(dt.entries)
-            b = InstrBuilder(; func_name="emit_dispatch_wrappers!", mod=mod)
+            local _wr_res = dt.result_wasm_type in (I32, I64, F32, F64, AnyRef) ?
+                            WasmValType[dt.result_wasm_type] : WasmValType[]
+            b = InstrBuilder(copy(dt.slot_types), _wr_res; func_name="emit_dispatch_wrappers!", mod=mod)
 
             # For each parameter: local.get + unbox/cast to concrete type
             for (j, tid) in enumerate(entry.type_ids)

--- a/src/codegen/flow.jl
+++ b/src/codegen/flow.jl
@@ -3,7 +3,7 @@ Generate code using Wasm's structured control flow.
 For simple if-then-else patterns, we use the `if` instruction.
 """
 function generate_structured(ctx::AbstractCompilationContext, blocks::Vector{BasicBlock})::Vector{UInt8}
-    b = InstrBuilder(; func_name="generate_structured", mod=ctx.mod)
+    b = _ctx_builder(ctx, "generate_structured")
     code = ctx.code_info.code
     # parity(M1) ONE LOWERING (dart: one CodeGenerator, one structured lowering, no strategy
     # choice): try/catch keeps its EH driver; a single block is plain statement emission;
@@ -268,7 +268,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function emit_phi_local_set!(bytes::Vector{UInt8}, val, phi_ssa_idx::Int, ctx::AbstractCompilationContext)::Bool
-    lb = InstrBuilder(; func_name="emit_phi_local_set!", mod=ctx.mod)
+    lb = _ctx_builder(ctx, "emit_phi_local_set!")
     r = emit_phi_local_set!(lb, val, phi_ssa_idx, ctx)
     append!(bytes, builder_code(lb))
     return r

--- a/src/codegen/invoke.jl
+++ b/src/codegen/invoke.jl
@@ -1396,7 +1396,7 @@ _compile_invoke_print(name::Symbol, args, ctx::AbstractCompilationContext)::Vect
 function _compile_invoke_print_b(name::Symbol, args, ctx::AbstractCompilationContext)::InstrBuilder
     io = get_io_imports()
     if io !== nothing
-        b = InstrBuilder(; func_name="_compile_invoke_print", mod=ctx.mod)
+        b = _ctx_builder(ctx, "_compile_invoke_print")
         # parity(M9): the io bridge consumes the DATA array — every string value
         # funnels through the expected-type channel so classed strings unwrap here.
         _pr_str_arr = ConcreteRef(get_string_array_type!(ctx.mod, ctx.type_registry), true)
@@ -1635,7 +1635,7 @@ function _compile_invoke_print_b(name::Symbol, args, ctx::AbstractCompilationCon
         return b
     else
         # No IO imports — stub as no-op (empty builder)
-        return InstrBuilder(; func_name="_compile_invoke_print", mod=ctx.mod)
+        return _ctx_builder(ctx, "_compile_invoke_print")
     end
 end
 
@@ -1646,7 +1646,7 @@ The interior accumulates into a FRAGMENT builder `fb` (≡ the old `bytes` buffe
 same discard semantics: arms that replace it re-init; exits merge typed).
 """
 function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompilationContext)
-    fb = InstrBuilder(; func_name="compile_invoke.frag", mod=ctx.mod)
+    fb = _ctx_builder(ctx, "compile_invoke.frag")
     _seed_builder_locals!(fb, ctx)
 
     # Early skip check — before compiling arguments.
@@ -1660,7 +1660,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
     # Used by Therapy.jl to wire js() calls as WASM imports (Leptos pattern).
     if haskey(ctx.invoke_imports, idx)
         import_idx = ctx.invoke_imports[idx]
-        bii = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+        bii = _ctx_builder(ctx, "compile_invoke")
         call!(bii, import_idx, WasmValType[], WasmValType[])
         return append_builder!(b, bii)
     end
@@ -1676,14 +1676,14 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
         # Signal getter: no args, returns the signal value
         if haskey(ctx.signal_ssa_getters, ssa_id) && isempty(args)
             global_idx = ctx.signal_ssa_getters[ssa_id]
-            bsg = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+            bsg = _ctx_builder(ctx, "compile_invoke")
             global_get!(bsg, global_idx, AnyRef)
             return append_builder!(b, bsg)
         end
         # Signal setter: one arg, sets the signal value
         if haskey(ctx.signal_ssa_setters, ssa_id) && length(args) == 1
             global_idx = ctx.signal_ssa_setters[ssa_id]
-            bss2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+            bss2 = _ctx_builder(ctx, "compile_invoke")
             # Compile the argument (the new value)
             emit_value!(bss2, args[1], ctx, ctx.mod.globals[Int(global_idx) + 1].valtype)   # step4
             # Store to global
@@ -1924,7 +1924,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
 
             # _searchindex(String, String, Int64) → str_find (returns I32, widen to I64)
             if _name_early === :_searchindex && length(args) == 3
-                bsi = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bsi = _ctx_builder(ctx, "compile_invoke")
                 append_builder!(bsi, _compile_invoke_str_find_b([args[1], args[2]], ctx))
                 num!(bsi, Opcode.I64_EXTEND_I32_S)
                 return append_builder!(b, bsi)
@@ -1937,7 +1937,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                ctx.func_registry !== nothing
                 _dec_info = get_function(ctx.func_registry, Base.dec, (UInt64, Int64, Bool))
                 if _dec_info !== nothing
-                    bd = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bd = _ctx_builder(ctx, "compile_invoke")
                     _x = args[4]  # the integer value
 
                     # Push abs(x) as I64 (same bits as UInt64): select(x, -x, x >= 0)
@@ -1991,7 +1991,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # byte-filled array.new (same single-byte assumption as str_lpad).
                 local _rep_at = try infer_value_type(args[1], ctx) catch; nothing end
                 if _rep_at === Char
-                    br = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    br = _ctx_builder(ctx, "compile_invoke")
                     str_t = get_string_array_type!(ctx.mod, ctx.type_registry)
                     emit_value!(br, args[1], ctx)  # char i32 (left-packed)
                     i32_const!(br, 24)
@@ -2054,7 +2054,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             param_type = param_types[arg_idx]
             wasm_type = julia_to_wasm_type_concrete(param_type, ctx)
             # Emit the appropriate null/zero value based on the wasm type
-            _nb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+            _nb = _ctx_builder(ctx, "compile_invoke")
             if wasm_type isa ConcreteRef
                 ref_null!(_nb, Int64(wasm_type.type_idx), ConcreteRef(UInt32(wasm_type.type_idx), true))
             elseif wasm_type === ExternRef
@@ -2079,7 +2079,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
         elseif is_nothing_arg
             # Nothing arg without param_types — emit ref.null anyref as safe default
             # PURE-9022: Use anyref (not externref) for internal polymorphic positions
-            _nb2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+            _nb2 = _ctx_builder(ctx, "compile_invoke")
             ref_null!(_nb2, AnyRef)
             append_builder!(fb, _nb2)
         else
@@ -2097,7 +2097,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                     local _sp_pt = param_types[arg_idx]
                     local _sp_w = get_concrete_wasm_type(_sp_pt isa Type ? _sp_pt : _sp_jt,
                                                          ctx.mod, ctx.type_registry)
-                    local _spb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    local _spb = _ctx_builder(ctx, "compile_invoke")
                     if _sp_w isa ConcreteRef
                         ref_null!(_spb, Int64(_sp_w.type_idx), ConcreteRef(UInt32(_sp_w.type_idx), true))
                         append_builder!(fb, _spb)
@@ -2171,14 +2171,14 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                     if _ab_is_local
                         actual_local_wasm = arg_ty
                         if actual_local_wasm isa ConcreteRef || actual_local_wasm === StructRef || actual_local_wasm === ArrayRef || actual_local_wasm === AnyRef
-                            local _eca = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                            local _eca = _ctx_builder(ctx, "compile_invoke")
                             extern_convert_any!(_eca)
                             append_builder!(fb, _eca)
                             extern_convert_emitted = true
                         end
                     elseif arg_ty isa ConcreteRef
                         # a concrete GC ref (struct_new & co) — needs conversion
-                        local _eca = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                        local _eca = _ctx_builder(ctx, "compile_invoke")
                         extern_convert_any!(_eca)
                         append_builder!(fb, _eca)
                         extern_convert_emitted = true
@@ -2362,7 +2362,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                                 last_arg = args[n_args]
 
                                 if last_target_wasm === ExternRef && (last_actual_wasm isa ConcreteRef || last_actual_wasm === StructRef || last_actual_wasm === ArrayRef || last_actual_wasm === AnyRef)
-                                    blca = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                                    blca = _ctx_builder(ctx, "compile_invoke")
                                     extern_convert_any!(blca)
                                     append_builder!(fb, blca)
                                 elseif last_target_wasm === ExternRef && last_actual_wasm === ExternRef && last_arg isa Core.SSAValue
@@ -2373,7 +2373,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                                         if local_arr_idx >= 1 && local_arr_idx <= length(ctx.locals)
                                             actual_local_wasm = ctx.locals[local_arr_idx]
                                             if actual_local_wasm isa ConcreteRef || actual_local_wasm === StructRef || actual_local_wasm === ArrayRef || actual_local_wasm === AnyRef
-                                                blca2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                                                blca2 = _ctx_builder(ctx, "compile_invoke")
                                                 extern_convert_any!(blca2)
                                                 append_builder!(fb, blca2)
                                             end
@@ -2427,7 +2427,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                         end
 
                         # Cross-function call - emit call instruction with target index
-                        bcc = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                        bcc = _ctx_builder(ctx, "compile_invoke")
                         call!(bcc, target_info.wasm_idx, WasmValType[], WasmValType[])
                         cross_call_handled = true
                         # PURE-6024: If callee returns Union{} (Bottom), it always throws/traps.
@@ -2492,13 +2492,13 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 _dl === nothing && return
                 local _doff = _dl - ctx.n_params
                 (_doff >= 0 && _doff < length(ctx.locals) && ctx.locals[_doff + 1] === AnyRef) || return
-                local _rbx = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                local _rbx = _ctx_builder(ctx, "compile_invoke")
                 emit_classid_box!(_rbx, ctx, is_32bit ? I32 : I64, nothing)
                 append_builder!(fb, _rbx)
             end
             if is_self_call
                 # Self-recursive call - emit call instruction
-                bsc2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bsc2 = _ctx_builder(ctx, "compile_invoke")
                 call!(bsc2, ctx.func_idx, WasmValType[], WasmValType[])
                 # PURE-908: Bridge return type for self-calls (externref→anyref)
                 if haskey(ctx.ssa_locals, idx)
@@ -2525,7 +2525,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # Already handled above
 
             elseif name === :+ || name === :add_int
-                badd = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                badd = _ctx_builder(ctx, "compile_invoke")
                 num!(badd, is_32bit ? Opcode.I32_ADD : Opcode.I64_ADD)
                 append_builder!(fb, badd)
                 _f3_result_box!()
@@ -2533,13 +2533,13 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 if length(args) == 1
                     # WBUILD-3001: Unary negation -(x) → 0 - x. Prepend the 0 via
                     # fragment composition (the pushfirst! byte surgery is gone).
-                    local _negb = InstrBuilder(; func_name="compile_invoke.frag", mod=ctx.mod)
+                    local _negb = _ctx_builder(ctx, "compile_invoke.frag")
                     _seed_builder_locals!(_negb, ctx)
                     is_32bit ? i32_const!(_negb, 0) : i64_const!(_negb, 0)
                     append_builder!(_negb, fb)
                     fb = _negb
                 end
-                bsub3 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bsub3 = _ctx_builder(ctx, "compile_invoke")
                 num!(bsub3, is_32bit ? Opcode.I32_SUB : Opcode.I64_SUB)
                 append_builder!(fb, bsub3)
                 _f3_result_box!()
@@ -2551,11 +2551,11 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # cross-call (its body bottoms out in Vararg _string) and was
                 # emitting i64.mul on two string refs — the E-003 island's
                 # fn#107 validation failure. Args were pre-pushed: rebuild.
-                bcat = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bcat = _ctx_builder(ctx, "compile_invoke")
                 append_builder!(bcat, compile_string_concat_b(args[1], args[2], ctx))
                 return append_builder!(b, bcat)
             elseif name === :* || name === :mul_int
-                bmul = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bmul = _ctx_builder(ctx, "compile_invoke")
                 num!(bmul, is_32bit ? Opcode.I32_MUL : Opcode.I64_MUL)
                 append_builder!(fb, bmul)
             elseif name === :throw_boundserror || name === :throw || name === :throw_inexacterror ||
@@ -2567,7 +2567,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                    name === :throw_overflowerr_binaryop || name === :throw_overflowerr_negation
                 # PURE-1102: Error throwing functions - emit throw (catchable) instead of unreachable (trap)
                 # Clear the stack first (arguments were pushed but not needed)
-                bt = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Reset - don't need the pushed args
+                bt = _ctx_builder(ctx, "compile_invoke")  # Reset - don't need the pushed args
                 ensure_exception_tag!(ctx.mod)
                 # PURE-9032: Stash a ref.null any as exception (no specific value for these)
                 exn_global = ensure_exception_global!(ctx.mod)
@@ -2602,7 +2602,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                         if arg1_type === Float32
                             # First arg is f32, need to insert promotion before second arg
                             # This is tricky with stack order. For now, just promote both
-                            bpow = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Reset
+                            bpow = _ctx_builder(ctx, "compile_invoke")  # Reset
                             emit_value!(bpow, args[1], ctx, F32)   # step4: the promote follows
                             num!(bpow, Opcode.F64_PROMOTE_F32)  # f64.promote_f32 (0xBB)
                             emit_value!(bpow, args[2], ctx)
@@ -2611,7 +2611,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                             end
                             fb = bpow   # discard-and-replace (march4)
                         end
-                        bpow2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                        bpow2 = _ctx_builder(ctx, "compile_invoke")
                         call!(bpow2, pow_import_idx, WasmValType[], WasmValType[])
                         # Convert back to f32 if needed
                         if arg1_type === Float32
@@ -2640,7 +2640,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # Vector length is handled in calls.jl via struct_get on size field
                 # Other AbstractVector subtypes (StepRange, SubArray, ReinterpretArray)
                 # must go through cross-function call to their specific length() method
-                blen = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                blen = _ctx_builder(ctx, "compile_invoke")
                 if arg_type === Any || arg_type === Union{}
                     any_convert_extern!(blen)        # externref → anyref
                     ref_cast!(blen, ArrayRef, true)  # anyref → (ref null array)
@@ -2678,7 +2678,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 str_type_idx = get_string_array_type!(ctx.mod, ctx.type_registry)
                 arg_type = infer_value_type(args[1], ctx)
 
-                basc = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                basc = _ctx_builder(ctx, "compile_invoke")
 
                 # If the argument is a CodeUnits struct, extract the String field.
                 if arg_type !== String && arg_type !== Symbol
@@ -2765,7 +2765,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
 
                 # Compile string arg (already pushed by args loop)
                 # Compile index arg and convert to 0-based
-                bchr = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bchr = _ctx_builder(ctx, "compile_invoke")
                 idx_type = infer_value_type(args[2], ctx)
                 # parity(M9): the pre-pushed string is the CLASSED struct sitting UNDER
                 # the index — save idx, read .data, reload idx.
@@ -2800,7 +2800,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # So we need: compile string, compile index-1, compile char
 
                 # Clear the bytes from the args loop - we'll recompile in correct order
-                bsc = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bsc = _ctx_builder(ctx, "compile_invoke")
 
                 # Compile string
                 emit_value!(bsc, args[1], ctx)
@@ -2829,7 +2829,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             elseif name === :str_len && length(args) == 1
                 # Get string length as Int32
                 # Arg already compiled, just emit array.len
-                blen2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                blen2 = _ctx_builder(ctx, "compile_invoke")
                 array_len!(blen2)
                 append_builder!(fb, blen2)
 
@@ -2839,7 +2839,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 str_type_idx = get_string_array_type!(ctx.mod, ctx.type_registry)
 
                 # Length arg already compiled
-                bnew = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bnew = _ctx_builder(ctx, "compile_invoke")
                 len_type = infer_value_type(args[1], ctx)
                 if len_type === Int64 || len_type === Int
                     num!(bnew, Opcode.I32_WRAP_I64)
@@ -2856,7 +2856,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
 
                 # Clear bytes - recompile in correct order for array.copy
                 # array.copy expects: dst, dst_offset, src, src_offset, len
-                bcp = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bcp = _ctx_builder(ctx, "compile_invoke")
 
                 # dst array
                 emit_value!(bcp, args[3], ctx)
@@ -2903,7 +2903,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 result_local, src_local, _, _, _ = ctx.scratch_locals
 
                 # Clear bytes - recompile in correct order
-                bss = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bss = _ctx_builder(ctx, "compile_invoke")
 
                 # Store source string DATA (parity M9: the funnel unwraps the class)
                 emit_value!(bss, args[1], ctx, ConcreteRef(UInt32(str_type_idx), true))
@@ -3016,7 +3016,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 arr_type_idx = get_array_type!(ctx.mod, ctx.type_registry, elem_type)
 
                 # Clear previous arg compilation - we only need length
-                ban = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                ban = _ctx_builder(ctx, "compile_invoke")
 
                 # Compile length arg
                 len_type = infer_value_type(args[2], ctx)
@@ -3038,7 +3038,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 arr_type_idx = get_array_type!(ctx.mod, ctx.type_registry, elem_type)
 
                 # Convert index to 0-based
-                bget = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bget = _ctx_builder(ctx, "compile_invoke")
                 idx_type = infer_value_type(args[2], ctx)
                 if idx_type === Int64 || idx_type === Int
                     num!(bget, Opcode.I32_WRAP_I64)
@@ -3057,7 +3057,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 arr_type_idx = get_array_type!(ctx.mod, ctx.type_registry, elem_type)
 
                 # Recompile in correct order for array.set: arr, index-1, val
-                bas = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bas = _ctx_builder(ctx, "compile_invoke")
                 local _arrset_elem_w = get_concrete_wasm_type(elem_type, ctx.mod, ctx.type_registry)
                 local _arrset_elem_w2 = _arrset_elem_w isa WasmValType ? _arrset_elem_w : AnyRef
 
@@ -3102,7 +3102,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # arr_len(arr) -> Int32
             elseif name === :arr_len && length(args) == 1
                 # Arg already compiled, just emit array.len
-                blen3 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                blen3 = _ctx_builder(ctx, "compile_invoke")
                 array_len!(blen3)
                 append_builder!(fb, blen3)
 
@@ -3114,7 +3114,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                    name === :tan_domain_error || name === :asin_domain_error ||
                    name === :acos_domain_error || name === :log_domain_error ||
                    name === :sqrt_domain_error
-                bdm = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Reset - don't need the pushed args
+                bdm = _ctx_builder(ctx, "compile_invoke")  # Reset - don't need the pushed args
                 ensure_exception_tag!(ctx.mod)
                 # PURE-9032: Stash a ref.null any as exception (no specific value)
                 exn_global = ensure_exception_global!(ctx.mod)
@@ -3143,7 +3143,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                    value_type === Int8 || value_type === UInt8
 
                     # Clear the bytes (args were already pushed)
-                    bis = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bis = _ctx_builder(ctx, "compile_invoke")
 
                     # Check if int_to_string is in the function registry
                     int_to_string_info = nothing
@@ -3197,7 +3197,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # Core.memoryref(memory::Memory{T}) -> MemoryRef{T}
                 # In WasmGC, Memory and MemoryRef are both the array reference
                 # Clear args bytes (already pushed) and re-compile just the memory arg
-                bmr = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bmr = _ctx_builder(ctx, "compile_invoke")
                 emit_value!(bmr, args[1], ctx)
                 return append_builder!(b, bmr)
 
@@ -3211,7 +3211,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                    name === :InexactError || name === :ErrorException || name === :KeyError ||
                    name === :MethodError || name === :AssertionError || name === :AssertionError ||
                    name === :StackOverflowError || name === :OutOfMemoryError || name === :UndefVarError
-                bec = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Clear pre-compiled args (we re-compile below for correct field order)
+                bec = _ctx_builder(ctx, "compile_invoke")  # Clear pre-compiled args (we re-compile below for correct field order)
                 local _ctor_type = nothing
                 if name === :BoundsError; _ctor_type = BoundsError
                 elseif name === :ArgumentError; _ctor_type = ArgumentError
@@ -3302,7 +3302,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # every index is valid. Create struct: {string, offset, ncodeunits}
             # ================================================================
             elseif name === :SubString
-                bsub2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Clear accumulated arg bytes
+                bsub2 = _ctx_builder(ctx, "compile_invoke")  # Clear accumulated arg bytes
                 if length(args) >= 3
                     str_arg = args[1]
                     start_arg = args[2]
@@ -3351,7 +3351,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # character index is valid (no multi-byte encoding).
             # ================================================================
             elseif (name === :_thisind_continued || name === Symbol("#_thisind_continued#_thisind_str##0")) && length(args) >= 2
-                bti = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bti = _ctx_builder(ctx, "compile_invoke")
                 # Closure form: (closure, string, index, len) → return index
                 if length(args) >= 3
                     emit_value!(bti, args[2], ctx)
@@ -3361,7 +3361,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 return append_builder!(b, bti)
 
             elseif (name === :_nextind_continued || name === Symbol("#_nextind_continued#_nextind_str##0")) && length(args) >= 2
-                bni = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bni = _ctx_builder(ctx, "compile_invoke")
                 # nextind(s, i) = i + 1 in WasmGC
                 if length(args) >= 3
                     emit_value!(bni, args[2], ctx)
@@ -3378,7 +3378,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # Allocates one result array of total length, copies each arg in
             # ================================================================
             elseif (name === :string || name === :_string) && length(args) > 1
-                bms = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Clear pre-compiled args
+                bms = _ctx_builder(ctx, "compile_invoke")  # Clear pre-compiled args
 
                 str_type_idx = get_string_array_type!(ctx.mod, ctx.type_registry)
                 str_arr_type = ConcreteRef(str_type_idx, true)
@@ -3463,7 +3463,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                        value_type === Int16 || value_type === UInt16 ||
                        value_type === Int8 || value_type === UInt8
                     # Integer types - redirect to int_to_string
-                    bis1 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bis1 = _ctx_builder(ctx, "compile_invoke")
 
                     int_to_string_info = nothing
                     if ctx.func_registry !== nothing
@@ -3505,7 +3505,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                    name === :throw || name === :rethrow ||
                    name === :_throw_not_readable || name === :_throw_not_writable
                 ensure_exception_tag!(ctx.mod)
-                bthr2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bthr2 = _ctx_builder(ctx, "compile_invoke")
                 if name === :rethrow
                     # PURE-9034: rethrow() preserves the exception in the global —
                     # just re-throw without overwriting. The caught exception is
@@ -3529,7 +3529,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # trim-collected show machinery), push its representation so the
                 # statement wrapper's local.set has a value to consume.
                 if haskey(ctx.ssa_locals, idx)
-                    bpn = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bpn = _ctx_builder(ctx, "compile_invoke")
                     ref_null!(bpn, AnyRef)  # ref.null any (0xD0 0x6E)
                     append_builder!(fb, bpn)
                 end
@@ -3539,7 +3539,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             elseif name === :show
                 io = get_io_imports()
                 if io !== nothing
-                    bsh2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bsh2 = _ctx_builder(ctx, "compile_invoke")
                     for arg in args
                         # Determine argument type
                         arg_type = nothing
@@ -3597,7 +3597,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                     end
                     return append_builder!(b, bsh2)
                 else
-                    fb = InstrBuilder(; func_name="compile_invoke.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
+                    fb = _ctx_builder(ctx, "compile_invoke.frag"); _seed_builder_locals!(fb, ctx)
                 end
 
             # Handle truncate (IOBuffer resize) — no-op in WasmGC
@@ -3613,7 +3613,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # so multi-byte continuation shouldn't be needed. If hit, it means
             # a code path assumes byte-level string access.
             elseif name === :getindex_continued
-                bgic = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bgic = _ctx_builder(ctx, "compile_invoke")
                 record_unsupported!(ctx, :unsupported_method, "string getindex_continued (byte-level multibyte access)"; idx=idx)
                 unreachable!(bgic)
                 append_builder!(fb, bgic)
@@ -3622,7 +3622,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # Handle print_to_string (used in string interpolation / error messages)
             # PURE-9016: Convert each arg to string and concatenate
             elseif name === :print_to_string
-                bpts = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bpts = _ctx_builder(ctx, "compile_invoke")
                 str_type_idx_pt = get_string_array_type!(ctx.mod, ctx.type_registry)
                 str_arr_type_pt = ConcreteRef(str_type_idx_pt, true)
                 n_pt = length(args)
@@ -3723,7 +3723,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # PURE-9032: Create exception struct objects and stash in $current_exn
             # so that :the_exception + isa checks can identify the exception type.
             elseif name === :error
-                berr = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Clear pre-pushed args
+                berr = _ctx_builder(ctx, "compile_invoke")  # Clear pre-pushed args
                 ensure_exception_tag!(ctx.mod)
                 exn_global = ensure_exception_global!(ctx.mod)
                 # error("msg") → create ErrorException struct, stash, throw
@@ -3746,7 +3746,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                    name === :ArgumentError || name === :AssertionError ||
                    name === :KeyError || name === :ErrorException ||
                    name === :BoundsError || name === :MethodError
-                bthr = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Clear pre-pushed args
+                bthr = _ctx_builder(ctx, "compile_invoke")  # Clear pre-pushed args
                 ensure_exception_tag!(ctx.mod)
                 exn_global = ensure_exception_global!(ctx.mod)
                 # Try to create a proper exception struct for known error types
@@ -3790,7 +3790,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # distinct GC object, so aliasing is impossible. Just return src.
             elseif name === :unalias
                 # Discard accumulated argument bytes and re-compile just src (arg 2)
-                bua = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bua = _ctx_builder(ctx, "compile_invoke")
                 src_arg = expr.args[4]  # args: [mi, func_ref, dest, src]
                 emit_value!(bua, src_arg, ctx)
                 return append_builder!(b, bua)
@@ -3808,7 +3808,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # Must be checked BEFORE the "#" closure handler below, since #sizehint!#81
             # starts with "#" and would be incorrectly caught by the _growend! handler.
             elseif name === :sizehint! || name === Symbol("#sizehint!#81")
-                bsh = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bsh = _ctx_builder(ctx, "compile_invoke")
                 # The vector argument: for sizehint! it's args[1], for #sizehint!#81 it's args[4]
                 vec_arg = name === :sizehint! ? (length(args) >= 1 ? args[1] : nothing) :
                           (length(args) >= 4 ? args[4] : nothing)
@@ -3822,13 +3822,13 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
 
             elseif meth.module === Base && startswith(string(name), "#")
                 # Clear any accumulated bytes from argument compilation
-                fb = InstrBuilder(; func_name="compile_invoke.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
+                fb = _ctx_builder(ctx, "compile_invoke.frag"); _seed_builder_locals!(fb, ctx)
 
                 # Drop the closure object from the stack if it's there
                 func_ref = expr.args[2]
                 if func_ref isa Core.SSAValue
                     if !haskey(ctx.ssa_locals, func_ref.id) && !haskey(ctx.phi_locals, func_ref.id)
-                        bgrd = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                        bgrd = _ctx_builder(ctx, "compile_invoke")
                         drop!(bgrd)
                         append_builder!(fb, bgrd)
                     end
@@ -3869,7 +3869,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                     old_cap_local = allocate_local!(ctx, I32)
                     vec_scratch_local = allocate_local!(ctx, ConcreteRef(vec_type_idx, true))
 
-                    bgr = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bgr = _ctx_builder(ctx, "compile_invoke")
 
                     # 1. Get the vector and store in local
                     emit_value!(bgr, vec_arg, ctx)
@@ -3939,7 +3939,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
 
                 else
                     # Fallback: can't determine vector type — emit unreachable
-                    bgrf = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bgrf = _ctx_builder(ctx, "compile_invoke")
                     record_unsupported!(ctx, :unsupported_method, "vector op: element type undeterminable"; idx=idx)
                     unreachable!(bgrf)
                     append_builder!(fb, bgrf)
@@ -3958,7 +3958,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             elseif name === :typeintersect && length(args) >= 2 && args[1] isa Type && args[2] isa Type
                 # Evaluate at compile time — pure function with constant args
                 result_type = typeintersect(args[1], args[2])
-                bti2 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Clear pre-pushed args
+                bti2 = _ctx_builder(ctx, "compile_invoke")  # Clear pre-pushed args
                 global_idx = get_type_constant_global!(ctx.mod, ctx.type_registry, result_type)
                 global_get!(bti2, global_idx, AnyRef)
                 # Convert concrete ref to externref (Type values are externref in general context)
@@ -3968,7 +3968,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # PURE-6024: _tuple_error — error function in tuple convert dead code path.
             # Emit throw (catchable) instead of unreachable (trap).
             elseif name === :_tuple_error
-                bte = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Clear pre-pushed args
+                bte = _ctx_builder(ctx, "compile_invoke")  # Clear pre-pushed args
                 ensure_exception_tag!(ctx.mod)
                 global_get!(bte, ensure_exception_global!(ctx.mod), AnyRef); ref_null!(bte, ExternRef); throw_!(bte, 0; inputs=WasmValType[AnyRef, ExternRef])   # typed (exn, trace) tag
                 ctx.last_stmt_was_stub = true  # PURE-908
@@ -3977,7 +3977,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             # Julia 1.13: hash_bytes(ptr, len, seed, secret) replaces memhash foreigncall
             # Trace ptr back to jl_string_ptr to find original string, then use FNV-1a helper
             elseif name === :hash_bytes
-                bhb = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # Clear pre-pushed args
+                bhb = _ctx_builder(ctx, "compile_invoke")  # Clear pre-pushed args
                 str_arg = nothing
                 # args: [CodeInstance/MI, func_ref, ptr, len, seed, secret]
                 if length(expr.args) >= 3
@@ -4052,7 +4052,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # Extract target type from Type{T}
                 local _ctor_target = mi.specTypes.parameters[1].parameters[1]::DataType
                 # Clear pre-compiled args — we re-emit in correct order with typeId
-                fb = InstrBuilder(; func_name="compile_invoke.frag", mod=ctx.mod); _seed_builder_locals!(fb, ctx)
+                fb = _ctx_builder(ctx, "compile_invoke.frag"); _seed_builder_locals!(fb, ctx)
                 # Register struct type if not already registered
                 if !haskey(ctx.type_registry.structs, _ctor_target)
                     register_struct_type!(ctx.mod, ctx.type_registry, _ctor_target)
@@ -4073,14 +4073,14 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                         end
                     end
                     # struct.new
-                    bscn = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bscn = _ctx_builder(ctx, "compile_invoke")
                     struct_new!(bscn, _ctor_sinfo.wasm_type_idx)   # mod-resolved fields (march3)
                     append_builder!(fb, bscn)
                 else
                     # Registration failed — codegen cannot lay out this struct type.
                     record_unsupported!(ctx, :unsupported_type,
                         "struct constructor for `$(_ctor_target)` (type registration failed)"; idx=idx, detail=expr)
-                    bscnf = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                    bscnf = _ctx_builder(ctx, "compile_invoke")
                     record_unsupported!(ctx, :unsupported_method, "struct type registration failed (cannot lay out)"; idx=idx)
                     unreachable!(bscnf)
                     append_builder!(fb, bscnf)
@@ -4093,7 +4093,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # pins an out-of-range literal). The native behaviour IS a
                 # throw, so emit a catchable tag-0 throw — unreachable would
                 # turn a natively-catchable error into an uncatchable trap.
-                bi32 = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)  # discard pre-pushed args
+                bi32 = _ctx_builder(ctx, "compile_invoke")  # discard pre-pushed args
                 ensure_exception_tag!(ctx.mod)
                 exn_global = ensure_exception_global!(ctx.mod)
                 ref_null!(bi32, AnyRef)        # ref.null any
@@ -4109,7 +4109,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # a stub dead-codes the rest of the block) and let consumers
                 # (_svec_len etc.) fold against the host value via
                 # _try_host_svec.
-                bpad = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bpad = _ctx_builder(ctx, "compile_invoke")
                 ref_null!(bpad, ArrayRef)
                 return append_builder!(b, bpad)
 
@@ -4120,7 +4120,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 # sort paths, and its args arrive as literal types — host-evaluate
                 # and emit the Bool constant (the stub trapped the whole
                 # IEEEFloatOptimization sort path at runtime).
-                bsub = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)   # discard pre-pushed args
+                bsub = _ctx_builder(ctx, "compile_invoke")   # discard pre-pushed args
                 i32_const!(bsub, Base.array_subpadding(args[1], args[2]) ? 1 : 0)
                 return append_builder!(b, bsub)
 
@@ -4133,7 +4133,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 record_unsupported!(ctx, :unsupported_method,
                     "method `$name`" * (mi !== nothing ? " for $(mi.specTypes)" : "");
                     idx=idx, detail=expr)
-                bunk = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+                bunk = _ctx_builder(ctx, "compile_invoke")
                 record_unsupported!(ctx, :unsupported_method, "unknown invoke target (no handler arm)"; idx=idx)
                 unreachable!(bunk)
                 append_builder!(fb, bunk)
@@ -4148,7 +4148,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function compile_invoke(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Vector{UInt8}
-    b = InstrBuilder(; func_name="compile_invoke", mod=ctx.mod)
+    b = _ctx_builder(ctx, "compile_invoke")
     _seed_builder_locals!(b, ctx)
     compile_invoke!(b, expr, idx, ctx)
     return builder_code(b)

--- a/src/codegen/invoke.jl
+++ b/src/codegen/invoke.jl
@@ -2427,7 +2427,22 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                         end
 
                         # Cross-function call - emit call instruction with target index
-                        bcc = _ctx_builder(ctx, "compile_invoke")
+                        # fullstrict: the args sit on the PARENT builder — seed the real
+                        # param count (readable from the pre-declared placeholder).
+                        local _cc_params = begin
+                            local _m = ctx.mod
+                            local _ni = count(imp -> imp.kind == 0x00, _m.imports)
+                            local _fi = Int(target_info.wasm_idx) - _ni
+                            local _ps = WasmValType[]
+                            if _fi >= 0 && _fi < length(_m.functions)
+                                local _ft = _m.types[Int(_m.functions[_fi + 1].type_idx) + 1]
+                                _ft isa FuncType && (_ps = WasmValType[q for q in _ft.params])
+                            end
+                            _ps
+                        end
+                        haskey(ENV, "WT_DBG_CC") && println(stderr, "CC target=", target_info.name, " idx=", target_info.wasm_idx, " params=", _cc_params, " fbh=", length(fb.v.stack))
+                        bcc = _sub_builder(fb, ctx, "compile_invoke", length(_cc_params);
+                                           seed_types=_cc_params)   # the placeholder truth IS the contract
                         call!(bcc, target_info.wasm_idx, WasmValType[], WasmValType[])
                         cross_call_handled = true
                         # PURE-6024: If callee returns Union{} (Bottom), it always throws/traps.
@@ -2498,7 +2513,19 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
             end
             if is_self_call
                 # Self-recursive call - emit call instruction
-                bsc2 = _ctx_builder(ctx, "compile_invoke")
+                # fullstrict: the args live on fb; the OWN placeholder sig is the contract
+                local _sc_params = begin
+                    local _m = ctx.mod
+                    local _ni = count(imp -> imp.kind == 0x00, _m.imports)
+                    local _fi = Int(ctx.func_idx) - _ni
+                    local _ps = WasmValType[]
+                    if _fi >= 0 && _fi < length(_m.functions)
+                        local _ft = _m.types[Int(_m.functions[_fi + 1].type_idx) + 1]
+                        _ft isa FuncType && (_ps = WasmValType[q for q in _ft.params])
+                    end
+                    _ps
+                end
+                bsc2 = _sub_builder(fb, ctx, "compile_invoke", length(_sc_params); seed_types=_sc_params)
                 call!(bsc2, ctx.func_idx, WasmValType[], WasmValType[])
                 # PURE-908: Bridge return type for self-calls (externref→anyref)
                 if haskey(ctx.ssa_locals, idx)

--- a/src/codegen/selector_table.jl
+++ b/src/codegen/selector_table.jl
@@ -170,7 +170,9 @@ function fill_selector_table_elements!(mod::WasmModule, dt_registry)
         # axis2, emitted as tiny uniform-sig functions living in the SAME table.
         for c in get(dt_registry.selector_cascades, func_ref, [])
             arity = Int(dt.arity)
-            tb = InstrBuilder(; func_name="selector_trampoline", mod=mod)
+            local _tr_res = dt.result_wasm_type in (I32, I64, F32, F64, AnyRef) ?
+                            WasmValType[dt.result_wasm_type] : WasmValType[]
+            tb = InstrBuilder(copy(dt.slot_types), _tr_res; func_name="selector_trampoline", mod=mod)
             for j in 1:arity
                 local_get!(tb, UInt32(j - 1))
             end
@@ -222,8 +224,13 @@ function generate_selector_caller_body(dt::DispatchTable, dt_registry,
                                        caller_return_type::Type=Any, mod=nothing, type_registry=nothing)
     axis = dt_registry.selector_axis[dt.func_ref]
     offset = dt_registry.selector_offset[dt.func_ref]
-    b = InstrBuilder(; func_name="selector_caller")
     arity = Int(dt.arity)
+    # fullstrict: the builder carries its TRUE signature (params + the dispatch result)
+    # so the function frame's end validates against the real contract, and mod for
+    # the derived-truth chokepoints.
+    local _sc_res = dt.result_wasm_type in (I32, I64, F32, F64, AnyRef) ?
+                    WasmValType[dt.result_wasm_type] : WasmValType[]
+    b = InstrBuilder(copy(dt.slot_types), _sc_res; func_name="selector_caller", mod=mod)
     # dispatch signature params are AnyRef: push params in order
     for j in 1:arity
         local_get!(b, UInt32(j - 1))

--- a/src/codegen/stackified.jl
+++ b/src/codegen/stackified.jl
@@ -63,7 +63,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function emit_numeric_to_externref!(target_bytes::Vector{UInt8}, val, val_wasm::WasmValType, ctx::AbstractCompilationContext)
-    b = InstrBuilder(; func_name="emit_numeric_to_externref!", mod=ctx.mod)
+    b = _ctx_builder(ctx, "emit_numeric_to_externref!")
     emit_numeric_to_externref!(b, val, val_wasm, ctx)
     append!(target_bytes, builder_code(b))
     return
@@ -93,7 +93,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function emit_numeric_to_anyref!(target_bytes::Vector{UInt8}, val, val_wasm::WasmValType, ctx::AbstractCompilationContext)
-    b = InstrBuilder(; func_name="emit_numeric_to_anyref!", mod=ctx.mod)
+    b = _ctx_builder(ctx, "emit_numeric_to_anyref!")
     emit_numeric_to_anyref!(b, val, val_wasm, ctx)
     append!(target_bytes, builder_code(b))
     return
@@ -603,7 +603,7 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
     function emit_phi_type_default(wasm_type::WasmValType)::Vector{UInt8}
         # MIGRATED to InstrBuilder: pure straight-line value emission (no inspection).
         # strict=false; byte-identical to the prior raw emission.
-        tb = InstrBuilder(; func_name="emit_phi_type_default", mod=ctx.mod)
+        tb = _ctx_builder(ctx, "emit_phi_type_default")
         if wasm_type isa ConcreteRef
             ref_null!(tb, Int64(wasm_type.type_idx), ConcreteRef(UInt32(wasm_type.type_idx), true))
         elseif wasm_type === StructRef
@@ -641,7 +641,7 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
         # pushes; the pv_ty===nothing guess that let an invalid module through WT's
         # own validation is structurally impossible now). `temp_map` substitutes
         # circular-phi temp locals at the plain local.get branches (PURE-1001).
-        pvb = InstrBuilder(; func_name="compile_phi_value", mod=ctx.mod)
+        pvb = _ctx_builder(ctx, "compile_phi_value")
         _seed_builder_locals!(pvb, ctx)
         _cpv_ret() = begin
             if get(ENV, "WT_AUDIT_VALUE_STACK", "") == "1" && length(pvb.v.stack) != 1 && !isempty(pvb.instrs)
@@ -673,7 +673,7 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
                         # Loop C flow/phi dedup: box / cast / UNBOX via the single shared
                         # converter (source = local.get of the SSA local). The unbox arm is
                         # what fixes Any[i]→0 (numeric phi local ← classId-box SSA local).
-                        local _srcb = InstrBuilder(; func_name="phi_edge_src", mod=ctx.mod)
+                        local _srcb = _ctx_builder(ctx, "phi_edge_src")
                         _seed_builder_locals!(_srcb, ctx)
                         local_get!(_srcb, local_idx)
                         if !_emit_phi_edge_convert!(pvb, ctx, phi_local_wasm_type, ssa_local_type, _srcb)
@@ -699,7 +699,7 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
                 src_local_type = ctx.locals[local_idx - ctx.n_params + 1]
                 if phi_local_wasm_type !== nothing && !wasm_types_compatible(phi_local_wasm_type, src_local_type)
                     # Loop C flow/phi dedup: box / cast / UNBOX (phi-to-phi) via the single helper.
-                    local _srcb = InstrBuilder(; func_name="phi_edge_src", mod=ctx.mod)
+                    local _srcb = _ctx_builder(ctx, "phi_edge_src")
                     _seed_builder_locals!(_srcb, ctx)
                     local_get!(_srcb, local_idx)
                     if !_emit_phi_edge_convert!(pvb, ctx, phi_local_wasm_type, src_local_type, _srcb)
@@ -722,7 +722,7 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
                 ssa_julia_type = get(ctx.ssa_types, val.id, Any)
                 ssa_wasm_type = get_concrete_wasm_type(ssa_julia_type, ctx.mod, ctx.type_registry)
                 if phi_local_wasm_type !== nothing && !wasm_types_compatible(phi_local_wasm_type, ssa_wasm_type) && !(phi_local_wasm_type === I64 && ssa_wasm_type === I32)
-                    local _sb = InstrBuilder(; func_name="phi_edge_src", mod=ctx.mod)
+                    local _sb = _ctx_builder(ctx, "phi_edge_src")
                     _seed_builder_locals!(_sb, ctx)
                     emit_value!(_sb, val, ctx)
                     if !_emit_phi_edge_convert!(pvb, ctx, phi_local_wasm_type, ssa_wasm_type, _sb)
@@ -1144,7 +1144,7 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
         # MIGRATED: block_bytes is now a sub-builder `bb`; straight-line emission uses
         # typed methods, recursive sub-results (stmt_bytes/phi_value_bytes) bridge via
         # emit_raw!, and the byte-INSPECTING DROP/box scans stay on those sub-results.
-        bb = InstrBuilder(; func_name="generate_stackified_flow.block", mod=ctx.mod)
+        bb = _ctx_builder(ctx, "generate_stackified_flow.block")
         _seed_builder_locals!(bb, ctx)
         # march17: values legitimately flow BETWEEN basic blocks on the wasm stack —
         # the block fragment declares the incoming stack (the merge settles exactly).

--- a/src/codegen/stackified.jl
+++ b/src/codegen/stackified.jl
@@ -361,10 +361,10 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
     # `b` via emit_raw!. strict=false (collect mode): a full control-flow body's stack
     # effect can't be tracked precisely by the fragment model, so we never gate.
     # Byte-identical to the prior raw emission.
-    # march17: the ONE documented opt-out — the whole-body flow's stack effect spans
-    # fragments and control joins the per-builder model can't see (the merge validators
-    # + the emitted module's wasm-tools pass gate it instead). R-strict counts this.
-    b = InstrBuilder(; func_name="generate_stackified_flow", strict=false, mod=ctx.mod)
+    # fullstrict: the opt-out is DEAD — the whole-body flow tracks exactly (the
+    # fragment contracts + the live locals provider + derived-truth chokepoints
+    # made it possible). ZERO opt-outs anywhere.
+    b = InstrBuilder(; func_name="generate_stackified_flow", mod=ctx.mod)
     _seed_builder_locals!(b, ctx)
 
     # For very complex functions, use a dispatcher-style approach

--- a/src/codegen/statements.jl
+++ b/src/codegen/statements.jl
@@ -543,7 +543,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
         # march4 Phase A: the dispatcher emits into a FRAGMENT (the god-fn VISITORS);
         # stmt_bytes = its serialization — byte-identical while the byte tail migrates
         # to _sf's tracked state cluster-by-cluster (dev/MARCH4_STATEMENT_PLAN.md).
-        local _sf = InstrBuilder(; func_name="compile_statement.frag", mod=ctx.mod)
+        local _sf = _ctx_builder(ctx, "compile_statement.frag")
         set_context!(_sf, first(string(stmt), 80))   # march17: errors name the stmt
         # march17: statements legitimately consume values earlier statements left on
         # the wasm stack (the stackified model) — seed the fragment with the parent's
@@ -889,7 +889,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
                             # emitted a type-safe NULL default, silently dropping the value
                             # (the box-contents reads of the escaping-closure case).
                             append_builder!(b, _sf)
-                            local _nbx = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+                            local _nbx = _ctx_builder(ctx, "compile_statement")
                             seed_input!(_nbx, WasmValType[ssa_wasm_type])
                             convert_type!(_nbx, ssa_wasm_type, local_wasm_type, ctx;
                                           from_julia=(ssa_julia_type isa DataType ? ssa_julia_type : nothing))
@@ -912,7 +912,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
                             else
                                 # Insert: any_convert_extern (externref→anyref) + ref.cast null <type>
                                 needs_ref_cast_local = local_wasm_type
-                                local _aceb = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+                                local _aceb = _ctx_builder(ctx, "compile_statement")
                                 any_convert_extern!(_aceb)
                                 append_builder!(_sf, _aceb); stmt_bytes = builder_code(_sf)
                             end
@@ -1077,7 +1077,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
 
                 # PURE-913: ref → externref conversion (e.g., compilerbarrier returning struct into Any local)
                 if needs_extern_convert_any
-                    local _ecab = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+                    local _ecab = _ctx_builder(ctx, "compile_statement")
                     extern_convert_any!(_ecab)
                     append_builder!(_sf, _ecab); stmt_bytes = builder_code(_sf)
                 end
@@ -1146,7 +1146,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
                         if local_wasm_type !== nothing
                             # Type-safe default + local.set (typed; byte-identical).
                             _emit_default!(b, local_wasm_type)
-                            local _msb = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+                            local _msb = _ctx_builder(ctx, "compile_statement")
                             local_set!(_msb, local_idx)
                             append_builder!(b, _msb)
                         end
@@ -1191,7 +1191,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
                     (ssa_type.name.name === :MemoryRef && length(ssa_type.parameters) >= 1 && ssa_type.parameters[1] === Nothing) ||
                     (ssa_type.name.name === :GenericMemoryRef && length(ssa_type.parameters) >= 2 && ssa_type.parameters[2] === Nothing))
                 if is_nothing_ref
-                    local _drb = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+                    local _drb = _ctx_builder(ctx, "compile_statement")
                     drop!(_drb)  # drop i32_index
                     drop!(_drb)  # drop array_ref
                     append_builder!(b, _drb)
@@ -1205,7 +1205,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
         stmt_type_check = get(ctx.ssa_types, idx, Any)
         if stmt_type_check === Union{} && !isempty(stmt_bytes) &&
            !(!isempty(_sf.instrs) && _sf.instrs[end] isa InstrIR.Unreachable)
-            local _urb = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+            local _urb = _ctx_builder(ctx, "compile_statement")
             unreachable!(_urb)  # structural trap (dart-legit dead path)
             append_builder!(b, _urb)
         end
@@ -1238,11 +1238,11 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
                 if local_type !== nothing && !wasm_types_compatible(local_type, value_wasm_type)
                     # PURE-908: externref↔anyref conversion instead of drop+default
                     if value_wasm_type === ExternRef && local_type === AnyRef
-                        local _cvb = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+                        local _cvb = _ctx_builder(ctx, "compile_statement")
                         any_convert_extern!(_cvb)
                         append_builder!(b, _cvb)
                     elseif value_wasm_type === AnyRef && local_type === ExternRef
-                        local _cvb = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+                        local _cvb = _ctx_builder(ctx, "compile_statement")
                         extern_convert_any!(_cvb)
                         append_builder!(b, _cvb)
                     else
@@ -1276,7 +1276,7 @@ function compile_statement!(b::InstrBuilder, stmt, idx::Int, ctx::AbstractCompil
                                     _cs4_ret = julia_to_wasm_type(_fi.return_type)
                                     # Cross-function return-type fixups, typed; byte-identical
                                     # (0x6B = UInt8(StructRef) → ref.cast null struct).
-                                    local _csb = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+                                    local _csb = _ctx_builder(ctx, "compile_statement")
                                     if local_type isa ConcreteRef
                                         if _cs4_ret === AnyRef || _cs4_ret === StructRef || _cs4_ret === ArrayRef
                                             ref_cast!(_csb, Int64(local_type.type_idx), true)
@@ -1328,7 +1328,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function compile_statement(stmt, idx::Int, ctx::AbstractCompilationContext)::Vector{UInt8}
-    b = InstrBuilder(; func_name="compile_statement", mod=ctx.mod)
+    b = _ctx_builder(ctx, "compile_statement")
     _seed_builder_locals!(b, ctx)
     compile_statement!(b, stmt, idx, ctx)
     return builder_code(b)
@@ -2110,7 +2110,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function compile_new(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Vector{UInt8}
-    b = InstrBuilder(; func_name="compile_new", mod=ctx.mod)
+    b = _ctx_builder(ctx, "compile_new")
     _seed_builder_locals!(b, ctx)
     compile_new!(b, expr, idx, ctx)
     return builder_code(b)
@@ -3092,7 +3092,7 @@ end
 
 """bytes shell for the remaining byte-region callers (dies with them)."""
 function compile_foreigncall(expr::Expr, idx::Int, ctx::AbstractCompilationContext)::Vector{UInt8}
-    b = InstrBuilder(; func_name="compile_foreigncall", mod=ctx.mod)
+    b = _ctx_builder(ctx, "compile_foreigncall")
     _seed_builder_locals!(b, ctx)
     compile_foreigncall!(b, expr, idx, ctx)
     return builder_code(b)

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -913,6 +913,14 @@ function _seed_builder_locals!(b::InstrBuilder, ctx::AbstractCompilationContext)
     for (k, t) in enumerate(ctx.locals)
         builder_set_local_type!(b, ctx.n_params + k - 1, t)
     end
+    # fullstrict: the LIVE provider — locals allocated AFTER this builder's creation
+    # resolve to their true types (the stale-snapshot AnyRef guesses poisoned the
+    # tracker downstream of every mid-emission allocate_local!).
+    b.locals_fn = function(idx::Int)
+        idx < ctx.n_params && return nothing   # params: the static seed rules
+        local off = idx - ctx.n_params + 1
+        (off >= 1 && off <= length(ctx.locals)) ? ctx.locals[off] : nothing
+    end
     return b
 end
 

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -895,6 +895,19 @@ function emit_value!(b::InstrBuilder, val, ctx::AbstractCompilationContext,
 end
 
 """
+    _ctx_builder(ctx, name) -> InstrBuilder
+
+fullstrict: THE codegen builder constructor — mod + seeded params + the LIVE locals
+provider, so the tracker always reads ctx truth (bare builders guessed AnyRef for
+locals allocated after creation — the largest residual mismatch class).
+"""
+function _ctx_builder(ctx::AbstractCompilationContext, name::String)::InstrBuilder
+    local b = InstrBuilder(; func_name=name, mod=ctx.mod)
+    _seed_builder_locals!(b, ctx)
+    return b
+end
+
+"""
     _seed_builder_locals!(b, ctx)
 
 Teach a fresh value-builder the function's REAL local types (params via the same julia→wasm
@@ -929,7 +942,7 @@ function _compile_value_b(val, ctx::AbstractCompilationContext)::InstrBuilder
     # byte-INSPECTING branches (struct/Dict/Vector/Memory constants) keep building
     # local UInt8[] buffers (they LEB-decode + scan recursive results) and splice them
     # into `b` via emit_raw! / RawBytes. Byte-identical to the prior raw emission.
-    b = InstrBuilder(; func_name="compile_value", mod=ctx.mod)
+    b = _ctx_builder(ctx, "compile_value")
     _seed_builder_locals!(b, ctx)
     # Bridge external byte-emitting helpers (their intermediate buffers stay bytes):
     _emit_tid!(T) = emit_type_id!(b, ctx.type_registry, T)

--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -187,8 +187,14 @@ function _wt_heap_kind(t, mod)::Symbol
         # `mod === nothing` only happens for the numeric-only builders (int128 etc.) whose
         # validators never see a ConcreteRef — but guard it anyway so a stray concrete ref
         # degrades to the default struct kind instead of crashing on `length(nothing.types)`.
-        if mod !== nothing && idx + 1 >= 1 && idx + 1 <= length(mod.types) && mod.types[idx + 1] isa ArrayType
-            return :concrete_array
+        if mod !== nothing && idx + 1 >= 1 && idx + 1 <= length(mod.types)
+            local ct = mod.types[idx + 1]
+            ct isa ArrayType && return :concrete_array
+            # fullstrict: a ConcreteRef to a FUNC type lives in the func hierarchy
+            # (the closure vtable's `ref.cast (ref $sig)` on a funcref entry — valid
+            # wasm the validator previously mis-hierarchied).
+            ct isa FuncType && return :func
+            return :concrete_struct
         else
             return :concrete_struct  # default concrete kind (struct; also for out-of-range / no-mod)
         end
@@ -197,6 +203,10 @@ function _wt_heap_kind(t, mod)::Symbol
         return _wt_heap_kind_of_byte(t.heaptype_byte)
     elseif t isa RefType
         return _wt_heap_kind_of_byte(UInt8(t))
+    elseif t isa UInt8
+        # fullstrict: RAW BYTE valtypes (the vtable's funcref fields etc.) resolve
+        # through the same byte table
+        return _wt_heap_kind_of_byte(t)
     else
         return :unknown
     end

--- a/test/parity_ratchet.jl
+++ b/test/parity_ratchet.jl
@@ -162,7 +162,7 @@ const LOCKS = [
     "L7_wasmtools_demoted" => ("no always-on external-validate default may return — validity is the strict builder's job; wasm-tools is opt-in (validate=true / WT_VALIDATE=1) (M4; locked 2026-07-01)",
         () -> count_sites(r"validate::Bool\s*=\s*true")),
     "L6_all_builders_strict" => ("explicit InstrBuilder strict opt-outs beyond THE ONE documented (the whole-body flow builder, whose cross-fragment stack the per-builder model cannot see — merge validators + wasm-tools gate it). march17: the DEFAULT is now genuinely strict (the runtests L-strict lock asserts it + @test_throws); this lock keeps the opt-out set frozen at that single site.",
-        () -> count_sites(r"InstrBuilder\([^)]*strict\s*=\s*false") - 1),
+        () -> count_sites(r"InstrBuilder\([^)]*strict\s*=\s*false")),
     "L5_no_tagged_union" => ("the tagged-union wrapper family is DELETED — needs_tagged_union/emit_(un)wrap_union_value must never reappear (M3; locked 2026-07-01)",
         () -> count_sites(r"needs_tagged_union\(|emit_wrap_union_value\(|emit_unwrap_union_value\(")),
     "L4_no_postemit_reguess" => ("infer_value_wasm_type is GONE — renamed to static_wasm_type (pre-emit-ONLY contract); the post-emission re-guess anti-pattern is dead (M2; locked 2026-07-01)",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1506,14 +1506,29 @@ begin
     # ========================================================================
     @pphase "Phase 1: Test Harness Infrastructure" begin
 
-        @testset "L-strict: THE ENFORCING BUILDER is the DEFAULT (march17 lock)" begin
-            # Dale's directive: an ill-typed emit on a DEFAULT-constructed builder must
-            # THROW at the emitting line (dart wasm_builder semantics). This lock makes
-            # the 07-01 regression (the default silently unwired) impossible to repeat.
+        @testset "L-strict: THE FULL-STRICT BUILDER — forever (the lock)" begin
+            # Dale's bar: valid-by-construction in FULL. EVERY violation throws on a
+            # DEFAULT builder: underflow, TYPE MISMATCH, frame error. Zero opt-outs.
+            # This lock makes any regression — the silent unwiring, a staged carve-out,
+            # a new opt-out — impossible to land.
             WT = WasmTarget
             lb = WT.InstrBuilder(WT.WasmValType[], WT.WasmValType[]; func_name="lock")
             @test lb.strict   # the default IS strict
-            @test_throws WT.StackImbalanceError WT.num!(lb, WT.Opcode.I64_ADD)  # pops 2 from empty
+            @test_throws WT.StackImbalanceError WT.num!(lb, WT.Opcode.I64_ADD)  # UNDERFLOW throws
+            lb2 = WT.InstrBuilder(WT.WasmValType[], WT.WasmValType[]; func_name="lock2")
+            WT.i64_const!(lb2, 1)
+            @test_throws WT.StackImbalanceError WT.num!(lb2, WT.Opcode.I32_EQZ)  # TYPE MISMATCH throws
+            # ZERO opt-outs in the tree (no netting, no exceptions):
+            cgdir = joinpath(dirname(pathof(WasmTarget)), "..")
+            n_optout = 0
+            for (root, _, files) in walkdir(joinpath(cgdir, "src"))
+                for f in files
+                    endswith(f, ".jl") || continue
+                    n_optout += count(l -> occursin(r"InstrBuilder\([^)]*strict\s*=\s*false", l),
+                                      readlines(joinpath(root, f)))
+                end
+            end
+            @test n_optout == 0
         end
 
         @testset "InstrBuilder (typed wasm builder, dart2wasm-style)" begin


### PR DESCRIPTION
**Total enforcement, forever**: every violation throws at the emitting line — underflow, type mismatch, frame error. Zero opt-outs (the flow builder's exemption is deleted). The L-lock asserts default-strict + both throw classes + a zero-opt-out tree count: regression cannot land.

The machinery: derive-the-truth chokepoints (struct/array/global/call read the module, never caller claims), the live locals provider swept across 180 builder creations, entry-narrowing contracts, **pre-declared signatures** (declare-then-define), the hierarchy arms. The burn: **1,267 tracked-type violations → 0**.

wasm-tools is demoted to the CI disagreement alarm only — builder-pass + wasm-tools-fail = P0 builder bug. The development loop never touches it again.
