### PR TITLE
fix: preserve explicit IO calls in closed worlds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Verify interactive docs islands compiled
         run: |
           rg -F 'window.TherapyHydrate["examplelorenz"]' docs/dist/index.html
+          julia --project=. test/verify_lorenz_docs.jl docs/dist/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,10 @@ jobs:
         run: |
           julia --project=docs --optimize=3 docs/app.jl build
 
+      - name: Verify interactive docs islands compiled
+        run: |
+          rg -F 'window.TherapyHydrate["examplelorenz"]' docs/dist/index.html
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 

--- a/dev/parity_baseline.toml
+++ b/dev/parity_baseline.toml
@@ -95,6 +95,7 @@ L92_runtime_predicates_and_bottom_edges_are_exact = 0
 L93_recovered_capture_calls_are_exact_closed_world_edges = 0
 L94_codegen_errors_keep_structured_ledgers = 0
 L95_type_object_specializations_match_runtime_representation = 0
+L96_explicit_io_never_becomes_host_console = 0
 L8_no_silent_traps = 0
 L9_no_unjustified_untyped_emission = 0
 

--- a/src/codegen/compile.jl
+++ b/src/codegen/compile.jl
@@ -558,6 +558,48 @@ function generate_intrinsic_body(f, arg_types::Tuple, mod::WasmModule, type_regi
     return nothing
 end
 
+"""Return whether a typed `print`/`println`/`show` call has an explicit IO receiver.
+
+`print(io, ...)` and `show(io, ...)` are ordinary Julia formatting calls.  They
+must stay in the collected call graph; only receiver-free display calls use the
+host IO bridge.  Confusing the two also used to append imports to a
+framework-supplied module after it already contained local functions, shifting
+every pre-existing function index.
+"""
+function _ir_call_has_explicit_io(stmt::Expr, code_info::Core.CodeInfo)::Bool
+    first_type = Any
+    if stmt.head === :invoke && !isempty(stmt.args) &&
+       stmt.args[1] isa Core.MethodInstance
+        spec = Base.unwrap_unionall(stmt.args[1].specTypes)
+        if spec isa DataType && spec <: Tuple && length(spec.parameters) >= 2
+            first_type = spec.parameters[2]
+        end
+    else
+        first_pos = stmt.head === :invoke ? 3 : 2
+        if length(stmt.args) >= first_pos
+            arg = stmt.args[first_pos]
+            first_type = if arg isa Core.SSAValue &&
+                            code_info.ssavaluetypes isa Vector &&
+                            1 <= arg.id <= length(code_info.ssavaluetypes)
+                code_info.ssavaluetypes[arg.id]
+            elseif arg isa Core.Argument && code_info.slottypes !== nothing &&
+                   1 <= arg.n <= length(code_info.slottypes)
+                code_info.slottypes[arg.n]
+            elseif arg isa QuoteNode
+                typeof(arg.value)
+            else
+                typeof(arg)
+            end
+        end
+    end
+    first_type = try
+        Core.Compiler.widenconst(first_type)
+    catch
+        Any
+    end
+    return first_type isa Type && first_type <: IO
+end
+
 """
     compile_module(functions::Vector) -> WasmModule
 
@@ -698,7 +740,10 @@ function _compile_closed_world_plan(functions::Vector;
             for stmt in ci.code
                 if stmt isa Expr && (stmt.head === :invoke || stmt.head === :call)
                     func_arg = stmt.head === :invoke ? stmt.args[2] : stmt.args[1]
-                    if func_arg isa GlobalRef && (func_arg.name === :println || func_arg.name === :print || func_arg.name === :show)
+                    if func_arg isa GlobalRef &&
+                       (func_arg.name === :println || func_arg.name === :print ||
+                        func_arg.name === :show) &&
+                       !_ir_call_has_explicit_io(stmt, code_info)
                         needs_io = true
                         break
                     end

--- a/src/codegen/invoke.jl
+++ b/src/codegen/invoke.jl
@@ -1,3 +1,16 @@
+# Only receiver-free display calls belong to WT's host-console bridge.  Julia's
+# `print(io, ...)` / `show(io, ...)` methods are formatting machinery and must be
+# resolved and compiled like ordinary calls.
+function _invoke_has_explicit_io(param_types)::Bool
+    (param_types === nothing || isempty(param_types)) && return false
+    first_type = try
+        Core.Compiler.widenconst(first(param_types))
+    catch
+        Any
+    end
+    return first_type isa Type && first_type <: IO
+end
+
 # parity(M9): emit a string-op ARG through the funnel — classed strings adjust to
 # their DATA array (op contract: these positions are strings; no type re-query).
 function _emit_str_arg!(b::InstrBuilder, arg, ctx::AbstractCompilationContext, str_type_idx)
@@ -3138,7 +3151,8 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
                 ctx.last_stmt_was_stub = true  # PURE-908
 
             # PURE-9040: println/print → JS IO bridge imports
-            elseif name === :println || name === :print
+            elseif (name === :println || name === :print) &&
+                   !_invoke_has_explicit_io(param_types)
                 fb = _compile_invoke_print_b(name, args, ctx)
                 # print returns `nothing`; the io imports are void. If this SSA
                 # has a local (the nothing value is USED downstream — common in
@@ -3152,7 +3166,7 @@ function compile_invoke!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCom
 
             # PURE-9041: show(x) → IO bridge imports (like print, no newline)
             # show(42) displays "42", show(true) displays "true", show(nothing) displays "nothing"
-            elseif name === :show
+            elseif name === :show && !_invoke_has_explicit_io(param_types)
                 io = get_io_imports()
                 if io !== nothing
                     bsh2 = _ctx_builder(ctx, "compile_invoke")

--- a/src/codegen/stackified.jl
+++ b/src/codegen/stackified.jl
@@ -429,7 +429,8 @@ function generate_stackified_flow(ctx::AbstractCompilationContext, blocks::Vecto
     for target_idx in ctx.entry_calls
         params, results = _true_call_sig(b, target_idx, WasmValType[], WasmValType[])
         isempty(params) && isempty(results) || throw(ArgumentError(
-            "root entry call $target_idx must have signature () -> ()"))
+            "root entry call $target_idx must have signature () -> (); got " *
+            "$(params) -> $(results) while compiling $(ctx.func_ref)"))
         call!(b, target_idx, WasmValType[], WasmValType[])
     end
 

--- a/test/module_builder_validation.jl
+++ b/test/module_builder_validation.jl
@@ -30,6 +30,8 @@ end
 Base.@noinline _mbv_root_link_leaf(x::Int64) = x + Int64(1)
 _mbv_root_link_caller(x::Int64) = _mbv_root_link_leaf(x)
 _mbv_string_init() = "framework-seed"
+Base.@noinline _mbv_io_receiver_print(io::IOBuffer, c::Char) = print(io, '\\', c)
+Base.@noinline _mbv_host_print(x::Int64) = print(x)
 
 @testset "module builder rejects invalid modules at construction" begin
     @testset "start signature" begin
@@ -149,6 +151,22 @@ _mbv_string_init() = "framework-seed"
     @testset "Binaryen Windows scheduling is bounded" begin
         @test MBV._binaryen_worker_count(true) == "1"
         @test MBV._binaryen_worker_count(false) === nothing
+    end
+
+    @testset "explicit IO formatting does not activate host-console imports" begin
+        function print_invoke(fn, arg_types)
+            ci = only(Base.code_typed(fn, arg_types; optimize=true))[1]
+            site = findfirst(ci.code) do stmt
+                stmt isa Expr && stmt.head === :invoke && length(stmt.args) >= 2 &&
+                    stmt.args[2] isa GlobalRef && stmt.args[2].name === :print
+            end
+            site === nothing && error("explicit-IO fixture lost its print invoke")
+            return ci.code[site], ci
+        end
+        io_stmt, io_ci = print_invoke(_mbv_io_receiver_print, (IOBuffer, Char))
+        host_stmt, host_ci = print_invoke(_mbv_host_print, (Int64,))
+        @test MBV._ir_call_has_explicit_io(io_stmt, io_ci)
+        @test !MBV._ir_call_has_explicit_io(host_stmt, host_ci)
     end
 
     @testset "closure roots use declared global substitutions" begin

--- a/test/parity_ratchet.jl
+++ b/test/parity_ratchet.jl
@@ -535,6 +535,20 @@ const LOCKS = [
                         "(mi.def, canonical_sig) in collected_method_specs"]
             count(p -> !occursin(p, trim_src), required)
         end),
+    "L96_explicit_io_never_becomes_host_console" => ("print(io, ...) and show(io, ...) remain ordinary compiled Julia formatting calls, so host IO imports cannot shift framework-owned function indices",
+        () -> begin
+            compile_src = read(joinpath(CODEGEN, "compile.jl"), String)
+            invoke_src = read(joinpath(CODEGEN, "invoke.jl"), String)
+            docs_ci = read(joinpath(ROOT, ".github", "workflows", "docs.yml"), String)
+            required = ["_ir_call_has_explicit_io(stmt, code_info)",
+                        "_invoke_has_explicit_io(param_types)",
+                        "explicit IO formatting does not activate host-console imports",
+                        "Verify interactive docs islands compiled",
+                        "window.TherapyHydrate[\"examplelorenz\"]"]
+            count(p -> !occursin(p,
+                compile_src * invoke_src * read(joinpath(ROOT, "test", "module_builder_validation.jl"), String) * docs_ci),
+                required)
+        end),
     "L92_runtime_predicates_and_bottom_edges_are_exact" => ("Julia 1.13 UnionAll predicates use the canonical nominal hierarchy and bottom phi producers preserve their real terminator without inventing a runtime type",
         () -> begin
             context_src = read(joinpath(CODEGEN, "context.jl"), String)

--- a/test/verify_lorenz_docs.jl
+++ b/test/verify_lorenz_docs.jl
@@ -1,0 +1,35 @@
+using Test
+using Binaryen_jll
+
+html_path = only(ARGS)
+html = read(html_path, String)
+
+@testset "Lorenz docs island calls Canvas2D imports" begin
+    @test occursin("window.TherapyHydrate[\"examplelorenz\"]", html)
+
+    hydrate_at = findfirst("function hydrate_examplelorenz()", html)
+    @test hydrate_at !== nothing
+    array_marker = "var _wb = new Uint8Array(["
+    marker_at = findnext(array_marker, html, first(hydrate_at))
+    @test marker_at !== nothing
+    bytes_at = last(marker_at) + 1
+    array_end = findnext("]);", html, bytes_at)
+    @test array_end !== nothing
+    wasm = UInt8[parse(UInt8, n) for n in
+        split(SubString(html, bytes_at, first(array_end) - 1), ',')]
+
+    mktemp() do wasm_path, wasm_io
+        write(wasm_io, wasm)
+        close(wasm_io)
+        mktemp() do wat_path, wat_io
+            close(wat_io)
+            run(`$(Binaryen_jll.wasmdis_path) $wasm_path -o $wat_path`)
+            wat = read(wat_path, String)
+            @test occursin("(import \"canvas2d\" \"begin_path\"", wat)
+            @test occursin("(call \$canvas2d.begin_path)", wat)
+            # If this export exists, Therapy compiled WasmMakie's Julia-native
+            # no-op stub instead of resolving calls to the browser import.
+            @test !occursin("(export \"canvas_begin_path\"", wat)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- keep `print(io, ...)` and `show(io, ...)` on the ordinary Julia call path
- prevent host-console imports from being appended after framework-owned functions and shifting their indices
- improve root-entry signature diagnostics
- fail the docs workflow if the Lorenz hydration payload is absent

## Evidence

- module-builder validation: 61/61
- parity locks: all green, including L96
- exact Therapy 0.2.2 + WasmMakie 0.1.2 Lorenz build compiles
- paired with GroupTherapyOrg/Therapy.jl canvas-import fix, browser test paints 540,000 pixels and redraws after slider input

The live docs repair should deploy after the paired Therapy fix is released.