### PR TITLE
ci: instantiate Lorenz verifier dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,9 @@ jobs:
             Pkg.resolve()
             Pkg.instantiate()
           '
+          # The Lorenz disassembly gate uses Binaryen_jll from the package's
+          # test environment, which is separate from the docs environment.
+          julia --project=. -e 'using Pkg; Pkg.instantiate()'
 
       - name: Build docs
         run: |


### PR DESCRIPTION
The guarded docs build reaches the Lorenz verifier, but the workflow only instantiated the separate docs environment. Instantiate the package environment as well so its declared Binaryen_jll test dependency is available.\n\nLocal evidence: root instantiate succeeds and the Lorenz disassembly verifier passes 7/7.