### PR TITLE
fix: discard framework root results without trapping

### DIFF
--- a/src/codegen/values.jl
+++ b/src/codegen/values.jl
@@ -756,6 +756,20 @@ ref.null / extern-box. Else if the value type cannot satisfy the return type →
 `return`. Byte-identical to the inlined blocks it replaces.
 """
 function emit_return_coerced!(b::InstrBuilder, val, ctx::AbstractCompilationContext)
+    # Framework roots may deliberately erase a Julia result (`void_return=true`).
+    # The typed IR still contains `return %value`; evaluate that value for its
+    # side effects, discard its physical result when present, and return void.
+    # Treating Nothing like an ordinary value made a valid setter-returning
+    # handler end in `drop; unreachable`, so its surrounding reactive batch
+    # never reached the flush/presentation boundary.
+    if ctx.return_type === Nothing
+        # The discard is still a typed consumer: route through THE wrap funnel
+        # with the value's static physical representation, then drop it.
+        emit_value!(b, val, ctx, static_wasm_type(val, ctx))
+        drop!(b)
+        return_!(b)
+        return b
+    end
     # parity(M2): THE wrap for returns — emit typed, coerce the ACTUAL type through the ONE
     # convert_type! funnel, return. Deletes the infer_value_wasm_type pre-guess and the
     # numeric→ConcreteRef ref.null VALUE DROP (the funnel boxes value-preservingly; an

--- a/test/module_builder_validation.jl
+++ b/test/module_builder_validation.jl
@@ -29,6 +29,7 @@ function _mbv_constant_closure()
 end
 Base.@noinline _mbv_root_link_leaf(x::Int64) = x + Int64(1)
 _mbv_root_link_caller(x::Int64) = _mbv_root_link_leaf(x)
+_mbv_void_numeric_root(x::Int64) = x + Int64(1)
 _mbv_string_init() = "framework-seed"
 Base.@noinline _mbv_io_receiver_print(io::IOBuffer, c::Char) = print(io, '\\', c)
 Base.@noinline _mbv_host_print(x::Int64) = print(x)
@@ -193,6 +194,15 @@ Base.@noinline _mbv_host_print(x::Int64) = print(x)
         ft = compiled.types[Int(fn.type_idx) + 1]
         @test isempty(ft.params)
         @test isempty(ft.results)
+        void_module = MBV.compile_module(Any[(_mbv_void_numeric_root, (Int64,), "void_numeric")];
+            root_bindings=Dict("void_numeric" => MBV.RootBindings(void_return=true)))
+        mktempdir() do dir
+            wasm = joinpath(dir, "void-root.wasm")
+            write(wasm, MBV.to_bytes(void_module))
+            probe = "WebAssembly.instantiate(require('fs').readFileSync(process.argv[1])).then(m=>m.instance.exports.void_numeric(1n)).catch(e=>{console.error(e);process.exit(1)})"
+            proc = run(ignorestatus(`node -e $probe $wasm`))
+            @test proc.exitcode == 0
+        end
 
         partial = MBV.RootBindings(captured_globals=Dict([first(captured)]),
                                    elide_closure_context=true)


### PR DESCRIPTION
Framework roots declared with `void_return=true` must evaluate and discard typed Julia return values, not reinterpret `Nothing` as an incompatible physical result and trap.

This fixes Therapy event handlers that updated their signal but trapped before reactive flush/frame presentation. The return value now flows through the single typed emission/coercion funnel and is dropped before the void return.

Verification:
- module-builder execution: 62/62
- exact shard 0: 347/347
- parity locks green; untyped emission count improves 30 → 29
- remaining Julia 1.12 shards and all differential fuzz families green
- Therapy WasmMakie browser interaction test green