### PR TITLE
fix: lower fast-math float intrinsics to plain ops

### DIFF
--- a/src/codegen/calls.jl
+++ b/src/codegen/calls.jl
@@ -5234,20 +5234,22 @@ function compile_call!(b::InstrBuilder, expr::Expr, idx::Int, ctx::AbstractCompi
         end
         append_builder!(fb, _bswb)
 
-    # Float operations
-    elseif is_func(func, :add_float)
+    # Float operations. The `_fast` forms are what `@fastmath` emits
+    # (Base.FastMath.add_float_fast etc. alias the Core intrinsics); wasm has
+    # no fast-math flags, so they lower to the same ops as the strict forms.
+    elseif is_func(func, :add_float) || is_func(func, :add_float_fast)
         _op1!(arg_type === Float32 ? Opcode.F32_ADD : Opcode.F64_ADD)
 
-    elseif is_func(func, :sub_float)
+    elseif is_func(func, :sub_float) || is_func(func, :sub_float_fast)
         _op1!(arg_type === Float32 ? Opcode.F32_SUB : Opcode.F64_SUB)
 
-    elseif is_func(func, :mul_float)
+    elseif is_func(func, :mul_float) || is_func(func, :mul_float_fast)
         _op1!(arg_type === Float32 ? Opcode.F32_MUL : Opcode.F64_MUL)
 
-    elseif is_func(func, :div_float)
+    elseif is_func(func, :div_float) || is_func(func, :div_float_fast)
         _op1!(arg_type === Float32 ? Opcode.F32_DIV : Opcode.F64_DIV)
 
-    elseif is_func(func, :neg_float)
+    elseif is_func(func, :neg_float) || is_func(func, :neg_float_fast)
         _op1!(arg_type === Float32 ? Opcode.F32_NEG : Opcode.F64_NEG)
 
     # Fused multiply-add: muladd_float(a, b, c) = a*b + c

--- a/src/codegen/context.jl
+++ b/src/codegen/context.jl
@@ -854,7 +854,7 @@ function analyze_control_flow!(ctx::AbstractCompilationContext)
                     # Check if used as argument to boolean/comparison/arithmetic intrinsics
                     if use_stmt isa Expr && use_stmt.head === :call && length(use_stmt.args) >= 2
                         func = use_stmt.args[1]
-                        if func isa GlobalRef && func.mod in (Core, Base, Core.Intrinsics)
+                        if func isa GlobalRef && func.mod in (Core, Base, Core.Intrinsics, Base.FastMath)
                             fname = func.name
                             is_bool_op = fname in (:not_int, :and_int, :or_int, :xor_int)
                             is_cmp_op = fname in (:eq_int, :ne_int, :slt_int, :sle_int,
@@ -871,7 +871,12 @@ function analyze_control_flow!(ctx::AbstractCompilationContext)
                                                     :trunc_int, :sext_int, :zext_int, :fpext, :fptrunc,
                                                     :ctpop_int, :ctlz_int, :cttz_int, :bswap_int,
                                                     :flipsign_int, :copysign_float,
-                                                    :eq_float, :ne_float, :lt_float, :le_float)
+                                                    :eq_float, :ne_float, :lt_float, :le_float,
+                                                    # `@fastmath` forms (Base.FastMath aliases)
+                                                    :add_float_fast, :sub_float_fast, :mul_float_fast,
+                                                    :div_float_fast, :neg_float_fast, :sqrt_llvm_fast,
+                                                    :min_float_fast, :max_float_fast,
+                                                    :eq_float_fast, :ne_float_fast, :lt_float_fast, :le_float_fast)
                             if is_bool_op || is_cmp_op || is_arith_op
                                 for arg in use_stmt.args[2:end]
                                     if arg === phi_ssa_val
@@ -1542,7 +1547,7 @@ function allocate_ssa_locals!(ctx::AbstractCompilationContext)
                     # Check if used as argument to comparison/boolean intrinsics
                     if use_stmt isa Expr && use_stmt.head === :call && length(use_stmt.args) >= 2
                         func = use_stmt.args[1]
-                        if func isa GlobalRef && func.mod in (Core, Base, Core.Intrinsics)
+                        if func isa GlobalRef && func.mod in (Core, Base, Core.Intrinsics, Base.FastMath)
                             fname = func.name
                             # Boolean ops that take boolean/i32 operands
                             is_bool_op = fname in (:not_int, :and_int, :or_int, :xor_int)
@@ -1562,7 +1567,12 @@ function allocate_ssa_locals!(ctx::AbstractCompilationContext)
                                                     :trunc_int, :sext_int, :zext_int, :fpext, :fptrunc,
                                                     :ctpop_int, :ctlz_int, :cttz_int, :bswap_int,
                                                     :flipsign_int, :copysign_float,
