### PR TITLE
ci: use portable grep in docs verifier

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Verify interactive docs islands compiled
         run: |
-          rg -F 'window.TherapyHydrate["examplelorenz"]' docs/dist/index.html
+          grep -F 'window.TherapyHydrate["examplelorenz"]' docs/dist/index.html
           julia --project=. test/verify_lorenz_docs.jl docs/dist/index.html
 
       - name: Setup Pages


### PR DESCRIPTION
The guarded docs deployment built successfully but the verifier runner does not include ripgrep, causing exit 127 before the Lorenz assertions ran. Use POSIX grep for the hydration marker; the Julia disassembly verifier remains unchanged.\n\nLocal evidence: hydration marker found and Lorenz verifier passes 7/7.