-                                                    :eq_float, :ne_float, :lt_float, :le_float)
+                                                    :eq_float, :ne_float, :lt_float, :le_float,
+                                                    # `@fastmath` forms (Base.FastMath aliases)
+                                                    :add_float_fast, :sub_float_fast, :mul_float_fast,
+                                                    :div_float_fast, :neg_float_fast, :sqrt_llvm_fast,
+                                                    :min_float_fast, :max_float_fast,
+                                                    :eq_float_fast, :ne_float_fast, :lt_float_fast, :le_float_fast)
                             if is_bool_op || is_cmp_op || is_arith_op
                                 for arg in use_stmt.args[2:end]
                                     if arg === ssa_val

--- a/src/codegen/helpers.jl
+++ b/src/codegen/helpers.jl
@@ -51,6 +51,7 @@ function is_comparison(func)::Bool
         name = func.name
         return name in (:slt_int, :sle_int, :ult_int, :ule_int, :eq_int, :ne_int,
                         :lt_float, :le_float, :eq_float, :ne_float,
+                        :lt_float_fast, :le_float_fast, :eq_float_fast, :ne_float_fast,
                         :(===), :(!==))
     end
     return false

--- a/src/codegen/intrinsics_table.jl
+++ b/src/codegen/intrinsics_table.jl
@@ -73,6 +73,18 @@ const INTRINSIC_BINOPS = Dict{Tuple{WasmValType,WasmValType,Symbol},BinOpEmit}(
     (F64, F64, :copysign_float) => BinOpEmit(Opcode.F64_COPYSIGN, F64),
     (F64, F64, :min_float) => BinOpEmit(Opcode.F64_MIN, F64),
     (F64, F64, :max_float) => BinOpEmit(Opcode.F64_MAX, F64),
+    # `@fastmath` variants (Base.FastMath.*_float_fast, aliases of the Core
+    # intrinsics): wasm has no fast-math flags, so they lower to the SAME ops.
+    (F64, F64, :add_float_fast) => BinOpEmit(Opcode.F64_ADD, F64),
+    (F64, F64, :sub_float_fast) => BinOpEmit(Opcode.F64_SUB, F64),
+    (F64, F64, :mul_float_fast) => BinOpEmit(Opcode.F64_MUL, F64),
+    (F64, F64, :div_float_fast) => BinOpEmit(Opcode.F64_DIV, F64),
+    (F64, F64, :eq_float_fast)  => BinOpEmit(Opcode.F64_EQ,  I32),
+    (F64, F64, :ne_float_fast)  => BinOpEmit(Opcode.F64_NE,  I32),
+    (F64, F64, :lt_float_fast)  => BinOpEmit(Opcode.F64_LT,  I32),
+    (F64, F64, :le_float_fast)  => BinOpEmit(Opcode.F64_LE,  I32),
+    (F64, F64, :min_float_fast) => BinOpEmit(Opcode.F64_MIN, F64),
+    (F64, F64, :max_float_fast) => BinOpEmit(Opcode.F64_MAX, F64),
     # ── f32 × f32 ────────────────────────────────────────────────────────
     (F32, F32, :add_float) => BinOpEmit(Opcode.F32_ADD, F32),
     (F32, F32, :sub_float) => BinOpEmit(Opcode.F32_SUB, F32),
@@ -82,6 +94,16 @@ const INTRINSIC_BINOPS = Dict{Tuple{WasmValType,WasmValType,Symbol},BinOpEmit}(
     (F32, F32, :ne_float)  => BinOpEmit(Opcode.F32_NE,  I32),
     (F32, F32, :lt_float)  => BinOpEmit(Opcode.F32_LT,  I32),
     (F32, F32, :le_float)  => BinOpEmit(Opcode.F32_LE,  I32),
+    (F32, F32, :add_float_fast) => BinOpEmit(Opcode.F32_ADD, F32),
+    (F32, F32, :sub_float_fast) => BinOpEmit(Opcode.F32_SUB, F32),
+    (F32, F32, :mul_float_fast) => BinOpEmit(Opcode.F32_MUL, F32),
+    (F32, F32, :div_float_fast) => BinOpEmit(Opcode.F32_DIV, F32),
+    (F32, F32, :eq_float_fast)  => BinOpEmit(Opcode.F32_EQ,  I32),
+    (F32, F32, :ne_float_fast)  => BinOpEmit(Opcode.F32_NE,  I32),
+    (F32, F32, :lt_float_fast)  => BinOpEmit(Opcode.F32_LT,  I32),
+    (F32, F32, :le_float_fast)  => BinOpEmit(Opcode.F32_LE,  I32),
+    (F32, F32, :min_float_fast) => BinOpEmit(Opcode.F32_MIN, F32),
+    (F32, F32, :max_float_fast) => BinOpEmit(Opcode.F32_MAX, F32),
 )
 
 """

--- a/test/fastmath_intrinsics.jl
+++ b/test/fastmath_intrinsics.jl
@@ -1,0 +1,79 @@
+# `@fastmath` float intrinsics (Base.FastMath.add_float_fast / sub / mul / div /
+# neg / sqrt_llvm_fast / eq / ne / lt / le / min / max _fast).
+#
+# `@fastmath` rewrites `a / b` etc. to the `*_fast` aliases of the Core intrinsics.
+# Only min/max/sqrt had `_fast` arms in calls.jl; every other fast form fell through
+# to "unresolved dynamic call" (surfaced by SimpleDiffEq's SimpleATsit5 step-size
+# controller: `@fastmath q = q11 / (qold^beta2)`). Wasm has no fast-math flags, so
+# each fast form now lowers to the same opcode as its strict form (intrinsics
+# table + legacy arms + the operand-typing name lists in context.jl/helpers.jl).
+#
+# Native `@fastmath` may legitimately differ in the last bits (LLVM reassociation /
+# contraction), so the differential check is tolerance-based, NOT bit-exact.
+
+# native-vs-wasm to a tolerance (compare_julia_wasm is exact-equality).
+function _fm_check(f, args...; tol = 1e-12)
+    expected = f(args...)
+    bytes = WasmTarget.compile(f, Tuple(map(typeof, args)))
+    actual = run_wasm_with_imports(bytes, string(nameof(f)), Dict("Math" => Dict("pow" => "Math.pow")), args...)
+    actual === nothing && return true                # no Node → skip (matches compare_julia_wasm)
+    T = typeof(expected)
+    return isapprox(T(actual), expected; rtol = tol, atol = tol)
+end
+
+@testset "fastmath float intrinsics lower to plain ops" begin
+    # table shape: every fast binop has an entry with the same result type as its strict form
+    for (op, res) in ((:add_float_fast, WasmTarget.F64), (:sub_float_fast, WasmTarget.F64),
+                      (:mul_float_fast, WasmTarget.F64), (:div_float_fast, WasmTarget.F64),
+                      (:min_float_fast, WasmTarget.F64), (:max_float_fast, WasmTarget.F64),
+                      (:eq_float_fast, WasmTarget.I32), (:ne_float_fast, WasmTarget.I32),
+                      (:lt_float_fast, WasmTarget.I32), (:le_float_fast, WasmTarget.I32))
+        b = WasmTarget.InstrBuilder(; func_name = "fm")
+        WasmTarget.seed_input!(b, WasmTarget.WasmValType[WasmTarget.F64, WasmTarget.F64])
+        @test WasmTarget.emit_intrinsic_binop!(b, WasmTarget.F64, WasmTarget.F64, op) === res
+        b32 = WasmTarget.InstrBuilder(; func_name = "fm32")
+        WasmTarget.seed_input!(b32, WasmTarget.WasmValType[WasmTarget.F32, WasmTarget.F32])
+        @test WasmTarget.emit_intrinsic_binop!(b32, WasmTarget.F32, WasmTarget.F32, op) ===
+              (res === WasmTarget.F64 ? WasmTarget.F32 : WasmTarget.I32)
+    end
+
+    # Float64: / * + - ^ inv sqrt under @fastmath, differential to 1e-12
+    fm_arith64(a::Float64, b::Float64)::Float64 =
+        @fastmath (a / b) * (a + b) - (a - b) + a^b + inv(b) + sqrt(a)
+    @test _fm_check(fm_arith64, 2.5, 1.25)
+    @test _fm_check(fm_arith64, 9.0, 0.5)
+    @test _fm_check(fm_arith64, 1.0e-3, 3.0)
+
+    # Float32 analogue
+    fm_arith32(a::Float32, b::Float32)::Float32 =
+        @fastmath (a / b) * (a + b) - (a - b) + a^b + inv(b) + sqrt(a)
+    @test _fm_check(fm_arith32, 2.5f0, 1.25f0; tol = 1e-6)
+    @test _fm_check(fm_arith32, 9.0f0, 0.5f0; tol = 1e-6)
+
+    # unary negation
+    fm_neg64(a::Float64)::Float64 = @fastmath -a + 0.0
+    fm_neg32(a::Float32)::Float32 = @fastmath -a + 0.0f0
+    @test _fm_check(fm_neg64, 3.75)
+    @test _fm_check(fm_neg32, 3.75f0; tol = 1e-6)
+
+    # comparisons: each fast compare feeds a branch, result packed into one Int64
+    fm_cmp64(a::Float64, b::Float64)::Int64 =
+        @fastmath (a < b ? 1 : 0) + (a <= b ? 10 : 0) + (a == b ? 100 : 0) + (a != b ? 1000 : 0)
+    @test compare_julia_wasm(fm_cmp64, 1.0, 2.0).pass    # 1011
+    @test compare_julia_wasm(fm_cmp64, 2.0, 2.0).pass    # 110
+    @test compare_julia_wasm(fm_cmp64, 3.0, 2.0).pass    # 1000
+    fm_cmp32(a::Float32, b::Float32)::Int64 =
+        @fastmath (a < b ? 1 : 0) + (a <= b ? 10 : 0) + (a == b ? 100 : 0) + (a != b ? 1000 : 0)
+    @test compare_julia_wasm(fm_cmp32, 1.0f0, 2.0f0).pass
+    @test compare_julia_wasm(fm_cmp32, 2.0f0, 2.0f0).pass
+
+    # the SimpleATsit5 PI-controller shape that surfaced the gap
+    fm_pi(eest::Float64, qold::Float64)::Float64 = @fastmath begin
+        q11 = eest^(0.7 / 5)
+        q = q11 / (qold^(0.08))
+        max(inv(5.0), min(inv(0.2), q / 0.9))
+    end
+    @test _fm_check(fm_pi, 0.5, 1.0)
+    @test _fm_check(fm_pi, 1.0e-4, 0.3)
+    @test _fm_check(fm_pi, 40.0, 2.0)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,6 +158,9 @@ _wt_shard0() && include("f31_union_value_backfills.jl")
 # Parity Loop 0: F11 Int128 bit-counting intrinsics (cttz/ctpop/not_int now handle is_128bit;
 # a single i64 op on a 128-bit value was invalid wasm). See dev/HISTORY.md#parity-method.
 _wt_shard0() && include("f11_int128_bitcount_backfills.jl")
+# `@fastmath` float intrinsics (add/sub/mul/div/neg/cmp _fast) lower to the plain ops; the
+# SimpleATsit5 step-size controller's `@fastmath q11 / qold^beta2` was an unresolved call.
+_wt_shard0() && include("fastmath_intrinsics.jl")
 # Parity probe: sort comparator kwargs (by/lt) were silently dropped by the non-mutating sort
 # overlay (only rev was forwarded to sort!) → sort(v, by=f) returned default order. See FINDINGS.md.
 _wt_shard0() && include("sort_comparator_backfills.jl")


### PR DESCRIPTION
## Problem

`@fastmath` rewrites float arithmetic and comparisons to the `Base.FastMath.*_float_fast` aliases of the Core intrinsics. Only `min`/`max`/`sqrt` had `_fast` arms in the compiler; `add/sub/mul/div/neg_float_fast` and `eq/ne/lt/le_float_fast` fell through to

```
unresolved dynamic call `div_float_fast` (Float64, Float64)
```

Surfaced by SimpleDiffEq's `SimpleATsit5` PI step-size controller, `@fastmath q = q11 / (qold^beta2)`, while compiling an adaptive ODE solve for the browser (SciMLWasm.jl).

## Fix

Wasm has no fast-math flags, so each fast form lowers to the same opcode as its strict form:

- `intrinsics_table.jl`: f64 and f32 entries for the ten `_fast` binops
- `calls.jl`: the legacy `add/sub/mul/div/neg_float` arms also accept the `_fast` names
- `helpers.jl`: `is_comparison` knows the four `_fast` comparisons
- `context.jl`: the operand-typing name lists in `analyze_control_flow!` / `allocate_ssa_locals!` include the `_fast` names and accept `Base.FastMath` as the callee module

`pow_fast` needs no change on Julia 1.12: `pow_fast(::T, ::T) where T<:Number` is plain `x^y` and inlines to the regular `^(::Float64, ::Float64)` invoke.

## Test

`test/fastmath_intrinsics.jl` (wired into shard 0): table-shape assertions for every `_fast` binop in f64 and f32, and a native-vs-wasm differential over `/ * + - ^ inv sqrt neg` and the four comparisons under `@fastmath`, plus the SimpleATsit5 controller expression. The differential is tolerance-based (1e-12 f64, 1e-6 f32), not bit-exact, since native `@fastmath` may legitimately differ in the last bits.

35/35 pass locally on Julia 1.12.7.
